### PR TITLE
chore: add retry when listening for tasks

### DIFF
--- a/aggregator/cmd/main.go
+++ b/aggregator/cmd/main.go
@@ -51,8 +51,7 @@ func aggregatorMain(context *cli.Context) error {
 	go func() {
 		listenErr := aggregator.SubscribeToNewTasks()
 		if listenErr != nil {
-			// TODO: Retry listening for tasks
-			aggregatorConfig.BaseConfig.Logger.Error("Error listening for tasks", "err", listenErr)
+			aggregatorConfig.BaseConfig.Logger.Fatal("Error listening for tasks", "err", listenErr)
 		}
 	}()
 

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/yetanotherco/aligned_layer/contracts/bindings/AlignedLayerServiceManager"
 	"github.com/yetanotherco/aligned_layer/core/chainio"
@@ -47,15 +46,6 @@ func NewAggregator(aggregatorConfig config.AggregatorConfig) (*Aggregator, error
 		return nil, err
 	}
 
-	// Subscriber to Ethereum serviceManager task events
-	taskSubscriber, err := avsSubscriber.AvsContractBindings.ServiceManager.WatchNewTaskCreated(&bind.WatchOpts{},
-		newTaskCreatedChan, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	aggregatorConfig.BaseConfig.Logger.Info("Created subscriber for task creation events")
-
 	tasks := make(map[uint64]contractAlignedLayerServiceManager.AlignedLayerServiceManagerTask)
 	taskResponses := make(map[uint64]*TaskResponsesWithStatus, 0)
 
@@ -63,7 +53,6 @@ func NewAggregator(aggregatorConfig config.AggregatorConfig) (*Aggregator, error
 		AggregatorConfig:   &aggregatorConfig,
 		avsSubscriber:      avsSubscriber,
 		avsWriter:          avsWriter,
-		taskSubscriber:     taskSubscriber,
 		NewTaskCreatedChan: newTaskCreatedChan,
 		tasks:              tasks,
 		tasksMutex:         &sync.Mutex{},

--- a/aggregator/internal/pkg/subscriber.go
+++ b/aggregator/internal/pkg/subscriber.go
@@ -60,8 +60,7 @@ func (agg *Aggregator) tryCreateTaskSubscriber() error {
 		agg.NewTaskCreatedChan, nil)
 
 	if err != nil {
-		message := fmt.Sprintf("Failed to create task subscriber")
-		agg.AggregatorConfig.BaseConfig.Logger.Info(message, "err", err)
+		agg.AggregatorConfig.BaseConfig.Logger.Info("Failed to create task subscriber", "err", err)
 	}
 	return err
 }

--- a/aggregator/internal/pkg/subscriber.go
+++ b/aggregator/internal/pkg/subscriber.go
@@ -1,12 +1,36 @@
 package pkg
 
-import "github.com/yetanotherco/aligned_layer/core/types"
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/yetanotherco/aligned_layer/core/types"
+	"time"
+)
+
+const (
+	MaxRetries    = 5
+	RetryInterval = 10 * time.Second
+)
 
 func (agg *Aggregator) SubscribeToNewTasks() error {
+
+	var err error
+
+	for attempt := 0; attempt < MaxRetries; attempt++ {
+		if err != nil {
+			err = tryCreateTaskSubscriber(agg)
+		} else {
+			err = agg.subscribeToNewTasks()
+		}
+	}
+
+	return err
+}
+
+func (agg *Aggregator) subscribeToNewTasks() error {
 	for {
 		select {
 		case err := <-agg.taskSubscriber.Err():
-			// TODO: Retry subscription
 			agg.AggregatorConfig.BaseConfig.Logger.Error("Error in subscription", "err", err)
 			return err
 		case task := <-agg.NewTaskCreatedChan:
@@ -25,4 +49,24 @@ func (agg *Aggregator) SubscribeToNewTasks() error {
 			agg.taskResponsesMutex.Unlock()
 		}
 	}
+}
+
+func tryCreateTaskSubscriber(agg *Aggregator) error {
+	var err error
+
+	for attempt := 0; attempt < MaxRetries; attempt++ {
+		agg.AggregatorConfig.BaseConfig.Logger.Info("Subscribing to Ethereum serviceManager task events")
+		agg.taskSubscriber, err = agg.avsSubscriber.AvsContractBindings.ServiceManager.WatchNewTaskCreated(&bind.WatchOpts{},
+			agg.NewTaskCreatedChan, nil)
+
+		if err != nil {
+			message := fmt.Sprintf("Failed to create task subscriber, waiting %d seconds before retrying", RetryInterval/time.Second)
+			agg.AggregatorConfig.BaseConfig.Logger.Info(message, "err", err)
+			time.Sleep(RetryInterval)
+		} else {
+			break
+		}
+	}
+
+	return err
 }


### PR DESCRIPTION
# Description
- Added retry when listening for tasks. 
- There is a limit of 5 max retries and each retry is done every 10 seconds.
- When the subscription fails, `WatchNewTaskCreated` is called to create the task subscriber again.