### PR TITLE
docs: update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -666,6 +666,7 @@ build_all_ffi_linux: ## Build all FFIs for Linux
 	@$(MAKE) build_risc_zero_linux
 #	@$(MAKE) build_merkle_tree_linux
 	@$(MAKE) build_halo2_ipa_linux
+	@$(MAKE) build_halo2_kzg_linux
 	@echo "All Linux FFIs built successfully."
 
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ Ensure you have the following installed:
 - [Rust](https://www.rust-lang.org/tools/install)
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 
+Also, you have to install the following dependencies for Linux:
+
+- pkg-config
+- libssl-dev
+
 To install foundry, run:
 
 ```bash


### PR DESCRIPTION
Added the following dependencies to the readme

- pkg-config
- libssl-dev

Added `build_halo2_kzg_linux` to `build_all_ffi_linux`