### PR TITLE
docs(getting-started): update broken hyperlink to proof guides

### DIFF
--- a/docs/introduction/1_getting_started.md
+++ b/docs/introduction/1_getting_started.md
@@ -72,4 +72,4 @@ Aligned works in:
 
 If you don't meet these requirements, you can compile the binaries yourself following the [README](https://github.com/yetanotherco/aligned_layer)
 
-To try Aligned with other proving systems, check [this](https://docs.alignedlayer.com/guides/0_proving_systems) guide
+To try Aligned with other proving systems, check [this](https://docs.alignedlayer.com/guides/0_submitting_proofs) guide


### PR DESCRIPTION
# Changes

* Update link from `0_proving_systems` to `0_submitting_proofs`