### PR TITLE
chore: enable tls in batcher client

### DIFF
--- a/batcher/client/Cargo.lock
+++ b/batcher/client/Cargo.lock
@@ -6674,7 +6674,9 @@ checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.21.0",
 ]
 
@@ -6910,6 +6912,7 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
+ "native-tls",
  "rand",
  "sha1",
  "thiserror",

--- a/batcher/client/Cargo.toml
+++ b/batcher/client/Cargo.toml
@@ -8,7 +8,7 @@ serde = { version = "1.0.201", features = ["derive"] }
 serde_json = "1.0.117"
 futures-util = "0.3.30"
 tokio = { version = "1.37.0", features = ["io-std", "time", "macros", "rt", "rt-multi-thread"] }
-tokio-tungstenite = "0.21.0"
+tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 tungstenite = "0.21.0"
 url = "2.5.0"
 futures-channel = "0.3.30"


### PR DESCRIPTION
To test run

```
cd batcher/client/ && cargo run --release -- \
--proving_system Groth16Bn254 \
--proof test_files/groth16/ineq_1_groth16.proof \
--public_input test_files/groth16/ineq_1_groth16.pub \
--vk test_files/groth16/ineq_1_groth16.vk \
--proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
--conn wss://batcher.alignedlayer.com
```

You should the following log
```INFO  batcher_client] WebSocket handshake has been successfully completed```