### PR TITLE
feat: add github action to upload batcher-client binary in each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          files: /batcher/client/target/release/batcher-client
+          files: batcher/client/target/release/batcher-client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Build and Release Rust Project
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Build batcher client
+        run: make build_batcher_client
+  
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: /batcher/client/target/release/batcher-client


### PR DESCRIPTION
# Description

- This PR adds a Github action that builds the batcher-client and uploads it to a release when a new tag is created and pushed.