### PR TITLE
docs: use markdown highlighting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Aligned Layer
 
-<b> To be used in testnet only. </b>
+> [!CAUTION]
+> To be used in testnet only.
 
 Basic repo demoing a Stark/Snark verifier AVS middleware with full eigenlayer integration. 
 


### PR DESCRIPTION
I noticed the warning and thought it could be improved. Here you go!

There might be other parts that can be highlighted ([more info on this discussion](https://github.com/orgs/community/discussions/16925)).