### PR TITLE
fix(batcher) add timeout and retries logic to submit batch function

### DIFF
--- a/batcher/src/types/errors.rs
+++ b/batcher/src/types/errors.rs
@@ -6,6 +6,7 @@ pub enum BatcherError {
     ConnectionError(tungstenite::Error),
     BatchVerifiedEventStreamError(String),
     EthereumSubscriptionError(String),
+    TransactionError(String),
 }
 
 impl From<tungstenite::Error> for BatcherError {
@@ -25,6 +26,9 @@ impl fmt::Debug for BatcherError {
             }
             BatcherError::EthereumSubscriptionError(e) => {
                 write!(f, "Ethereum subscription was not successful: {}", e)
+            }
+            BatcherError::TransactionError(e) => {
+                write!(f, "Transaction error: {}", e)
             }
         }
     }


### PR DESCRIPTION
> [!NOTE]
> This PR is missing Testing and Merge Conflicts before Ready for Review

I added this timeout logic to the wait for tx receipt
```rust
match timeout(Duration::from_secs(60), pending_tx).await {
        Ok(Ok(Some(receipt))) => Ok(receipt),
        Ok(Ok(None)) => Err(anyhow::anyhow!("Transaction was mined but no receipt was returned")),
        Ok(Err(e)) => Err(anyhow::anyhow!("Transaction failed: {:?}", e)),
        Err(_) => Err(anyhow::anyhow!("Transaction was not mined within 60 seconds")),
    }
```
I think `Err(_)` case should return `Ok(None)` instead of `Err(...)` because this case does not mean that the tx failed, but the receipt was not received @MauroToscano @entropidelic 

To test the normal behavior, run anvil and the aggregator and send proofs