### PR TITLE
fix (aggregator): improve stability

### DIFF
--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -44,7 +44,6 @@ type Aggregator struct {
 	// Note: In case of a reboot, this doesn't need to be loaded,
 	// and can start from zero
 	batchesRootByIdx      map[uint32][32]byte
-	//batchesRootByIdxMutex *sync.Mutex
 
 	// This is the counterpart,
 	// to use when we have the batch but not the index
@@ -57,7 +56,9 @@ type Aggregator struct {
 	// Note: In case of a reboot it can start from 0 again
 	nextBatchIndex      uint32
 
+	// Mutex to protect batchesRootByIdx, batchesIdxByRoot and nextBatchIndex
 	taskMutex 			*sync.Mutex
+
 	logger               logging.Logger
 
 	metricsReg *prometheus.Registry
@@ -195,7 +196,7 @@ func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg
 		"taskIndex", blsAggServiceResp.TaskIndex,
 	)
 
-	agg.taskMutex.Lock() // TODO: Might not be necessary
+	agg.taskMutex.Lock()
 	batchMerkleRoot := agg.batchesRootByIdx[blsAggServiceResp.TaskIndex]
 	agg.taskMutex.Unlock()
 
@@ -241,6 +242,6 @@ func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, taskCreatedBlock uin
 	// --- INCREASE BATCH INDEX ---
 	agg.nextBatchIndex = agg.nextBatchIndex + 1
 
-	agg.logger.Info("New task added", "batchIndex", batchIndex, "batchMerkleRoot", batchMerkleRoot)
 	agg.taskMutex.Unlock()
+	agg.logger.Info("New task added", "batchIndex", batchIndex, "batchMerkleRoot", batchMerkleRoot)
 }

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -212,6 +212,8 @@ func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg
 		}
 
 		agg.logger.Warn("Aggregator failed to respond to task", "retryNumber", i, "err", err)
+		// Sleep for a bit before retrying
+		time.Sleep(2 * time.Second)
 	}
 }
 

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -196,14 +196,14 @@ func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg
 		"taskIndex", blsAggServiceResp.TaskIndex,
 	)
 
+	// Wait a bit
+	time.Sleep(15 * time.Second)
+
 	agg.taskMutex.Lock()
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Fetching merkle root")
 	batchMerkleRoot := agg.batchesRootByIdx[blsAggServiceResp.TaskIndex]
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Fetching merkle root")
 	agg.taskMutex.Unlock()
-
-	// Wait a block, going to fast generates errors
-	time.Sleep(15 * time.Second)
 
 	_, err := agg.avsWriter.SendAggregatedResponse(context.Background(), batchMerkleRoot, nonSignerStakesAndSignature)
 	if err != nil {

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -240,7 +240,7 @@ func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, taskCreatedBlock uin
 	if _, ok := agg.batchesIdxByRoot[batchMerkleRoot]; ok {
 		agg.logger.Warn("Batch already exists", "batchIndex", batchIndex, "batchRoot", batchMerkleRoot)
 		agg.taskMutex.Unlock()
-		agg.AggregatorConfig.BaseConfig.Logger.Info("- Unocked Resources: Adding new task")
+		agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Adding new task")
 		return
 	}
 

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -248,7 +248,7 @@ func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, taskCreatedBlock uin
 	if _, ok := agg.batchesRootByIdx[batchIndex]; ok {
 		agg.logger.Warn("Batch already exists", "batchIndex", batchIndex, "batchRoot", batchMerkleRoot)
 		agg.taskMutex.Unlock()
-		agg.AggregatorConfig.BaseConfig.Logger.Info("- Unocked Resources: Adding new task")
+		agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Adding new task")
 		return
 	}
 

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -266,6 +266,6 @@ func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, taskCreatedBlock uin
 	}
 
 	agg.taskMutex.Unlock()
-	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unocked Resources: Adding new task")
+	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Adding new task")
 	agg.logger.Info("New task added", "batchIndex", batchIndex, "batchMerkleRoot", batchMerkleRoot)
 }

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -202,6 +202,9 @@ func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Fetching merkle root")
 	agg.taskMutex.Unlock()
 
+	// Wait a block, going to fast generates errors
+	time.Sleep(15 * time.Second)
+
 	_, err := agg.avsWriter.SendAggregatedResponse(context.Background(), batchMerkleRoot, nonSignerStakesAndSignature)
 	if err != nil {
 		agg.logger.Error("Aggregator failed to respond to task", "err", err)

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -197,7 +197,7 @@ func (agg *Aggregator) sendAggregatedResponseToContract(blsAggServiceResp blsagg
 	)
 
 	// Wait a bit
-	time.Sleep(15 * time.Second)
+	time.Sleep(20 * time.Second)
 
 	agg.taskMutex.Lock()
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Fetching merkle root")

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -47,7 +47,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 	agg.AggregatorConfig.BaseConfig.Logger.Info("New task response", "taskResponse", signedTaskResponse)
 
 
-	agg.taskMutex.Lock() // TODO: I dont think this lock is necessary
+	agg.taskMutex.Lock()
 	taskIndex, ok := agg.batchesIdxByRoot[signedTaskResponse.BatchMerkleRoot]
 	if !ok {
 		agg.taskMutex.Unlock()

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -50,16 +50,15 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 		return fmt.Errorf("task with batch merkle root %d does not exist", signedTaskResponse.BatchMerkleRoot)
 	}
 
-	agg.batchesResponseMutex.Lock()
+	agg.taskMutex.Lock()
+
 	taskResponses := agg.OperatorTaskResponses[signedTaskResponse.BatchMerkleRoot]
 	taskResponses.taskResponses = append(
 		agg.OperatorTaskResponses[signedTaskResponse.BatchMerkleRoot].taskResponses,
 		*signedTaskResponse)
-	agg.batchesResponseMutex.Unlock()
-
-	agg.batchesIdxByRootMutex.Lock()
 	taskIndex := agg.batchesIdxByRoot[signedTaskResponse.BatchMerkleRoot]
-	agg.batchesIdxByRootMutex.Unlock()
+
+	agg.taskMutex.Unlock()
 
 	err := agg.blsAggregationService.ProcessNewSignature(
 		context.Background(), taskIndex, signedTaskResponse.BatchMerkleRoot,

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -46,14 +46,13 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 
 	agg.AggregatorConfig.BaseConfig.Logger.Info("New task response", "taskResponse", signedTaskResponse)
 
-	if _, ok := agg.batchesIdxByRoot[signedTaskResponse.BatchMerkleRoot]; !ok {
+
+	agg.taskMutex.Lock() // TODO: I dont think this lock is necessary
+	taskIndex, ok := agg.batchesIdxByRoot[signedTaskResponse.BatchMerkleRoot]
+	if !ok {
+		agg.taskMutex.Unlock()
 		return fmt.Errorf("task with batch merkle root %d does not exist", signedTaskResponse.BatchMerkleRoot)
 	}
-
-	agg.taskMutex.Lock()
-
-	taskIndex := agg.batchesIdxByRoot[signedTaskResponse.BatchMerkleRoot]
-
 	agg.taskMutex.Unlock()
 
 	err := agg.blsAggregationService.ProcessNewSignature(

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -46,19 +46,23 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 
 	agg.AggregatorConfig.BaseConfig.Logger.Info("New task response", "taskResponse", signedTaskResponse)
 
-
 	agg.taskMutex.Lock()
+	agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Starting processing of Response")
 	taskIndex, ok := agg.batchesIdxByRoot[signedTaskResponse.BatchMerkleRoot]
 	if !ok {
+		agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources")
 		agg.taskMutex.Unlock()
 		return fmt.Errorf("task with batch merkle root %d does not exist", signedTaskResponse.BatchMerkleRoot)
 	}
-	agg.taskMutex.Unlock()
 
 	err := agg.blsAggregationService.ProcessNewSignature(
 		context.Background(), taskIndex, signedTaskResponse.BatchMerkleRoot,
 		&signedTaskResponse.BlsSignature, signedTaskResponse.OperatorId,
 	)
+
+	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Task response processing finished")
+	agg.taskMutex.Unlock()
+
 	if err != nil {
 		agg.logger.Warnf("BLS aggregation service error: %s", err)
 		*reply = 1

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -58,7 +58,6 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 		return fmt.Errorf("task with batch merkle root %d does not exist", signedTaskResponse.BatchMerkleRoot)
 	}
 
-	// EigenSDK is unreliable, may get stuck
 	// Don't wait infinitely if it can't answer
 	// Create a context with a timeout of 5 seconds
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -73,12 +73,14 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 			context.Background(), taskIndex, signedTaskResponse.BatchMerkleRoot,
 			&signedTaskResponse.BlsSignature, signedTaskResponse.OperatorId,
 		)
+
 		if err != nil {
 			agg.logger.Warnf("BLS aggregation service error: %s", err)
 		} else {
 			agg.logger.Info("BLS process succeeded")
-			close(done)
 		}
+
+		close(done)
 	}()
 
 	*reply = 1
@@ -86,7 +88,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 	select {
 	case <-ctx.Done():
 		// The context's deadline was exceeded or it was canceled
-		agg.logger.Warn("Bls process timed out, batch will be lost")
+		agg.logger.Info("Bls process timed out, operator signature will be lost. Batch may not reach quorum")
 	case <-done:
 		// The task completed successfully
 		agg.logger.Info("Bls context finished correctly")

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -46,16 +46,12 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 
 	agg.AggregatorConfig.BaseConfig.Logger.Info("New task response", "taskResponse", signedTaskResponse)
 
-	if _, ok := agg.OperatorTaskResponses[signedTaskResponse.BatchMerkleRoot]; !ok {
+	if _, ok := agg.batchesIdxByRoot[signedTaskResponse.BatchMerkleRoot]; !ok {
 		return fmt.Errorf("task with batch merkle root %d does not exist", signedTaskResponse.BatchMerkleRoot)
 	}
 
 	agg.taskMutex.Lock()
 
-	taskResponses := agg.OperatorTaskResponses[signedTaskResponse.BatchMerkleRoot]
-	taskResponses.taskResponses = append(
-		agg.OperatorTaskResponses[signedTaskResponse.BatchMerkleRoot].taskResponses,
-		*signedTaskResponse)
 	taskIndex := agg.batchesIdxByRoot[signedTaskResponse.BatchMerkleRoot]
 
 	agg.taskMutex.Unlock()

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/rpc"
@@ -44,8 +45,9 @@ func (agg *Aggregator) ServeOperators() error {
 //   - 0: Success
 //   - 1: Error
 func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *types.SignedTaskResponse, reply *uint8) error {
-
-	agg.AggregatorConfig.BaseConfig.Logger.Info("New task response", "taskResponse", signedTaskResponse)
+	agg.AggregatorConfig.BaseConfig.Logger.Info("New task response",
+		"merkleRoot", hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),
+		"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
 
 	agg.taskMutex.Lock()
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Starting processing of Response")
@@ -78,8 +80,6 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *typ
 			close(done)
 		}
 	}()
-
-	fmt.Println("Starting bls signature process")
 
 	*reply = 1
 	// Wait for either the context to be done or the task to complete

--- a/aggregator/internal/pkg/subscriber.go
+++ b/aggregator/internal/pkg/subscriber.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	MaxRetries    = 20
-	RetryInterval = 10 * time.Second
+	MaxRetries    = 100
+	RetryInterval = 1 * time.Second
 )
 
 func (agg *Aggregator) SubscribeToNewTasks() error {

--- a/aggregator/internal/pkg/subscriber.go
+++ b/aggregator/internal/pkg/subscriber.go
@@ -32,7 +32,6 @@ func (agg *Aggregator) subscribeToNewTasks() error {
 	for {
 		select {
 		case err := <-agg.taskSubscriber.Err():
-			agg.AggregatorConfig.BaseConfig.Logger.Error("Error in subscription", "err", err)
 			return err
 		case newBatch := <-agg.NewBatchChan:
 			agg.AddNewTask(newBatch.BatchMerkleRoot, newBatch.TaskCreatedBlock)

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -108,13 +108,6 @@ func (w *AvsWriter) SendAggregatedResponse(ctx context.Context, batchMerkleRoot 
 		return nil, err
 	}
 
-	taskRespondedEvent, err := w.AvsContractBindings.ServiceManager.ContractAlignedLayerServiceManagerFilterer.ParseBatchVerified(*receipt.Logs[0])
-	if err != nil {
-		return nil, err
-	}
-
-	// FIXME(marian): Dummy log to check integration with the contract
-	w.logger.Infof("TASK RESPONDED EVENT: %+v", taskRespondedEvent)
 	return receipt, nil
 }
 

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -90,7 +90,6 @@ func (w *AvsWriter) SendAggregatedResponse(ctx context.Context, batchMerkleRoot 
 	txOpts.NoSend = true // simulate the transaction
 	tx, err := w.AvsContractBindings.ServiceManager.RespondToTask(&txOpts, batchMerkleRoot, nonSignerStakesAndSignature)
 	if err != nil {
-		w.logger.Error("Error submitting SubmitTaskResponse tx while calling respondToTask", "err", err)
 		return nil, err
 	}
 
@@ -99,7 +98,6 @@ func (w *AvsWriter) SendAggregatedResponse(ctx context.Context, batchMerkleRoot 
 	txOpts.GasLimit = tx.Gas() * 110 / 100 // Add 10% to the gas limit
 	tx, err = w.AvsContractBindings.ServiceManager.RespondToTask(&txOpts, batchMerkleRoot, nonSignerStakesAndSignature)
 	if err != nil {
-		w.logger.Error("Error submitting SubmitTaskResponse tx while calling respondToTask", "err", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
In this PR we fixed multiple issues to increase stability:

- We have changed the aggregator to use only one Mutex for all 3 data types that are related to the state of the local indexes and the Merkle Roots of the batches, since those 3 needs to be changed together. We also locked with it the aggregation service, since it was having some concurrency issues, and since it's fast using it sequentially isn't a problem. 

- We have added a timeout for the Bls Aggregation service when a task response is received, since it sometimes never returns

- We have added a retry with a delay when sending a batched task response to Eth, since it sometimes fails by saying the batch doesn't exist, when it in fact exists. This may be due to the node not having the data yet.

- We removed a data structure that was not used, and added unnecesary code that generates confusion

- We moved all the checks in AddNewTask to the beggining, since it could happen that it mutates the aggregator state partially, because at a later point a check failed, leading to a failure of the aggregator

- We have improved the logging, and changed the errors to be warning or errors depending on if the error implies that the system fail or lost a batch, or that something may be wrong but the system is not sure

This closes #319 