### PR TITLE
docs: Rectify typographical inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Aligned works with EigenLayer to leverage ethereum consensus mechanism for ZK pr
 
 If you want to run an operator, check our [Operator Guide](./README_OPERATOR.md)
 
-## Aligned Infraestructure Guide
+## Aligned Infrastructure Guide
 
 If you are developing in Aligned, or want to run your own devnet, check our [Infraestructure Guide](./README_INFRAESTRUCTURE.md)
 

--- a/README_INFRAESTRUCTURE.md
+++ b/README_INFRAESTRUCTURE.md
@@ -1,7 +1,7 @@
 
-# Aligned Infraestructure Deployment Guide
+# Aligned Infrastructure Deployment Guide
 
-- [Aligned Infraestructure Deployment Guide](#aligned-infraestructure-deployment-guide)
+- [Aligned Infrastructure Deployment Guide](#aligned-infraestructure-deployment-guide)
   - [Local Devnet Setup](#local-devnet-setup)
   - [Deploying Aligned Contracts to Holesky or Testnet](#deploying-aligned-contracts-to-holesky-or-testnet)
   - [Metrics](#metrics)

--- a/docs/about_aligned/FAQ.md
+++ b/docs/about_aligned/FAQ.md
@@ -32,7 +32,7 @@ Batching 1024 proofs using Aligned’s fast mode can cost around 2,100 gas in Et
     
 ### Why do you have a fast and slow mode?
     
-The fast mode is designed to offer very cheap verification costs and low latency. It uses crypto-economic guarantees provided by restaking; costs can be as low as 2100 gas. The slow mode works with proof aggregation, with higher fees and latency, and achieves the complete security of Ethereum. We verify an aggregated BLS signature (around 113,000 gas) in the fast mode. We verify an aggregated proof (around 300,000 gas) in the slow mode.
+The fast mode is designed to offer very cheap verification costs and low latency. It uses crypto-economic guarantees provided by restaking; costs can be as low as 2100 gas. The slow mode works with proof aggregation, with higher fees and latency, and achieves the complete security of Ethereum. We verify an aggregated BLS signature (around 113,000 gas) in the fast mode. We verify an aggregated proof (around 300,000 gas) in slow mode.
     
 ### Why don’t you run Aligned on top of a virtual machine?
     

--- a/docs/about_aligned/how_does_aligned_work.md
+++ b/docs/about_aligned/how_does_aligned_work.md
@@ -49,7 +49,7 @@ The flow for sending a proof and having the results on Ethereum is as follows:
 3. The user invokes an IsVerified function with this data in Solidity to check that the proof is valid.
 4. ( Optional ) The user checks that the commitment to the proven program matches the one it expects.
 
-### Full flow with internals of the proof (Fast Mode)
+### Full flow with the internals of the proof (Fast Mode)
 
 1. The user uses a provided CLI or SDK to send one proof or many to the batcher, and waits (Alternatively, the user can run a batcher or interact directly with Ethereum)
 2. The batcher accumulates proofs of many users for a small number of blocks (typically 1-3).

--- a/docs/about_aligned/modular_approach.md
+++ b/docs/about_aligned/modular_approach.md
@@ -2,7 +2,7 @@
 
 As stated in the EigenLayer paper:
 
-"Ethereum pioneered the concept of modular blockchains, where distributed applications (DApps) became modules that could be built permissionlessly on top of the Ethereum trust network".
+"Ethereum pioneered the concept of modular blockchains, where distributed applications (DApps) became modules that could be built permissionless on top of the Ethereum trust network".
 
 In this context, the concept of modularity goes against the initial approach to constructing blockchains, the monolithic approach, in which a single blockchain is responsible for performing all tasks such as processing transactions, checking for accuracy, and getting nodes to agree on them. This working method gives rise to certain inherent problems when it comes to expansion, resulting in expensive hardware, limited control, and high overhead.
 

--- a/explorer/config/dev.exs
+++ b/explorer/config/dev.exs
@@ -3,7 +3,7 @@ import Config
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #
-# The watchers configuration can be used to run external
+# The watcher's configuration can be used to run external
 # watchers to your application. For example, we can use it
 # to bundle .js and .css sources.
 config :explorer, ExplorerWeb.Endpoint,

--- a/explorer/lib/explorer_web/router.ex
+++ b/explorer/lib/explorer_web/router.ex
@@ -25,7 +25,7 @@ defmodule ExplorerWeb.Router do
   # To Enable LiveDashboard: (only enable behind auth)
   # if Application.compile_env(:explorer, :dev_routes) do
   #   # If you want to use the LiveDashboard in production, you should put
-  #   # it behind authentication and allow only admins to access it.
+  #   # it behind authentication and allows only admins to access it.
   #   # If your application does not have an admins-only section yet,
   #   # you can use Plug.BasicAuth to set up some basic authentication
   #   # as long as you are also using SSL (which you should anyway).

--- a/explorer/test/support/conn_case.ex
+++ b/explorer/test/support/conn_case.ex
@@ -8,7 +8,7 @@ defmodule ExplorerWeb.ConnCase do
   to build common data structures and query the data layer.
 
   Finally, if the test case interacts with the database,
-  we enable the SQL sandbox, so changes done to the database
+  we enable the SQL sandbox, so changes are done to the database
   are reverted at the end of every test. If you are using
   PostgreSQL, you can even run database tests asynchronously
   by setting `use ExplorerWeb.ConnCase, async: true`, although


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.