### PR TITLE
feat: check user balance against actual value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/**
 batcher/aligned/batch_inclusion_responses/*
 **/aligned_verification_data
 **/broadcast
+
+nonce_*.bin

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -45,7 +45,7 @@ mod zk_utils;
 
 const AGGREGATOR_COST: u128 = 400000;
 const BATCHER_SUBMISSION_BASE_COST: u128 = 100000;
-const ADDITIONAL_SUBMISSION_COST_PER_PROOF: u128 = 13000;
+const ADDITIONAL_SUBMISSION_COST_PER_PROOF: u128 = 13_000;
 const CONSTANT_COST: u128 = AGGREGATOR_COST + BATCHER_SUBMISSION_BASE_COST;
 const MIN_BALANCE_PER_PROOF: u128 = ADDITIONAL_SUBMISSION_COST_PER_PROOF * 100_000_000_000; // 100 Gwei = 0.0000001 ether (high gas price)
 
@@ -287,7 +287,7 @@ impl Batcher {
     // If user has sufficient balance, increments the user's proof count in the batch
     async fn check_user_balance(&self, addr: &Address) -> bool {
         let mut user_proof_counts = self.user_proof_count_in_batch.lock().await;
-        let user_proofs_in_batch = user_proof_counts.get(addr).unwrap_or(&0).clone();
+        let user_proofs_in_batch = user_proof_counts.get(addr).unwrap_or(&0).clone() + 1;
 
         let user_balance = self.get_user_balance(addr).await;
 
@@ -296,7 +296,7 @@ impl Batcher {
             return false;
         }
 
-        user_proof_counts.insert(*addr, user_proofs_in_batch + 1);
+        user_proof_counts.insert(*addr, user_proofs_in_batch);
         true
     }
 


### PR DESCRIPTION
Checks user balance is > a min value

Min value is 1_300_000_000_000_000 wei (or 0.0013 ether). Got this value by taking ~13k gas per proof and multiplying it by an upper bound 100 Gwei gas price.

# To test

First test normal flow with non paying address. 

Then you can test sending from aggregator keystore (which holds no balance)

```
cd batcher/aligned

cargo run --release -- submit \
                --proving_system Groth16Bn254 \
                --proof ../../scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.proof \
                --public_input ../../scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.pub \
                --vk ../../scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.vk \
                --repetitions 16 \
                --keystore_path ../../config-files/anvil.aggregator.ecdsa.key.json
```

It should fail 16 times with "Insufficient balance"

Then remove the local nonce file.

Then fund the address with 

```
cast send 0x7969c5eD335650692Bc04293B07F5BF2e7A673C0 --value 0.01ether --keystore ../../config-files/anvil.aggregator.ecdsa.key.json
```

Then try to submit proofs again (8th proof in batch should fail)