### PR TITLE
docs: update aligned documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Aligned’s mission is to extend Ethereum’s zero-knowledge capabilities. We ar
 
 ### Why do we need a ZK verification layer?
 
-Verifiable computation allows developers to build applications that help Ethereum scale or even create applications that were not possible before, with enhanced privacy properties. We believe the future of Ethereum will be shaped by zero-knowledge proofs and help it increase its capabilities. 
+Verifiable computation allows developers to build applications that help Ethereum scale or even create applications that were not possible before. We believe the future of Ethereum will be shaped by zero-knowledge and validity proofs, helping it increase its capabilities.
 
 ### What are the use cases of Aligned?
 

--- a/docs/about_aligned/FAQ.md
+++ b/docs/about_aligned/FAQ.md
@@ -6,7 +6,7 @@ Aligned’s mission is to extend Ethereum’s zero-knowledge capabilities. We ar
 
 ### Why do we need a ZK verification layer?
 
-Verifiable computation allows developers to build applications that help Ethereum scale or even create applications that were not possible before, with enhanced privacy properties. We believe the future of Ethereum will be shaped by zero-knowledge proofs and help it increase its capabilities. 
+Verifiable computation allows developers to build applications that help Ethereum scale or even create applications that were not possible before. We believe the future of Ethereum will be shaped by zero-knowledge and validity proofs, helping it increase its capabilities.
 
 ### What are the use cases of Aligned?
 

--- a/docs/about_aligned/learning_resources.md
+++ b/docs/about_aligned/learning_resources.md
@@ -12,6 +12,6 @@
 
 * [History of zero knowledge proofs]( https://blog.lambdaclass.com/our-highly-subjective-view-on-the-history-of-zero-knowledge-proofs/)
 * [Proof aggregation techniques](https://blog.lambdaclass.com/proof-aggregation-techniques/)
-* [An overview of the Groth 16 proof system](https://blog.lambdaclass.com/groth16/)
+* [An overview of the Groth16 proof system](https://blog.lambdaclass.com/groth16/)
 * [All you wanted to know about Plonk](https://blog.lambdaclass.com/all-you-wanted-to-know-about-plonk/)
 * [Arithmetization schemes for ZK-SNARKs](https://blog.lambdaclass.com/arithmetization-schemes-for-zk-snarks/)


### PR DESCRIPTION
- [x] In the FAQs: The term "privacy" was removed and "validity proofs" was added.
- [x] In the resources list: There was a name correction from "Groth 16" to "Groth16."