### PR TITLE
feat: add get user balance cli command

### DIFF
--- a/README_SEND_PROOFS.md
+++ b/README_SEND_PROOFS.md
@@ -52,8 +52,9 @@ This commands also allows the usage of the flags:
 - Note: `--amount` flag parameter must be with the shown format, followed by the `ether` keyword to specify how many ethers you wish to deposit to the batcher.
 
 After depositing funds, you can verify the Service has correctly received them, executing the following command:
+
 ```bash
-cast call <payment_service_smart_contract_address> "UserBalances(address)(uint256)" <address>
+aligned get-user-balance --user_addr <user_addr>
 ```
 
 ## 3. Send your proof to the batcher


### PR DESCRIPTION
# Description

- This PR adds a get user balance CLI command.

# To Test

- Run `make anvil_start`
- Run:
```
cast send <addr> --value 1ether --rpc-url http://localhost:8545 --private-key 0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6
```
- Run:
```
aligned get-user-balance --user_addr <addr>
```
It should say 0.
- Run:
```
aligned deposit-to-batcher --keystore_path <keystore_path> --amount 0.1ether
```
- Run:
```
aligned get-user-balance --user_addr <addr>
```
It should say 0.100000000000000000.