### PR TITLE
fix: change error to warn in aggregator

### DIFF
--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -66,7 +66,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 		&signedTaskResponse.BlsSignature, signedTaskResponse.OperatorId,
 	)
 	if err != nil {
-		agg.logger.Errorf("BLS aggregation service error: %s", err)
+		agg.logger.Warnf("BLS aggregation service error: %s", err)
 		*reply = 1
 		return err
 	}


### PR DESCRIPTION
# Description

- Change error to warn in aggregator to avoid sending slack notifications when not needed