### PR TITLE
feat: add make target operator_register_and_start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ operator_start:
 	go run operator/cmd/main.go start --config $(CONFIG_FILE) \
 	2>&1 | zap-pretty
 
+operator_register_and_start: operator_full_registration operator_start
+
 bindings:
 	cd contracts && ./generate-go-bindings.sh
 


### PR DESCRIPTION
This small PR adds a make target that registrates and starts the operator.

`make operator_register_and_start`