### PR TITLE
Change CLI name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          files: batcher/client/target/release/batcher-client
+          files: batcher/client/target/release/aligned

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ batcher_start: ./batcher/.env
 install_batcher:
 	@cargo +nightly-2024-04-17 install --path batcher
 
-install_batcher_client:
+install_aligned_cli: 
 	@cargo +nightly-2024-04-17 install --path batcher/client
 
 build_batcher_client:

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ install_batcher_client:
 build_batcher_client:
 	@cd batcher/client && cargo b --release
 
-batcher/client/target/release/batcher-client:
+batcher/client/target/release/aligned:
 	@cd batcher/client && cargo b --release
 
 batcher_send_sp1_task:
@@ -167,7 +167,7 @@ batcher_send_infinite_sp1:
 	@echo "Sending infinite SP1 fibonacci task to Batcher..."
 	@./batcher/client/send_infinite_sp1_tasks/send_infinite_sp1_tasks.sh
 
-batcher_send_plonk_bn254_task: batcher/client/target/release/batcher-client
+batcher_send_plonk_bn254_task: batcher/client/target/release/aligned
 	@echo "Sending Groth16Bn254 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system GnarkPlonkBn254 \
@@ -176,7 +176,7 @@ batcher_send_plonk_bn254_task: batcher/client/target/release/batcher-client
 		--vk test_files/plonk_bn254/plonk.vk \
 		--proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657
 
-batcher_send_plonk_bn254_burst: batcher/client/target/release/batcher-client
+batcher_send_plonk_bn254_burst: batcher/client/target/release/aligned
 	@echo "Sending Groth16Bn254 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system GnarkPlonkBn254 \
@@ -186,7 +186,7 @@ batcher_send_plonk_bn254_burst: batcher/client/target/release/batcher-client
 		--proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
 		--repetitions 15
 
-batcher_send_plonk_bls12_381_task: batcher/client/target/release/batcher-client
+batcher_send_plonk_bls12_381_task: batcher/client/target/release/aligned
 	@echo "Sending Groth16 BLS12-381 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system GnarkPlonkBls12_381 \
@@ -195,7 +195,7 @@ batcher_send_plonk_bls12_381_task: batcher/client/target/release/batcher-client
 		--vk test_files/plonk_bls12_381/plonk.vk \
 		--proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657
 
-batcher_send_plonk_bls12_381_burst: batcher/client/target/release/batcher-client
+batcher_send_plonk_bls12_381_burst: batcher/client/target/release/aligned
 	@echo "Sending Groth16 BLS12-381 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system GnarkPlonkBls12_381 \
@@ -206,7 +206,7 @@ batcher_send_plonk_bls12_381_burst: batcher/client/target/release/batcher-client
 		--repetitions 15
 
 
-batcher_send_groth16_bn254_task: batcher/client/target/release/batcher-client
+batcher_send_groth16_bn254_task: batcher/client/target/release/aligned
 	@echo "Sending Groth16Bn254 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system Groth16Bn254 \
@@ -215,7 +215,7 @@ batcher_send_groth16_bn254_task: batcher/client/target/release/batcher-client
 		--vk test_files/groth16/ineq_1_groth16.vk \
 		--proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657
 
-batcher_send_groth16_burst: batcher/client/target/release/batcher-client
+batcher_send_groth16_burst: batcher/client/target/release/aligned
 	@echo "Sending Groth16Bn254 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system Groth16Bn254 \
@@ -225,7 +225,7 @@ batcher_send_groth16_burst: batcher/client/target/release/batcher-client
 		--repetitions 15 \
 		--proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657
 
-batcher_send_infinite_groth16: ./batcher/client/target/release/batcher-client ## Send a different Groth16 BN254 proof using the task sender every 3 seconds
+batcher_send_infinite_groth16: ./batcher/client/target/release/aligned ## Send a different Groth16 BN254 proof using the task sender every 3 seconds
 	@mkdir -p task_sender/test_examples/gnark_groth16_bn254_infinite_script/infinite_proofs
 	@echo "Sending a different GROTH16 BN254 proof in a loop every n seconds..."
 	@./batcher/client/send_infinite_tasks.sh 4
@@ -234,7 +234,7 @@ batcher_send_burst_groth16: build_batcher_client
 	@echo "Sending a burst of tasks to Batcher..."
 	@./batcher/client/send_burst_tasks.sh $(BURST_SIZE)
 
-batcher_send_halo2_ipa_task: batcher/client/target/release/batcher-client
+batcher_send_halo2_ipa_task: batcher/client/target/release/aligned
 	@echo "Sending Halo2 IPA 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system Halo2IPA \
@@ -242,7 +242,7 @@ batcher_send_halo2_ipa_task: batcher/client/target/release/batcher-client
 		--public_input test_files/halo2_ipa/pub_input.bin \
 		--vk test_files/halo2_ipa/params.bin \
 
-batcher_send_halo2_ipa_task_burst_5: batcher/client/target/release/batcher-client
+batcher_send_halo2_ipa_task_burst_5: batcher/client/target/release/aligned
 	@echo "Sending Halo2 IPA 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system Halo2IPA \
@@ -251,7 +251,7 @@ batcher_send_halo2_ipa_task_burst_5: batcher/client/target/release/batcher-clien
 		--vk test_files/halo2_ipa/params.bin \
 		--repetitions 5
 
-batcher_send_halo2_kzg_task: batcher/client/target/release/batcher-client
+batcher_send_halo2_kzg_task: batcher/client/target/release/aligned
 	@echo "Sending Halo2 KZG 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system Halo2KZG \
@@ -260,7 +260,7 @@ batcher_send_halo2_kzg_task: batcher/client/target/release/batcher-client
 		--vk test_files/halo2_kzg/params.bin \
 		--proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657
 
-batcher_send_halo2_kzg_task_burst_5: batcher/client/target/release/batcher-client
+batcher_send_halo2_kzg_task_burst_5: batcher/client/target/release/aligned
 	@echo "Sending Halo2 KZG 1!=0 task to Batcher..."
 	@cd batcher/client/ && cargo run --release -- \
 		--proving_system Halo2KZG \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ make install_batcher_client
 The SP1 proof needs the proof file and the vm program file.
 
 ```bash
-batcher-client \
+aligned \
 --proving_system <SP1|GnarkPlonkBn254|GnarkPlonkBls12_381|Groth16Bn254> \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
@@ -52,7 +52,7 @@ batcher-client \
 **Example**
 
 ```bash
-batcher-client \
+aligned \
 --proving_system SP1 \
 --proof test_files/sp1/sp1_fibonacci.proof \
 --vm_program test_files/sp1/sp1_fibonacci-elf \
@@ -60,7 +60,7 @@ batcher-client \
 ```
 
 ```bash
-batcher-client \
+aligned \
 --proving_system SP1 \
 --proof test_files/sp1/sp1_fibonacci.proof \
 --vm_program test_files/sp1/sp1_fibonacci-elf \
@@ -72,7 +72,7 @@ batcher-client \
 The GnarkPlonkBn254, GnarkPlonkBls12_381 and Groth16Bn254 proofs need the proof file, the public input file and the verification key file.
 
 ```bash
-batcher-client \
+aligned \
 --proving_system <SP1|GnarkPlonkBn254|GnarkPlonkBls12_381|Groth16Bn254> \
 --proof <proof_file> \
 --public_input <public_input_file> \
@@ -84,7 +84,7 @@ batcher-client \
 **Examples**
 
 ```bash
-batcher-client \
+aligned \
 --proving_system GnarkPlonkBn254 \
 --proof test_files/plonk_bn254/plonk.proof \
 --public_input test_files/plonk_bn254/plonk_pub_input.pub \
@@ -93,7 +93,7 @@ batcher-client \
 ```
 
 ```bash
-batcher-client \
+aligned \
 --proving_system GnarkPlonkBls12_381 \
 --proof test_files/plonk_bls12_381/plonk.proof \
 --public_input test_files/plonk_bls12_381/plonk_pub_input.pub \
@@ -102,7 +102,7 @@ batcher-client \
 ```
 
 ```bash
-batcher-client \
+aligned \
 --proving_system Groth16Bn254 \
 --proof test_files/groth16/ineq_1_groth16.proof \
 --public_input test_files/groth16/ineq_1_groth16.pub \
@@ -469,7 +469,7 @@ The SP1 proof needs the proof file and the vm program file.
 The GnarkPlonkBn254, GnarkPlonkBls12_381 and Groth16Bn254 proofs need the proof file, the public input file and the verification key file.
 
 ```bash
-batcher-client \
+aligned \
 --proving_system <SP1|GnarkPlonkBn254|GnarkPlonkBls12_381|Groth16Bn254> \
 --proof <proof_file> \
 --public-input <public_input_file> \

--- a/README.md
+++ b/README.md
@@ -51,19 +51,12 @@ aligned \
 
 **Example**
 
-```bash
-aligned \
---proving_system SP1 \
---proof test_files/sp1/sp1_fibonacci.proof \
---vm_program test_files/sp1/sp1_fibonacci-elf \
---conn wss://batcher.alignedlayer.com
-```
 
 ```bash
 aligned \
 --proving_system SP1 \
---proof test_files/sp1/sp1_fibonacci.proof \
---vm_program test_files/sp1/sp1_fibonacci-elf \
+--proof ./batcher/client/test_files/sp1/sp1_fibonacci.proof \
+--vm_program ./batcher/client/test_files/sp1/sp1_fibonacci-elf \
 --conn wss://batcher.alignedlayer.com
 ```
 
@@ -86,27 +79,27 @@ aligned \
 ```bash
 aligned \
 --proving_system GnarkPlonkBn254 \
---proof test_files/plonk_bn254/plonk.proof \
---public_input test_files/plonk_bn254/plonk_pub_input.pub \
---vk test_files/plonk_bn254/plonk.vk \
+--proof ./batcher/client/test_files/plonk_bn254/plonk.proof \
+--public_input ./batcher/client/test_files/plonk_bn254/plonk_pub_input.pub \
+--vk ./batcher/client/test_files/plonk_bn254/plonk.vk \
 --conn wss://batcher.alignedlayer.com
 ```
 
 ```bash
 aligned \
 --proving_system GnarkPlonkBls12_381 \
---proof test_files/plonk_bls12_381/plonk.proof \
---public_input test_files/plonk_bls12_381/plonk_pub_input.pub \
---vk test_files/plonk_bls12_381/plonk.vk \
+--proof ./batcher/client/test_files/plonk_bls12_381/plonk.proof \
+--public_input ./batcher/client/test_files/plonk_bls12_381/plonk_pub_input.pub \
+--vk ./batcher/client/test_files/plonk_bls12_381/plonk.vk \
 --conn wss://batcher.alignedlayer.com
 ```
 
 ```bash
 aligned \
 --proving_system Groth16Bn254 \
---proof test_files/groth16/ineq_1_groth16.proof \
---public_input test_files/groth16/ineq_1_groth16.pub \
---vk test_files/groth16/ineq_1_groth16.vk \
+--proof ./batcher/client/test_files/groth16/ineq_1_groth16.proof \
+--public_input ./batcher/client/test_files/groth16/ineq_1_groth16.pub \
+--vk ./batcher/client/test_files/groth16/ineq_1_groth16.vk \
 --conn wss://batcher.alignedlayer.com
 ```
 

--- a/batcher/client/Cargo.toml
+++ b/batcher/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "batcher-client"
+name = "aligned"
 version = "0.1.0"
 edition = "2021"
 

--- a/batcher/client/send_infinite_sp1_tasks/send_infinite_sp1_tasks.sh
+++ b/batcher/client/send_infinite_sp1_tasks/send_infinite_sp1_tasks.sh
@@ -20,7 +20,7 @@ do
     random_addr=$(python3 ./send_infinite_sp1_tasks/generate_address.py)
     echo "Random address: $random_addr"
 
-    batcher-client \
+    aligned \
     --proving_system SP1 \
     --proof test_files/sp1/sp1_fibonacci.proof \
     --vm_program test_files/sp1/sp1_fibonacci-elf \


### PR DESCRIPTION
The CLI changed from ```batcher-client``` to ```aligned```

first you have to install the batcher running `make install_aligned_cli`
to test it run:

```bash
aligned \
--proving_system GnarkPlonkBn254 \
--proof ./batcher/client/test_files/plonk_bn254/plonk.proof \
--public_input ./batcher/client/test_files/plonk_bn254/plonk_pub_input.pub \
--vk ./batcher/client/test_files/plonk_bn254/plonk.vk \
--conn wss://batcher.alignedlayer.com
```