### PR TITLE
fix: remove panic error

### DIFF
--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -127,9 +127,7 @@ func (agg *Aggregator) Start(ctx context.Context) error {
 func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg.BlsAggregationServiceResponse) {
 	if blsAggServiceResp.Err != nil {
 		agg.logger.Error("BlsAggregationServiceResponse contains an error", "err", blsAggServiceResp.Err)
-
-		// FIXME: Panicking for fast debbuging, we should rework this
-		panic(blsAggServiceResp.Err)
+		return
 	}
 
 	nonSignerPubkeys := []servicemanager.BN254G1Point{}


### PR DESCRIPTION
# Description
- Removed panic from BlsAggregationServiceResponse.
- To replicate:
  - `make anvil-start`
  - `make aggregator-start`
  - Then send a task without starting an operator. After 100 secs the time should expire and you should see an error.
  - If you then register (`make operator-full-registration`), start the operator ( `make operator-start`) and send a task (`make send-plonk_bls12_381-proof`), execution should resume normally.