### PR TITLE
perf: read less blocks and catch bug

### DIFF
--- a/explorer/lib/explorer/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/aligned_layer_service_manager.ex
@@ -26,7 +26,7 @@ defmodule AlignedLayerServiceManager do
   def get_new_batch_events() do
     events =
       AlignedLayerServiceManager.EventFilters.new_batch(nil)
-      |> Ethers.get_logs(fromBlock: 0)
+      |> Ethers.get_logs(fromBlock: 1600000)
 
     case events do
       {:ok, []} -> []
@@ -38,7 +38,7 @@ defmodule AlignedLayerServiceManager do
   def get_new_batch_events(merkle_root) when is_binary(merkle_root) do
     events =
       AlignedLayerServiceManager.EventFilters.new_batch(Utils.string_to_bytes32(merkle_root))
-      |> Ethers.get_logs(fromBlock: 0)
+      |> Ethers.get_logs(fromBlock: 1600000)
 
     case events do
       {:error, reason} -> {:empty, reason}
@@ -96,7 +96,7 @@ defmodule AlignedLayerServiceManager do
 
   def get_batch_verified_events() do
     events =
-      AlignedLayerServiceManager.EventFilters.batch_verified(nil) |> Ethers.get_logs(fromBlock: 0)
+      AlignedLayerServiceManager.EventFilters.batch_verified(nil) |> Ethers.get_logs(fromBlock: 1600000)
 
     case events do
       {:ok, list} -> {:ok, list}
@@ -107,7 +107,7 @@ defmodule AlignedLayerServiceManager do
   def get_batch_verified_events(merkle_root) do
     events =
       AlignedLayerServiceManager.EventFilters.batch_verified(merkle_root)
-      |> Ethers.get_logs(fromBlock: 0)
+      |> Ethers.get_logs(fromBlock: 1600000)
 
     case events do
       {:error, reason} -> {:empty, reason}

--- a/explorer/lib/explorer/avs_directory.ex
+++ b/explorer/lib/explorer/avs_directory.ex
@@ -28,6 +28,6 @@ defmodule AVSDirectory do
       nil,
       AlignedLayerServiceManager.get_aligned_layer_service_manager_address()
     )
-    |> Ethers.get_logs(fromBlock: 0)
+    |> Ethers.get_logs(fromBlock: 1600000)
   end
 end

--- a/explorer/lib/explorer_web/live/pages/home/index.ex
+++ b/explorer/lib/explorer_web/live/pages/home/index.ex
@@ -43,6 +43,7 @@ defmodule ExplorerWeb.Home.Index do
   defp get_verified_batches_count() do
     AlignedLayerServiceManager.get_batch_verified_events()
     |> (fn
+          {:ok, nil} -> 0
           {:ok, list} -> Enum.count(list)
           {:error, _} -> 0
         end).()


### PR DESCRIPTION
this pr forces the requests to the rpc to read from a somewhat recen block number