### PR TITLE
fix: add error handling for bad rpc connection

### DIFF
--- a/explorer/lib/explorer_web/live/pages/home/index.ex
+++ b/explorer/lib/explorer_web/live/pages/home/index.ex
@@ -24,8 +24,10 @@ defmodule ExplorerWeb.Home.Index do
 
     operators_registered = get_operators_registered()
 
-    latest_batches = Batches.get_latest_batches(%{amount: 5})
-      |> Enum.map(fn %Batches{merkle_root: merkle_root} -> merkle_root end) #extract only the merkle root
+    latest_batches =
+      Batches.get_latest_batches(%{amount: 5})
+      # extract only the merkle root
+      |> Enum.map(fn %Batches{merkle_root: merkle_root} -> merkle_root end)
 
     verified_proofs = Batches.get_amount_of_verified_proofs()
 
@@ -56,8 +58,26 @@ defmodule ExplorerWeb.Home.Index do
           IO.puts("Other transport error: #{inspect(e)}")
       end
 
+    e in FunctionClauseError ->
+      case e do
+        %FunctionClauseError{
+          module: ExplorerWeb.Home.Index
+        } ->
+          {
+            :ok,
+            assign(socket,
+              verified_batches: :empty,
+              operators_registered: :empty,
+              latest_batches: :empty,
+              verified_proofs: :empty
+            )
+            |> put_flash(:error, "Something went wrong with the RPC, please try again later.")
+          }
+      end
+
     e ->
-      raise e
+      Logger.error("Other error: #{inspect(e)}")
+      {:ok, socket |> put_flash(:error, "Something went wrong, please try again later.")}
   end
 
   # tail-call recursion


### PR DESCRIPTION
# Objective

close #474. 

Fixes the explorer throwing a 500 error when the RPC connection fails

## Before

Throws 500 error and the page is no longer available.

## After

<img width="1470" alt="image" src="https://github.com/yetanotherco/aligned_layer/assets/58370608/ff4d0d27-ac58-475e-9e78-7d80d2125ada">
