### PR TITLE
feat (batcher_client): set address as an optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cargo run --  \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
 --conn wss://batcher.alignedlayer.com \
---proof_generator_addr <proof_generator_addr>
+--proof_generator_addr [proof_generator_addr]
 ```
 
 **Example**
@@ -51,8 +51,7 @@ cargo run -- \
 --proving_system SP1 \
 --proof test_files/sp1/sp1_fibonacci.proof \
 --vm_program test_files/sp1/sp1_fibonacci-elf \
---conn wss://batcher.alignedlayer.com \
---proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 ; 
+--conn wss://batcher.alignedlayer.com ;
 popd
 ```
 
@@ -62,8 +61,7 @@ cargo run -- \
 --proving_system SP1 \
 --proof test_files/sp1/sp1_fibonacci.proof \
 --vm_program test_files/sp1/sp1_fibonacci-elf \
---conn wss://batcher.alignedlayer.com \
---proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 ;
+--conn wss://batcher.alignedlayer.com ;
 popd
 ```
 
@@ -79,7 +77,7 @@ cargo run -- \
 --public_input <public_input_file> \
 --vk <verification_key_file> \
 --conn wss://batcher.alignedlayer.com \
---proof_generator_addr <proof_generator_addr> ;
+--proof_generator_addr [proof_generator_addr] ;
 popd
 ```
 
@@ -92,8 +90,7 @@ cargo run --release -- \
 --proof test_files/plonk_bn254/plonk.proof \
 --public_input test_files/plonk_bn254/plonk_pub_input.pub \
 --vk test_files/plonk_bn254/plonk.vk \
---conn wss://batcher.alignedlayer.com \
---proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 ;
+--conn wss://batcher.alignedlayer.com ;
 popd
 ```
 
@@ -104,8 +101,7 @@ cargo run -- \
 --proof test_files/plonk_bls12_381/plonk.proof \
 --public_input test_files/plonk_bls12_381/plonk_pub_input.pub \
 --vk test_files/plonk_bls12_381/plonk.vk \
---conn wss://batcher.alignedlayer.com \
---proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 ;
+--conn wss://batcher.alignedlayer.com ;
 popd
 ```
 
@@ -116,8 +112,7 @@ cargo run -- \
 --proof test_files/groth16/ineq_1_groth16.proof \
 --public_input test_files/groth16/ineq_1_groth16.pub \
 --vk test_files/groth16/ineq_1_groth16.vk \
---conn wss://batcher.alignedlayer.com \
---proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 ;
+--conn wss://batcher.alignedlayer.com ;
 popd
 ```
 
@@ -472,7 +467,7 @@ cd batcher/client/ && cargo run --release -- \
 --proof <proof_file> \
 --public-input <public_input_file> \
 --vm_program <vm_program_file> \
---proof_generator_addr <proof_generator_addr>
+--proof_generator_addr [proof_generator_addr]
 ```
 
 
@@ -812,7 +807,7 @@ cargo run --release -- \
 --proof <proof_path> \
 --vm_program <vm_program_path> \
 --conn wss://batcher.alignedlayer.com \
---proof_generator_addr <proof_generator_addr>
+--proof_generator_addr [proof_generator_addr]
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ cargo run --  \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
 --conn wss://batcher.alignedlayer.com \
---proof_generator_addr [proof_generator_addr]
+--proof_generator_addr [proof_generator_addr] ;
+popd
 ```
 
 **Example**

--- a/batcher/client/src/main.rs
+++ b/batcher/client/src/main.rs
@@ -53,8 +53,8 @@ struct Args {
     #[arg(
         name = "Proof generator address",
         long = "proof_generator_addr",
-        default_value = "."
-    )]
+        default_value = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+    )] // defaults to anvil address 1
     proof_generator_addr: String,
 
 }


### PR DESCRIPTION
Proof generator address is now an optional parameter.

# To test

1. Start anvil, batcher, aggregator and operator.
2. Run ```
pushd batcher/client/ ; \
cargo run -- \
--proving_system SP1 \
--proof test_files/sp1/sp1_fibonacci.proof \
--vm_program test_files/sp1/sp1_fibonacci-elf \
--conn wss://batcher.alignedlayer.com ;
popd
```
3. Run ```
pushd batcher/client/ ; \
cargo run -- \
--proving_system SP1 \
--proof test_files/sp1/sp1_fibonacci.proof \
--vm_program test_files/sp1/sp1_fibonacci-elf \
--conn wss://batcher.alignedlayer.com \
--proof_generator_addr 0x976EA74026E726554dB657fA54763abd0C3a0aa9 ;
popd
```