### PR TITLE
docs: add gitbook config and base summary

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,1 @@
+root: ./docs/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+# Aligned Layer

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,5 @@
+# Summary
+
+* [Aligned Layer](README.md)
+
+## Links


### PR DESCRIPTION
This is the base setup for the Aligned Layer Gitbook. 
The gitbook is live at [docs.alignedlayer.com](docs.alignedlayer.com)

Gitbook takes the documentation from `/docs` directory.
Inside `/docs` there are two files, a README and a SUMMARY.

If you wish, you can move the README from root to `/docs` and github will still show it as the repository's README.

In the SUMMARY, you can configure all sections and hyperlinks. 
- You can check summary [reference](https://docs.gitbook.com/integrations/git-sync/content-configuration#summary).
- Also, you can take a look to [Yet Another Bridge](https://github.com/yetanotherco/yet-another-bridge). It uses the same ocnfiguration for gitbook.