### PR TITLE
feat: command line tooling to send custom proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ logs.txt
 
 # just for example
 id_rsa
+
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -177,23 +177,13 @@ start-task-generator: ##
 
 __TASK_SENDERS__:
 send-cairo-proof:
-	go run task_sender/cmd/main.go --proof tests/testing_data/fibo_5.proof \
-		--verifier-id cairo \
-		2>&1 | zap-pretty
+	./scripts/send_proof.sh cairo tests/testing_data/fibo_5.proof
 
 send-sp1-proof:
-	go run task_sender/cmd/main.go --proof tests/testing_data/sp1_fibonacci.proof \
-		--verifier-id sp1 \
-		2>&1 | zap-pretty
+	./scripts/send_proof.sh sp1 tests/testing_data/sp1_fibonacci.proof
 
 send-plonk-proof:
-	go run task_sender/cmd/main.go --proof tests/testing_data/plonk_cubic_circuit.proof \
-		--pub-input tests/testing_data/witness.pub \
-		--verifier-id plonk \
-		2>&1 | zap-pretty
+	./scripts/send_proof.sh plonk tests/testing_data/plonk_cubic_circuit.proof tests/testing_data/witness.pub
 
 send-kimchi-proof:
-	go run task_sender/cmd/main.go --proof tests/testing_data/kimchi/kimchi_ec_add.proof \
-		--pub-input tests/testing_data/kimchi/kimchi_verifier_index.bin \
-		--verifier-id kimchi \
-		2>&1 | zap-pretty
+	./scripts/send_proof.sh kimchi tests/testing_data/kimchi/kimchi_ec_add.proof tests/testing_data/kimchi/kimchi_verifier_index.bin

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ make cli-setup-operator-linux
 make start-operator
 ```
 
-
 Start the task generator, which will be sending periodic tasks to the Aligned Layer task manager:
 
 ```bash
@@ -59,10 +58,14 @@ make start-task-generator
 
 To send custom tasks with proofs to be verified, in another terminal you can run:
 ```bash
-go run task_sender/cmd/main.go --proof <proof_path> --verifier-id <verifier-string-variant>
+./scripts/send_proof.sh <verifier-string-variant> <proof_path> <pub_input_path?>
 ```
 
-where `proof_path` is the path of the file containing the serialized proof you want to be verified and `verifier-string-variant` is either `cairo` or `plonk`.
+where `proof_path` is the path of the file containing the serialized proof you want to be verified and `verifier-string-variant` is either `cairo`, `plonk`, `sp1` or `kimchi`.
+
+Note that `pub_input_path` is required for `plonk` or `kimchi` but should not be sent otherwise.
+It can read CONFIG_FILE, ALIGNED_LAYER_DEPLOYMENT_FILE, SHARED_AVS_CONTRACTS_DEPLOYMENT_FILE and ECDSA_PRIVATE_KEY from env
+or use default values. By default it will use anvil devnet values.
 
 A shortcut for sending a CAIRO proof of a fibonacci program can be used:
 
@@ -74,6 +77,16 @@ Likewise, for sending a PLONK proof of a cubic circuit:
 
 ```bash
 make send-plonk-proof
+```
+
+To send a SP1 proof of a fibonacci program:
+```bash
+make send-sp1-proof
+```
+
+To send a simple Kimchi proof:
+```bash
+make send-kimchi-proof
 ```
 
 ## Workflow

--- a/scripts/send_proof.sh
+++ b/scripts/send_proof.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Take two arguments + optional third one: <plonk|sp1|cairo|kimchi> <proof_path> <pub_input_path?>
+# If the third argument is not provided, the task sender will not send the public input
+# The task sender will send the proof to the verifier with the given ID
+if [[ "$#" -lt 2 || "$#" -gt 3 ]]; then
+	echo "Usage: $0 <plonk|sp1|cairo|kimchi> <proof_path> <pub_input_path?>"
+	exit 1
+fi
+
+# Run the task sender
+if [[ "$#" -eq 2 ]]; then
+	go run task_sender/cmd/main.go --verifier-id $1 --proof $2 2>&1 | zap-pretty
+else 
+	go run task_sender/cmd/main.go --verifier-id $1 --proof $2 --pub-input $3 2>&1 | zap-pretty
+fi

--- a/task_sender/cmd/main.go
+++ b/task_sender/cmd/main.go
@@ -1,21 +1,14 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"strings"
 
-	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
-	"github.com/Layr-Labs/eigensdk-go/signer"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli"
 
-	sdklogging "github.com/Layr-Labs/eigensdk-go/logging"
-	sdkutils "github.com/Layr-Labs/eigensdk-go/utils"
-	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/yetanotherco/aligned_layer/common"
 	"github.com/yetanotherco/aligned_layer/core/config"
 	"github.com/yetanotherco/aligned_layer/task_generator"
@@ -29,6 +22,38 @@ var (
 )
 
 var (
+	ConfigFileFlag = cli.StringFlag{
+		Name:     "config",
+		Required: false,
+		Usage:    "Load configuration from `FILE`",
+		Value:    "config-files/aggregator.yaml",
+		EnvVar:   "CONFIG_FILE",
+	}
+
+	AlignedLayerDeploymentFileFlag = cli.StringFlag{
+		Name:     "aligned-layer-deployment",
+		Required: false,
+		Usage:    "Load credible squaring contract addresses from `FILE`",
+		Value:    "contracts/script/output/31337/aligned_layer_avs_deployment_output.json",
+		EnvVar:   "ALIGNED_LAYER_DEPLOYMENT_FILE",
+	}
+
+	SharedAvsContractsDeploymentFileFlag = cli.StringFlag{
+		Name:     "shared-avs-contracts-deployment",
+		Required: false,
+		Usage:    "Load shared avs contract addresses from `FILE`",
+		Value:    "contracts/script/output/31337/shared_avs_contracts_deployment_output.json",
+		EnvVar:   "SHARED_AVS_CONTRACTS_DEPLOYMENT_FILE",
+	}
+
+	EcdsaPrivateKeyFlag = cli.StringFlag{
+		Name:     "ecdsa-private-key",
+		Usage:    "Ethereum private key",
+		Value:    "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
+		Required: false,
+		EnvVar:   "ECDSA_PRIVATE_KEY",
+	}
+
 	ProofFileFlag = cli.StringFlag{
 		Name:     "proof",
 		Required: true,
@@ -49,6 +74,10 @@ var (
 )
 
 var flags = []cli.Flag{
+	ConfigFileFlag,
+	AlignedLayerDeploymentFileFlag,
+	SharedAvsContractsDeploymentFileFlag,
+	EcdsaPrivateKeyFlag,
 	ProofFileFlag,
 	VerifierIdFlag,
 	PubInputIdFlag,
@@ -71,7 +100,9 @@ func main() {
 
 func taskSenderMain(ctx *cli.Context) error {
 	log.Println("Initializing Task Sender...")
-	config, err := dummyConfig()
+
+	log.Println("Config file: ", ctx.GlobalString(ConfigFileFlag.Name))
+	config, err := config.NewConfig(ctx)
 	if err != nil {
 		return err
 	}
@@ -109,7 +140,7 @@ func taskSenderMain(ctx *cli.Context) error {
 		return err
 	}
 
-	log.Println("Task successfully sent\n")
+	log.Println("Task successfully sent")
 
 	return nil
 }
@@ -131,92 +162,4 @@ func parseVerifierId(verifierIdStr string) (common.VerifierId, error) {
 		// by the caller.
 		return common.LambdaworksCairo, errors.New("could not parse verifier ID")
 	}
-}
-
-// This function is almost identical to NewConfig, but with hardcoded values.
-// Its only purpose is to make the usage of the task sender CLI easier, since we don't really
-// need to setup special configurations for the moment.
-func dummyConfig() (*config.Config, error) {
-	var configRaw config.ConfigRaw
-	configFilePath := "config-files/aggregator.yaml"
-	sdkutils.ReadYamlConfig(configFilePath, &configRaw)
-
-	var alignedLayerDeploymentRaw config.AlignedLayerDeploymentRaw
-	alignedLayerDeploymentFilePath := "contracts/script/output/31337/aligned_layer_avs_deployment_output.json"
-	if _, err := os.Stat(alignedLayerDeploymentFilePath); errors.Is(err, os.ErrNotExist) {
-		panic("Path " + alignedLayerDeploymentFilePath + " does not exist")
-	}
-	sdkutils.ReadJsonConfig(alignedLayerDeploymentFilePath, &alignedLayerDeploymentRaw)
-
-	var sharedAvsContractsDeploymentRaw config.SharedAvsContractsRaw
-	sharedAvsContractsDeploymentFilePath := "contracts/script/output/31337/shared_avs_contracts_deployment_output.json"
-	if _, err := os.Stat(sharedAvsContractsDeploymentFilePath); errors.Is(err, os.ErrNotExist) {
-		panic("Path " + sharedAvsContractsDeploymentFilePath + " does not exist")
-	}
-	sdkutils.ReadJsonConfig(sharedAvsContractsDeploymentFilePath, &sharedAvsContractsDeploymentRaw)
-
-	logger, err := sdklogging.NewZapLogger(configRaw.Environment)
-	if err != nil {
-		return nil, err
-	}
-
-	ethRpcClient, err := eth.NewClient(configRaw.EthRpcUrl)
-	if err != nil {
-		logger.Errorf("Cannot create http ethclient", "err", err)
-		return nil, err
-	}
-
-	ethWsClient, err := eth.NewClient(configRaw.EthWsUrl)
-	if err != nil {
-		logger.Errorf("Cannot create ws ethclient", "err", err)
-		return nil, err
-	}
-
-	ecdsaPrivateKeyString := "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
-	if ecdsaPrivateKeyString[:2] == "0x" {
-		ecdsaPrivateKeyString = ecdsaPrivateKeyString[2:]
-	}
-	ecdsaPrivateKey, err := crypto.HexToECDSA(ecdsaPrivateKeyString)
-	if err != nil {
-		logger.Errorf("Cannot parse ecdsa private key", "err", err)
-		return nil, err
-	}
-
-	operatorAddr, err := sdkutils.EcdsaPrivateKeyToAddress(ecdsaPrivateKey)
-	if err != nil {
-		logger.Error("Cannot get operator address", "err", err)
-		return nil, err
-	}
-
-	chainId, err := ethRpcClient.ChainID(context.Background())
-	if err != nil {
-		logger.Error("Cannot get chainId", "err", err)
-		return nil, err
-	}
-
-	privateKeySigner, err := signer.NewPrivateKeySigner(ecdsaPrivateKey, chainId)
-	if err != nil {
-		logger.Error("Cannot create signer", "err", err)
-		return nil, err
-	}
-
-	config := &config.Config{
-		EcdsaPrivateKey:                ecdsaPrivateKey,
-		Logger:                         logger,
-		EthRpcUrl:                      configRaw.EthRpcUrl,
-		EthHttpClient:                  ethRpcClient,
-		EthWsClient:                    ethWsClient,
-		BlsOperatorStateRetrieverAddr:  gethCommon.HexToAddress(sharedAvsContractsDeploymentRaw.BlsOperatorStateRetrieverAddr),
-		AlignedLayerServiceManagerAddr: gethCommon.HexToAddress(alignedLayerDeploymentRaw.Addresses.AlignedLayerServiceManagerAddr),
-		SlasherAddr:                    gethCommon.HexToAddress(""),
-		AggregatorServerIpPortAddr:     configRaw.AggregatorServerIpPortAddr,
-		RegisterOperatorOnStartup:      configRaw.RegisterOperatorOnStartup,
-		Signer:                         privateKeySigner,
-		OperatorAddress:                operatorAddr,
-		BlsPublicKeyCompendiumAddress:  gethCommon.HexToAddress(configRaw.BLSPubkeyCompendiumAddr),
-		AVSServiceManagerAddress:       gethCommon.HexToAddress(configRaw.AvsServiceManagerAddress),
-		EnableMetrics:                  configRaw.EnableMetrics,
-	}
-	config.Validate()
-	return config, nil
 }


### PR DESCRIPTION
- Added `scripts/send_proof.sh` as shortcut for go command
- Added different proof options to Readme
- Added ability for task_sender to read CONFIG_FILE, ALIGNED_LAYER_DEPLOYMENT_FILE, SHARED_AVS_CONTRACTS_DEPLOYMENT_FILE and ECDSA_PRIVATE_KEY from env, keeping old defaults for simplicity