### PR TITLE
chore: update ServiceManager address

### DIFF
--- a/contracts/script/output/holesky/alignedlayer_deployment_output.json
+++ b/contracts/script/output/holesky/alignedlayer_deployment_output.json
@@ -2,7 +2,7 @@
   "addresses": {
     "alignedLayerProxyAdmin": "0x3eb924d928c138898FC089328f840105969bD6a0",
     "alignedLayerServiceManager": "0x58F280BeBE9B34c9939C3C39e0890C81f163B623",
-    "alignedLayerServiceManagerImplementation": "0x4bcb1f45868c38638d2cA9989998E296BDEad08c",
+    "alignedLayerServiceManagerImplementation": "0xd8eDbF59AE9ec47e047971a8D418C789998ED197",
     "blsApkRegistry": "0xD0A725d82649f9e4155D7A60B638Fe33b3F25e3b",
     "blsApkRegistryImplementation": "0xB05BB98a966F58aDAB8dF58350b77fF2131A3b87",
     "indexRegistry": "0x4A7DE0a9fBBAa4fF0270d31852B363592F68B81F",


### PR DESCRIPTION
This PR updates the ServiceManager contract address to the last version deployed with the changes that returns true/false instead of revert transaction on verifyProofOnChain