### PR TITLE
fix: download sp1 files from latest release instead of main

### DIFF
--- a/batcher/aligned/get_proof_test_files.sh
+++ b/batcher/aligned/get_proof_test_files.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-SP1_ELF_URL="https://raw.githubusercontent.com/yetanotherco/aligned_layer/main/scripts/test_files/sp1/sp1_fibonacci.elf"
-SP1_PROOF_URL="https://raw.githubusercontent.com/yetanotherco/aligned_layer/main/scripts/test_files/sp1/sp1_fibonacci.proof"
+CURRENT_TAG=$(curl -s -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/yetanotherco/aligned_layer/releases/latest \
+  | grep '"tag_name":' | awk -F'"' '{print $4}')
+
+SP1_ELF_URL="https://raw.githubusercontent.com/yetanotherco/aligned_layer/$CURRENT_TAG/scripts/test_files/sp1/sp1_fibonacci.elf"
+SP1_PROOF_URL="https://raw.githubusercontent.com/yetanotherco/aligned_layer/$CURRENT_TAG/scripts/test_files/sp1/sp1_fibonacci.proof"
 
 SP1_ELF_NAME="sp1_fibonacci.elf"
 SP1_PROOF_NAME="sp1_fibonacci.proof"
@@ -12,7 +18,7 @@ ALIGNED_TEST_FILES_DIR="$ALIGNED_DIR/test_files"
 
 mkdir -p "$ALIGNED_TEST_FILES_DIR"
 
-echo "Downloading SP1 ELF file..."
+echo "Downloading SP1 ELF file from $CURRENT_TAG release"
 
 if curl -sSf -L "$SP1_ELF_URL" -o "$ALIGNED_TEST_FILES_DIR/$SP1_ELF_NAME"; then
     echo "SP1 ELF download successful"

--- a/batcher/aligned/install_aligned.sh
+++ b/batcher/aligned/install_aligned.sh
@@ -28,7 +28,7 @@ fi
 
 mkdir -p "$ALIGNED_BIN_DIR"
 if curl -sSf -L "$RELEASE_URL$FILE" -o "$ALIGNED_BIN_PATH"; then
-    echo "Aligned download successful, installing..."
+    echo "Aligned download successful, installing $CURRENT_TAG release..."
 else
     echo "Error: Failed to download $RELEASE_URL$FILE"
     exit 1
@@ -69,6 +69,6 @@ if [[ ":$PATH:" != *":${ALIGNED_BIN_DIR}:"* ]]; then
     fi
 fi
 
-echo "Aligned installed successfully in $ALIGNED_BIN_PATH."
+echo "Aligned $CURRENT_TAG installed successfully in $ALIGNED_BIN_PATH."
 echo "Detected your preferred shell is $PREF_SHELL and added aligned to PATH."
 echo "Run 'source $PROFILE' or start a new terminal session to use aligned."


### PR DESCRIPTION
SP1 proofs were being downloaded from main latest commit, so when we update the SP1 version, but the system is running on the latest release, proofs are getting invalid

# How to test
1. `./batcher/aligned/get_proof_test_files.sh`
It should install v0.3.0
2. `./batcher/aligned/install_aligned.sh`
It should download files from v0.3.0
3. Send proof to aligned
```
rm -rf ~/.aligned/aligned_verification_data/ &&
aligned submit \
--proving_system SP1 \
--proof ~/.aligned/test_files/sp1_fibonacci.proof \
--vm_program ~/.aligned/test_files/sp1_fibonacci.elf \
--aligned_verification_data_path ~/.aligned/aligned_verification_data \
--conn wss://batcher.alignedlayer.com
```
It should work as usual

