### PR TITLE
fix: scientific notation being changed by script

### DIFF
--- a/contracts/scripts/anvil/deploy_mock_strategy.sh
+++ b/contracts/scripts/anvil/deploy_mock_strategy.sh
@@ -33,7 +33,7 @@ cd ../../
 erc20MockStrategy=$(jq -r '.erc20MockStrategy' "script/output/devnet/strategy_deployment_output.json")
 
 # Use the extracted value to replace the 0_strategy value in aligned.devnet.config.json and save it to a temporary file
-jq --arg erc20MockStrategy "$erc20MockStrategy" '.strategyWeights[0][0]."0_strategy" = $erc20MockStrategy' "script/deploy/config/devnet/aligned.devnet.config.json" > "script/deploy/config/devnet/aligned.devnet.config.temp.json"
+jq --arg erc20MockStrategy "$erc20MockStrategy" '.strategyWeights[0][0]."0_strategy" = $erc20MockStrategy' "script/deploy/config/devnet/aligned.devnet.config.json" | sed -r 's/1E\+([0-9]+)/1e+\1/g' > "script/deploy/config/devnet/aligned.devnet.config.temp.json"
 
 # Replace the original file with the temporary file
 mv "script/deploy/config/devnet/aligned.devnet.config.temp.json" "script/deploy/config/devnet/aligned.devnet.config.json"


### PR DESCRIPTION
# Description
- jq library [changes scientific notation from 1e+ to 1E+ to follow IEEE754 representation](https://arc.net/l/quote/xdeucdog).

# Changes
- To fix this, the output of jq is piped to sed with a regex which changes to the desired format.

# Replicate
To see this changes in effect, run `make anvil-deploy-mock-strategy`

In `aligned.devnet.config.json` you should see:
```
 "strategyWeights": [
    [
      {
        "0_strategy": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
        "1_multiplier": 1e+18
      }
    ]
  ],
 ```
And executing: `make anvil-deploy-aligned-contracts` should work.