### PR TITLE
docs: update aligned layer documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ The issue we face is that Ethereum was not originally designed for validity proo
 We want to become a key player in this space, supporting anyone involved in ZK technology development or research. With an incredible team and advisory group, we're determined to bring this vision to life.
 
 - [Features](about_aligned/features.md)
-- [Usecases](about_aligned/usecases.md)
+- Use cases
 - [Modular approach](about_aligned/modular_approach.md)
 - [Role of EigenLayer](about_aligned/role_of_eigenlayer.md)
 - [How does Aligned Layer work?](about_aligned/how_does_aligned_layer_work.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ The issue we face is that Ethereum was not originally designed for validity proo
 We want to become a key player in this space, supporting anyone involved in ZK technology development or research. With an incredible team and advisory group, we're determined to bring this vision to life.
 
 - [Features](about_aligned/features.md)
-- Use cases
+- [Use cases](about_aligned/use_cases.md)
 - [Modular approach](about_aligned/modular_approach.md)
 - [Role of EigenLayer](about_aligned/role_of_eigenlayer.md)
 - [How does Aligned Layer work?](about_aligned/how_does_aligned_layer_work.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,4 +15,4 @@
 
 * [Telegram Group](https://t.me/aligned_layer)
 * [Twitter/X](https://twitter.com/alignedlayer)
-* [Discord](https://discord.gg/dZCAeavY)
+* [Discord](https://discord.gg/WrgR6YsS)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,7 +5,7 @@
 ## About Aligned
 
 * [Features](about_aligned/features.md)
-* [Usecases](about_aligned/usecases.md)
+* Use cases
 * [Modular approach](about_aligned/modular_approach.md)
 * [Role of EigenLayer](about_aligned/role_of_eigenlayer.md)
 * [How does Aligned Layer work?](about_aligned/how_does_aligned_layer_work.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,7 +5,7 @@
 ## About Aligned
 
 * [Features](about_aligned/features.md)
-* Use cases
+* [Use cases](about_aligned/use_cases.md)
 * [Modular approach](about_aligned/modular_approach.md)
 * [Role of EigenLayer](about_aligned/role_of_eigenlayer.md)
 * [How does Aligned Layer work?](about_aligned/how_does_aligned_layer_work.md)

--- a/docs/about_aligned/use_cases.md
+++ b/docs/about_aligned/use_cases.md
@@ -1,6 +1,6 @@
-# Usecases:
+# Use cases:
 
-Among the possible usecases of Aligned Layer we have:
+Among the possible use cases of Aligned Layer we have:
 
 - Soft finality for Rollups and Appchains.
   


### PR DESCRIPTION
- [x] The term 'usecase' was initially used because that was how it was written in the whitepaper. After consultations, it was decided to modify it to 'use cases'.
- [x] The discord link was updated.