### PR TITLE
fix (aggregator): estimate respondToTask gas limit correctly

### DIFF
--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -2,7 +2,6 @@ package chainio
 
 import (
 	"context"
-
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
@@ -87,28 +86,7 @@ func (w *AvsWriter) SendTask(context context.Context, batchMerkleRoot [32]byte, 
 }
 
 func (w *AvsWriter) SendAggregatedResponse(ctx context.Context, batchMerkleRoot [32]byte, nonSignerStakesAndSignature servicemanager.IBLSSignatureCheckerNonSignerStakesAndSignature) (*gethtypes.Receipt, error) {
-	txOpts := w.Signer.GetTxOpts()
-	txOpts.GasLimit = 500_000 // TODO(juli): This is a temporary fix to avoid out of gas errors. Goethereum is underestimating the gas limit for this tx.
-	tx, err := w.AvsContractBindings.ServiceManager.RespondToTask(txOpts, batchMerkleRoot, nonSignerStakesAndSignature)
-	if err != nil {
-		w.logger.Error("Error submitting SubmitTaskResponse tx while calling respondToTask", "err", err)
-		return nil, err
-	}
-
-	receipt, err := utils.WaitForTransactionReceipt(w.Client, ctx, tx.Hash())
-	if err != nil {
-		return nil, err
-	}
-
-	taskRespondedEvent, err := w.AvsContractBindings.ServiceManager.ContractAlignedLayerServiceManagerFilterer.ParseBatchVerified(*receipt.Logs[0])
-	if err != nil {
-		return nil, err
-	}
-
-	// FIXME(marian): Dummy log to check integration with the contract
-	w.logger.Infof("TASK RESPONDED EVENT: %+v", taskRespondedEvent)
-	return receipt, nil
-}
+g}
 
 // func (w *AvsWriter) RaiseChallenge(
 // 	ctx context.Context,

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -96,7 +96,7 @@ func (w *AvsWriter) SendAggregatedResponse(ctx context.Context, batchMerkleRoot 
 
 	// Send the transaction
 	txOpts.NoSend = false
-	txOpts.GasLimit = uint64(float64(tx.Gas()) * 1.1) // Add 10% to the gas limit
+	txOpts.GasLimit = tx.Gas() * 110 / 100 // Add 10% to the gas limit
 	tx, err = w.AvsContractBindings.ServiceManager.RespondToTask(txOpts, batchMerkleRoot, nonSignerStakesAndSignature)
 	if err != nil {
 		w.logger.Error("Error submitting SubmitTaskResponse tx while calling respondToTask", "err", err)


### PR DESCRIPTION
We had to hardcode gas estimation to 500k beacause it was reverting because estimate was not sufficient. Now we add 10% to the estimate instead.

# To test
Tested in prod and seems fine