### PR TITLE
fix: integration tests paths and lambdaworks ffi binary compilation

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Rust toolchain install
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install libudev1
+        run: apt update && apt install libudev1
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Rust toolchain install
+        uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install libudev1
-        run: sudo apt update && sudo apt install libudev1
+        run: sudo apt update && sudo apt install libudev-dev
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install libudev1
-        run: sudo apt update && sudo apt install libudev-dev
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install libudev1
-        run: apt update && apt install libudev1
+        run: sudo apt update && sudo apt install libudev1
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21"

--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,17 @@ tests-unit: ## runs all unit tests
 tests-contract: ## runs all forge tests
 	cd contracts && forge test
 
-tests-integration: ## runs all integration tests
-	go test ./tests/integration/... -v -count=1
+tests-integration: build-lambdaworks ## runs all integration tests
+	go test ./tests/integration/... -v -count=1 -c integration.test
+	./integration.test
 
 __LAMBDAWORKS_FFI__: ## 
 build-lambdaworks:
 	@cd operator/cairo_platinum/lib && cargo build --release
 	@cp operator/cairo_platinum/lib/target/release/libcairo_platinum_ffi.a operator/cairo_platinum/lib/libcairo_platinum.a
 
-
+clean:
+	@rm -f operator/cairo_platinum/lib/libcairo_platinum.a
+	@rm -f integration_tests
+	@cd operator/cairo_platinum/lib && cargo clean 2> /dev/null
+	@go clean ./...

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -289,13 +289,3 @@ func (agg *Aggregator) sendNewTask(proof []byte) error {
 	agg.blsAggregationService.InitializeNewTask(taskIndex, newTask.TaskCreatedBlock, newTask.QuorumNumbers, quorumThresholdPercentages, taskTimeToExpiry)
 	return nil
 }
-
-func loadValidProof() []byte {
-	var err error
-	proof, err := os.ReadFile("tests/testing_data/fibo_5.proof")
-	if err != nil {
-		panic("Could not read proof file")
-	}
-
-	return proof
-}

--- a/operator/cairo_platinum/cairo_platinum.go
+++ b/operator/cairo_platinum/cairo_platinum.go
@@ -1,7 +1,7 @@
 package cairo_platinum
 
 /*
-#cgo LDFLAGS: operator/cairo_platinum/lib/libcairo_platinum.a
+#cgo LDFLAGS: operator/cairo_platinum/lib/libcairo_platinum.a -ldl
 #include "lib/cairo_platinum.h"
 */
 import "C"

--- a/operator/cairo_platinum/cairo_platinum.go
+++ b/operator/cairo_platinum/cairo_platinum.go
@@ -2,7 +2,7 @@ package cairo_platinum
 
 /*
 #cgo darwin LDFLAGS: operator/cairo_platinum/lib/libcairo_platinum.a
-#cgo linux LDFLAGS: operator/cairo_platinum/lib/libcairo_platinum.a -ldl -ludev -lrt -lm
+#cgo linux LDFLAGS: operator/cairo_platinum/lib/libcairo_platinum.a -ldl -lrt -lm
 
 #include "lib/cairo_platinum.h"
 */

--- a/operator/cairo_platinum/cairo_platinum.go
+++ b/operator/cairo_platinum/cairo_platinum.go
@@ -1,7 +1,9 @@
 package cairo_platinum
 
 /*
-#cgo LDFLAGS: operator/cairo_platinum/lib/libcairo_platinum.a -ldl
+#cgo darwin LDFLAGS: operator/cairo_platinum/lib/libcairo_platinum.a
+#cgo linux LDFLAGS: operator/cairo_platinum/lib/libcairo_platinum.a -ldl -ludev -lrt -lm
+
 #include "lib/cairo_platinum.h"
 */
 import "C"

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -337,7 +337,7 @@ func (o *Operator) ProcessNewTaskCreatedLog(newTaskCreatedLog *cstaskmanager.Con
 
 	proofLen := (uint)(len(proof))
 	o.logger.Info("Received new task with proof to verify",
-		"proofLen: ", proofLen,
+		"proofLen", proofLen,
 		"proofFirstBytes", "0x"+hex.EncodeToString(proof[0:8]),
 		"proofLastBytes", "0x"+hex.EncodeToString(proof[proofLen-8:proofLen]),
 		"taskIndex", newTaskCreatedLog.TaskIndex,


### PR DESCRIPTION
This PR changes all the paths in the integration tests so that they use the root path of the project. This way, there are no unexpected errors because of relative paths to the current working directory.
Makefile has been modified to address this and also to handle the lambdaworks ffi binary compilation before running the tests.