### PR TITLE
Start burst from given number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,8 @@ batcher_send_infinite_groth16: ./batcher/client/target/release/batcher-client ##
 
 batcher_send_burst_groth16: build_batcher_client
 	@echo "Sending a burst of tasks to Batcher..."
-	@./batcher/client/send_burst_tasks.sh $(BURST_SIZE)
+	@mkdir -p task_sender/test_examples/gnark_groth16_bn254_infinite_script/infinite_proofs
+	@./batcher/client/send_burst_tasks.sh $(BURST_SIZE) $(START_COUNTER)
 
 batcher_send_halo2_ipa_task: batcher/client/target/release/batcher-client
 	@echo "Sending Halo2 IPA 1!=0 task to Batcher..."

--- a/batcher/client/send_burst_tasks.sh
+++ b/batcher/client/send_burst_tasks.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# Valores por defecto
 counter=1
 burst=8
 
-# Procesar el argumento para el valor de burst
 if [ -z "$1" ]; then
     echo "Using default burst value: 10"
 elif ! [[ "$1" =~ ^[0-9]+$ ]]; then
@@ -15,7 +13,6 @@ else
     echo "Using burst value: $burst"
 fi
 
-# Procesar el argumento para el valor inicial del counter
 if [ -z "$2" ]; then
     echo "Using default counter start value: 1"
 elif ! [[ "$2" =~ ^[0-9]+$ ]]; then
@@ -26,10 +23,9 @@ else
     echo "Starting counter from: $counter"
 fi
 
-# Bucle para procesar exactamente el número de tareas definido por burst
 for ((i=0; i<burst; i++))
 do
-    # Ejecutar en segundo plano
+  # Run in backaground to be able to run onece per second, and not wait for the previous one to finish
     ./batcher/client/generate_proof_and_send.sh $counter $burst &
     sleep 1
     counter=$((counter + 1))

--- a/batcher/client/send_burst_tasks.sh
+++ b/batcher/client/send_burst_tasks.sh
@@ -1,24 +1,36 @@
 #!/bin/bash
 
+# Valores por defecto
 counter=1
 burst=8
 
+# Procesar el argumento para el valor de burst
 if [ -z "$1" ]; then
     echo "Using default burst value: 10"
 elif ! [[ "$1" =~ ^[0-9]+$ ]]; then
-    echo "Error: Argument must be a number."
+    echo "Error: First argument must be a number."
     exit 1
 else
     burst=$1
     echo "Using burst value: $burst"
 fi
 
-counter=1
-while true
-do
-  # Run in backaground to be able to run onece per second, and not wait for the previous one to finish
-  ./batcher/client/generate_proof_and_send.sh $counter $burst &
-  sleep 1
-  counter=$((counter + 1))
-done
+# Procesar el argumento para el valor inicial del counter
+if [ -z "$2" ]; then
+    echo "Using default counter start value: 1"
+elif ! [[ "$2" =~ ^[0-9]+$ ]]; then
+    echo "Error: Second argument must be a number."
+    exit 1
+else
+    counter=$2
+    echo "Starting counter from: $counter"
+fi
 
+# Bucle para procesar exactamente el número de tareas definido por burst
+for ((i=0; i<burst; i++))
+do
+    # Ejecutar en segundo plano
+    ./batcher/client/generate_proof_and_send.sh $counter $burst &
+    sleep 1
+    counter=$((counter + 1))
+done

--- a/task_sender/test_examples/gnark_groth16_bn254_infinite_script/pkg/generate_proof.go
+++ b/task_sender/test_examples/gnark_groth16_bn254_infinite_script/pkg/generate_proof.go
@@ -8,18 +8,13 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
-
-	//	"github.com/consensys/gnark/frontend/cs/scs"
-	"github.com/consensys/gnark/frontend/cs/r1cs"
-
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
 )
 
-// CubicCircuit defines a simple circuit
+// InequalityCircuit defines a simple circuit
 // x != 0
 type InequalityCircuit struct {
-	// struct tags on a variable is optional
-	// default uses variable name and secret visibility.
 	X frontend.Variable `gnark:"x"`
 }
 
@@ -34,23 +29,12 @@ func GenerateIneqProof(x int) {
 	outputDir := "task_sender/test_examples/gnark_groth16_bn254_infinite_script/infinite_proofs/"
 
 	var circuit InequalityCircuit
-	// use r1cs.NewBuilder instead of scs.NewBuilder
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &circuit)
 	if err != nil {
 		panic("circuit compilation error")
 	}
 
-	// rics is not used in the setup
-	//	r1cs := ccs.(*cs.SparseR1CS)
-	// as srs is not used in the setup, we can remove it
-	//	srs, err := test.NewKZGSRS(r1cs)
-	if err != nil {
-		panic("KZG setup error")
-	}
-
-	// no need to use srs in the setup
 	pk, vk, _ := groth16.Setup(ccs)
-	//	pk, vk, err := groth16.Setup(ccs, srs)
 
 	assignment := InequalityCircuit{X: x}
 
@@ -59,25 +43,21 @@ func GenerateIneqProof(x int) {
 		log.Fatal(err)
 	}
 
-	// TODO , this should be empty, right? private input is x and no pub input
 	publicWitness, err := frontend.NewWitness(&assignment, ecc.BN254.ScalarField(), frontend.PublicOnly())
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// This proof should be serialized for testing in the operator
 	proof, err := groth16.Prove(ccs, pk, fullWitness)
 	if err != nil {
 		panic("GROTH16 proof generation error")
 	}
 
-	// The proof is verified before writing it into a file to make sure it is valid.
 	err = groth16.Verify(proof, vk, publicWitness)
 	if err != nil {
 		panic("GROTH16 proof not verified")
 	}
 
-	// Open files for writing the proof, the verification key and the public witness
 	proofFile, err := os.Create(outputDir + "ineq_" + strconv.Itoa(x) + "_groth16.proof")
 	if err != nil {
 		panic(err)
@@ -107,7 +87,7 @@ func GenerateIneqProof(x int) {
 		panic("could not serialize proof into file")
 	}
 
-	fmt.Println("Proof written into ineq_{x}_groth16.proof")
-	fmt.Println("Verification key written into groth16_verification_key")
-	fmt.Println("Public witness written into witness.pub")
+	fmt.Printf("Proof written into ineq_%d_groth16.proof\n", x)
+	fmt.Printf("Verification key written into ineq_%d_groth16.vk\n", x)
+	fmt.Printf("Public witness written into ineq_%d_groth16.pub\n", x)
 }


### PR DESCRIPTION
to test run:


```bash
make batcher_send_burst_groth16 START_COUNTER=15
```
In this case, the burst will start from the counter value 15, generating and processing proofs sequentially from this starting point.

If no START_COUNTER is provided, it will default to starting from 1:

```bash
make batcher_send_burst_groth16
```