### PR TITLE
Fix infinite loop in batcher burst

### DIFF
--- a/batcher/client/send_burst_tasks.sh
+++ b/batcher/client/send_burst_tasks.sh
@@ -3,8 +3,9 @@
 counter=1
 burst=8
 
+# Establecer el valor de 'burst' desde el primer argumento
 if [ -z "$1" ]; then
-    echo "Using default burst value: 10"
+    echo "Using default burst value: 8"
 elif ! [[ "$1" =~ ^[0-9]+$ ]]; then
     echo "Error: First argument must be a number."
     exit 1
@@ -13,6 +14,7 @@ else
     echo "Using burst value: $burst"
 fi
 
+# Establecer el valor inicial del 'counter' desde el segundo argumento
 if [ -z "$2" ]; then
     echo "Using default counter start value: 1"
 elif ! [[ "$2" =~ ^[0-9]+$ ]]; then
@@ -23,10 +25,17 @@ else
     echo "Starting counter from: $counter"
 fi
 
-for ((i=0; i<burst; i++))
+count=0  # Inicializa un contador para el número de ejecuciones
+
+while true
 do
-  # Run in backaground to be able to run onece per second, and not wait for the previous one to finish
+    if [ "$count" -ge "$burst" ]; then
+        break  # Salir del bucle si se han ejecutado 'burst' veces
+    fi
+
+    echo "Generating proof $counter != 0"
     ./batcher/client/generate_proof_and_send.sh $counter $burst &
     sleep 1
     counter=$((counter + 1))
+    count=$((count + 1))  # Incrementar el contador de ejecuciones
 done

--- a/batcher/client/send_burst_tasks.sh
+++ b/batcher/client/send_burst_tasks.sh
@@ -3,20 +3,19 @@
 counter=1
 burst=8
 
-# Establecer el valor de 'burst' desde el primer argumento
 if [ -z "$1" ]; then
-    echo "Using default burst value: 8"
+    echo "Using default burst value: 10"
 elif ! [[ "$1" =~ ^[0-9]+$ ]]; then
-    echo "Error: First argument must be a number."
+    echo "Error: Argument must be a number."
     exit 1
 else
     burst=$1
     echo "Using burst value: $burst"
 fi
 
-# Establecer el valor inicial del 'counter' desde el segundo argumento
 if [ -z "$2" ]; then
     echo "Using default counter start value: 1"
+    counter=1
 elif ! [[ "$2" =~ ^[0-9]+$ ]]; then
     echo "Error: Second argument must be a number."
     exit 1
@@ -25,17 +24,10 @@ else
     echo "Starting counter from: $counter"
 fi
 
-count=0  # Inicializa un contador para el número de ejecuciones
-
 while true
 do
-    if [ "$count" -ge "$burst" ]; then
-        break  # Salir del bucle si se han ejecutado 'burst' veces
-    fi
-
-    echo "Generating proof $counter != 0"
+# Run in backaground to be able to run onece per second, and not wait for the previous one to finish
     ./batcher/client/generate_proof_and_send.sh $counter $burst &
     sleep 1
     counter=$((counter + 1))
-    count=$((count + 1))  # Incrementar el contador de ejecuciones
 done


### PR DESCRIPTION
to test run:

```bash
make batcher_send_burst_groth16 START_COUNTER=15
```
In this case, the burst will start from the counter value 15, generating and processing proofs sequentially from this starting point.


If no START_COUNTER is provided, it will default to starting from 1:

```bash
make batcher_send_burst_groth16
```

closes #347
