### PR TITLE
feat (aggregator): use different config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ anvil-start:
 # TODO: Allow enviroment variables / different configuration files
 aggregator-start:
 	@echo "Starting Aggregator..."
-	@go run aggregator/cmd/main.go --config config-files/config.yaml \
+	@go run aggregator/cmd/main.go --config $(CONFIG_FILE) \
 	2>&1 | zap-pretty
 
 aggregator-send-dummy-responses:

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ The above command starts a local anvil chain from a [saved state](./tests/integr
 
 Make sure to set config file variables to correct value at `config-files/config.yaml`.
 
-To start the aggregator, run:
+To start the aggregator with a default configuration, run:
 ```bash
 make aggregator-start
+```
+
+To use some custom configuration, set the `CONFIG_FILE` parameter with the path to your configuration file:
+```bash
+make aggregator-start CONFIG_FILE=<path_to_your_config> 
 ```
 
 To run dummy operator to test aggregator SubmitTaskResponse endpoint, run:


### PR DESCRIPTION
Give user option to use a different config file than default when starting operator.