### PR TITLE
feat: add task sender

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,3 +125,14 @@ start-task-generator: ##
 		--shared-avs-contracts-deployment ${DEPLOYMENT_FILES_DIR}/shared_avs_contracts_deployment_output.json \
 		--ecdsa-private-key ${AGGREGATOR_ECDSA_PRIV_KEY} \
 		2>&1 | zap-pretty
+	
+send-cairo-proof:
+	go run task_sender/cmd/main.go --proof tests/testing_data/fibo_5.proof \
+		--verifier-id cairo \
+		2>&1 | zap-pretty
+
+send-plonk-proof:
+	go run task_sender/cmd/main.go --proof tests/testing_data/plonk_cubic_circuit.proof \
+		--verifier-id plonk \
+		2>&1 | zap-pretty
+

--- a/README.md
+++ b/README.md
@@ -43,10 +43,29 @@ make cli-setup-operator
 make start-operator
 ```
 
-Lastly, start the task generator:
+Start the task generator, which will be sending periodic tasks to the Aligned Layer task manager:
 
 ```bash
 make start-task-generator
+```
+
+To send custom tasks with proofs to be verified, in another terminal you can run:
+```bash
+go run task_sender/cmd/main.go --proof <proof_path> --verifier-id <verifier-string-variant>
+```
+
+where `proof_path` is the path of the file containing the serialized proof you want to be verified and `verifier-string-variant` is either `cairo` or `plonk`.
+
+A shortcut for sending a CAIRO proof of a fibonacci program can be used:
+
+```bash
+make send-cairo-proof
+```
+
+Likewise, for sending a PLONK proof of a cubic circuit:
+
+```bash
+make send-plonk-proof
 ```
 
 ## Workflow

--- a/aggregator/cmd/main.go
+++ b/aggregator/cmd/main.go
@@ -25,9 +25,9 @@ func main() {
 	app := cli.NewApp()
 	app.Flags = config.Flags
 	app.Version = fmt.Sprintf("%s-%s-%s", Version, GitCommit, GitDate)
-	app.Name = "credible-squaring-aggregator"
-	app.Usage = "Credible Squaring Aggregator"
-	app.Description = "Service that sends number to be credibly squared by operator nodes."
+	app.Name = "aligned-layer-aggregator"
+	app.Usage = "Aligned Layer Aggregator"
+	app.Description = "Service that aggregates signed responses from operator nodes."
 
 	app.Action = aggregatorMain
 	err := app.Run(os.Args)

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -158,11 +158,11 @@ func NewConfig(ctx *cli.Context) (*Config, error) {
 		AVSServiceManagerAddress:       common.HexToAddress(configRaw.AvsServiceManagerAddress),
 		EnableMetrics:                  configRaw.EnableMetrics,
 	}
-	config.validate()
+	config.Validate()
 	return config, nil
 }
 
-func (c *Config) validate() {
+func (c *Config) Validate() {
 	// TODO: make sure every pointer is non-nil
 	if c.BlsOperatorStateRetrieverAddr == common.HexToAddress("") {
 		panic("Config: BLSOperatorStateRetrieverAddr is required")

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -18,9 +18,9 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Flags = []cli.Flag{config.ConfigFileFlag}
-	app.Name = "credible-squaring-operator"
-	app.Usage = "Credible Squaring Operator"
-	app.Description = "Service that reads numbers onchain, squares, signs, and sends them to the aggregator."
+	app.Name = "aligned-layer-operator"
+	app.Usage = "Aligned Layer Operator"
+	app.Description = "Service that reads proofs onchain, verifies them, signs, and sends them to the aggregator."
 
 	app.Action = operatorMain
 	err := app.Run(os.Args)

--- a/task_generator/cmd/main.go
+++ b/task_generator/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 }
 
 func taskGeneratorMain(ctx *cli.Context) error {
-	log.Println("Initializing Task Generator")
+	log.Println("Initializing Task Generator...")
 	config, err := config.NewConfig(ctx)
 	if err != nil {
 		return err

--- a/task_generator/task_generator.go
+++ b/task_generator/task_generator.go
@@ -63,7 +63,7 @@ func (tg *TaskGenerator) Start(ctx context.Context) error {
 	r.Read(badProof)
 	proof = badProof
 
-	_ = tg.sendNewTask(proof, common.LambdaworksCairo)
+	_ = tg.SendNewTask(proof, common.LambdaworksCairo)
 	taskNum++
 
 	for {
@@ -90,7 +90,7 @@ func (tg *TaskGenerator) Start(ctx context.Context) error {
 					r.Read(badProof)
 					proof = badProof
 				}
-				err := tg.sendNewTask(proof, common.LambdaworksCairo)
+				err := tg.SendNewTask(proof, common.LambdaworksCairo)
 				if err != nil {
 					// we log the errors inside sendNewTask() so here we just continue to the next task
 					continue
@@ -107,7 +107,7 @@ func (tg *TaskGenerator) Start(ctx context.Context) error {
 					r.Read(badProof)
 					proof = badProof
 				}
-				err := tg.sendNewTask(proof, common.GnarkPlonkBls12_381)
+				err := tg.SendNewTask(proof, common.GnarkPlonkBls12_381)
 				if err != nil {
 					// we log the errors inside sendNewTask() so here we just continue to the next task
 					continue
@@ -119,7 +119,7 @@ func (tg *TaskGenerator) Start(ctx context.Context) error {
 }
 
 // sendNewTask sends a new task to the task manager contract
-func (tg *TaskGenerator) sendNewTask(proof []byte, verifierId common.VerifierId) error {
+func (tg *TaskGenerator) SendNewTask(proof []byte, verifierId common.VerifierId) error {
 	_, taskIndex, err := tg.avsWriter.SendNewTaskVerifyProof(context.Background(), proof, verifierId, types.QUORUM_THRESHOLD_NUMERATOR, types.QUORUM_NUMBERS)
 	if err != nil {
 		tg.logger.Error("Task generator failed to send proof", "err", err)

--- a/task_generator/task_generator.go
+++ b/task_generator/task_generator.go
@@ -126,7 +126,7 @@ func (tg *TaskGenerator) SendNewTask(proof []byte, verifierId common.VerifierId)
 		return err
 	}
 
-	tg.logger.Infof("Generated new task with index %d", taskIndex)
+	tg.logger.Infof("Generated new task with index %d \n", taskIndex)
 
 	return nil
 }

--- a/task_sender/cmd/main.go
+++ b/task_sender/cmd/main.go
@@ -104,6 +104,9 @@ func parseVerifierId(verifierIdStr string) (common.VerifierId, error) {
 	return common.LambdaworksCairo, errors.New("could not parse verifier ID")
 }
 
+// This function is almost identical to NewConfig, but with hardcoded values.
+// Its only purpose is to make the usage of the task sender CLI easier, since we don't really
+// need to setup special configurations for the moment.
 func dummyConfig() (*config.Config, error) {
 	var configRaw config.ConfigRaw
 	configFilePath := "config-files/aggregator.yaml"

--- a/task_sender/cmd/main.go
+++ b/task_sender/cmd/main.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
+	"github.com/Layr-Labs/eigensdk-go/signer"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli"
 
+	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
+	sdkutils "github.com/Layr-Labs/eigensdk-go/utils"
+	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/yetanotherco/aligned_layer/common"
 	"github.com/yetanotherco/aligned_layer/core/config"
 	"github.com/yetanotherco/aligned_layer/task_generator"
@@ -35,17 +42,13 @@ var (
 )
 
 var flags = []cli.Flag{
-	config.ConfigFileFlag,
-	config.AlignedLayerDeploymentFileFlag,
-	config.SharedAvsContractsDeploymentFileFlag,
-	config.EcdsaPrivateKeyFlag,
 	ProofFileFlag,
 	VerifierIdFlag,
 }
 
 func main() {
 	app := cli.NewApp()
-	app.Flags = config.Flags
+	app.Flags = flags
 	app.Version = fmt.Sprintf("%s-%s-%s", Version, GitCommit, GitDate)
 	app.Name = "Aligned Layer Task Sender"
 	app.Usage = "Aligned Layer Task Sender"
@@ -60,7 +63,7 @@ func main() {
 
 func taskSenderMain(ctx *cli.Context) error {
 	log.Println("Initializing Task Sender")
-	config, err := config.NewConfig(ctx)
+	config, err := dummyConfig()
 	if err != nil {
 		return err
 	}
@@ -99,4 +102,89 @@ func parseVerifierId(verifierIdStr string) (common.VerifierId, error) {
 	// returning this just to return something, the error should be handled
 	// by the caller.
 	return common.LambdaworksCairo, errors.New("could not parse verifier ID")
+}
+
+func dummyConfig() (*config.Config, error) {
+	var configRaw config.ConfigRaw
+	configFilePath := "config-files/aggregator.yaml"
+	sdkutils.ReadYamlConfig(configFilePath, &configRaw)
+
+	var alignedLayerDeploymentRaw config.AlignedLayerDeploymentRaw
+	alignedLayerDeploymentFilePath := "contracts/script/output/31337/aligned_layer_avs_deployment_output.json"
+	if _, err := os.Stat(alignedLayerDeploymentFilePath); errors.Is(err, os.ErrNotExist) {
+		panic("Path " + alignedLayerDeploymentFilePath + " does not exist")
+	}
+	sdkutils.ReadJsonConfig(alignedLayerDeploymentFilePath, &alignedLayerDeploymentRaw)
+
+	var sharedAvsContractsDeploymentRaw config.SharedAvsContractsRaw
+	sharedAvsContractsDeploymentFilePath := "contracts/script/output/31337/shared_avs_contracts_deployment_output.json"
+	if _, err := os.Stat(sharedAvsContractsDeploymentFilePath); errors.Is(err, os.ErrNotExist) {
+		panic("Path " + sharedAvsContractsDeploymentFilePath + " does not exist")
+	}
+	sdkutils.ReadJsonConfig(sharedAvsContractsDeploymentFilePath, &sharedAvsContractsDeploymentRaw)
+
+	logger, err := sdklogging.NewZapLogger(configRaw.Environment)
+	if err != nil {
+		return nil, err
+	}
+
+	ethRpcClient, err := eth.NewClient(configRaw.EthRpcUrl)
+	if err != nil {
+		logger.Errorf("Cannot create http ethclient", "err", err)
+		return nil, err
+	}
+
+	ethWsClient, err := eth.NewClient(configRaw.EthWsUrl)
+	if err != nil {
+		logger.Errorf("Cannot create ws ethclient", "err", err)
+		return nil, err
+	}
+
+	ecdsaPrivateKeyString := "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
+	if ecdsaPrivateKeyString[:2] == "0x" {
+		ecdsaPrivateKeyString = ecdsaPrivateKeyString[2:]
+	}
+	ecdsaPrivateKey, err := crypto.HexToECDSA(ecdsaPrivateKeyString)
+	if err != nil {
+		logger.Errorf("Cannot parse ecdsa private key", "err", err)
+		return nil, err
+	}
+
+	operatorAddr, err := sdkutils.EcdsaPrivateKeyToAddress(ecdsaPrivateKey)
+	if err != nil {
+		logger.Error("Cannot get operator address", "err", err)
+		return nil, err
+	}
+
+	chainId, err := ethRpcClient.ChainID(context.Background())
+	if err != nil {
+		logger.Error("Cannot get chainId", "err", err)
+		return nil, err
+	}
+
+	privateKeySigner, err := signer.NewPrivateKeySigner(ecdsaPrivateKey, chainId)
+	if err != nil {
+		logger.Error("Cannot create signer", "err", err)
+		return nil, err
+	}
+
+	config := &config.Config{
+		EcdsaPrivateKey:                ecdsaPrivateKey,
+		Logger:                         logger,
+		EthRpcUrl:                      configRaw.EthRpcUrl,
+		EthHttpClient:                  ethRpcClient,
+		EthWsClient:                    ethWsClient,
+		BlsOperatorStateRetrieverAddr:  gethCommon.HexToAddress(sharedAvsContractsDeploymentRaw.BlsOperatorStateRetrieverAddr),
+		AlignedLayerServiceManagerAddr: gethCommon.HexToAddress(alignedLayerDeploymentRaw.Addresses.AlignedLayerServiceManagerAddr),
+		SlasherAddr:                    gethCommon.HexToAddress(""),
+		AggregatorServerIpPortAddr:     configRaw.AggregatorServerIpPortAddr,
+		RegisterOperatorOnStartup:      configRaw.RegisterOperatorOnStartup,
+		Signer:                         privateKeySigner,
+		OperatorAddress:                operatorAddr,
+		BlsPublicKeyCompendiumAddress:  gethCommon.HexToAddress(configRaw.BLSPubkeyCompendiumAddr),
+		AVSServiceManagerAddress:       gethCommon.HexToAddress(configRaw.AvsServiceManagerAddress),
+		EnableMetrics:                  configRaw.EnableMetrics,
+	}
+	config.Validate()
+	return config, nil
 }

--- a/task_sender/cmd/main.go
+++ b/task_sender/cmd/main.go
@@ -89,6 +89,8 @@ func taskSenderMain(ctx *cli.Context) error {
 		return err
 	}
 
+	log.Println("Task successfully sent\n")
+
 	return nil
 }
 

--- a/task_sender/cmd/main.go
+++ b/task_sender/cmd/main.go
@@ -62,7 +62,7 @@ func main() {
 }
 
 func taskSenderMain(ctx *cli.Context) error {
-	log.Println("Initializing Task Sender")
+	log.Println("Initializing Task Sender...")
 	config, err := dummyConfig()
 	if err != nil {
 		return err

--- a/task_sender/cmd/main.go
+++ b/task_sender/cmd/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/urfave/cli"
+
+	"github.com/yetanotherco/aligned_layer/core/config"
+	"github.com/yetanotherco/aligned_layer/task_generator"
+)
+
+var (
+	// Version is the version of the binary.
+	Version   string
+	GitCommit string
+	GitDate   string
+)
+
+var (
+	ProofFileFlag = cli.StringFlag{
+		Name:     "proof",
+		Required: true,
+		Usage:    "Load proof from `FILE`",
+	}
+
+	VerifierIdFlag = cli.StringFlag{
+		Name:     "verifier-id",
+		Required: true,
+		Usage:    "Set verifier ID",
+	}
+)
+
+var flags = []cli.Flag{
+	config.ConfigFileFlag,
+	config.AlignedLayerDeploymentFileFlag,
+	config.SharedAvsContractsDeploymentFileFlag,
+	config.EcdsaPrivateKeyFlag,
+	ProofFileFlag,
+	VerifierIdFlag,
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Flags = config.Flags
+	app.Version = fmt.Sprintf("%s-%s-%s", Version, GitCommit, GitDate)
+	app.Name = "Aligned Layer Task Sender"
+	app.Usage = "Aligned Layer Task Sender"
+	app.Description = "Service that sends proofs to verify by operator nodes."
+
+	app.Action = taskSenderMain
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatalln("Task sender application failed.", "Message:", err)
+	}
+}
+
+func taskSenderMain(ctx *cli.Context) error {
+	log.Println("Initializing Task Sender")
+	config, err := config.NewConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	taskGen, err := task_generator.NewTaskGenerator(config)
+	if err != nil {
+		return err
+	}
+
+	err = taskGen.SendNewTask(proof, VerifierId)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds functionality to send custom proofs as tasks to be verified.
Once all the components are up and running, it can be used like

```bash
go run task_sender/cmd/main.go --proof <proof_path> --verifier-id <verifier-string-variant>
```
where `proof_path` is the path of the file containing the serialized proof you want to be verified and `verifier-string-variant` is either *cairo* or *plonk*.

Shortcuts for sending the hardcoded CAIRO and PLONK proofs can be used too with
```bash
make send-cairo-proof
```
and
```bash
make send-plonk-proof
```