### PR TITLE
fix: spawn blocking for verification

### DIFF
--- a/batcher/Cargo.lock
+++ b/batcher/Cargo.lock
@@ -110,7 +110,6 @@ dependencies = [
  "halo2curves",
  "hex",
  "lambdaworks-crypto",
- "lazy_static",
  "log",
  "risc0-zkvm",
  "serde",

--- a/batcher/aligned-batcher/Cargo.toml
+++ b/batcher/aligned-batcher/Cargo.toml
@@ -19,14 +19,16 @@ bytes = "1.6.0"
 hex = "0.4.3"
 dotenv = "0.15.0"
 anyhow = "1.0.83"
-ethers = { tag = "v2.0.15-fix-reconnections", features = ["ws", "rustls"], git = "https://github.com/yetanotherco/ethers-rs.git" }
+ethers = { tag = "v2.0.15-fix-reconnections", features = [
+    "ws",
+    "rustls",
+], git = "https://github.com/yetanotherco/ethers-rs.git" }
 lambdaworks-crypto = { version = "0.7.0", features = ["serde"] }
 serde_yaml = "0.9.34"
 sp1-sdk = { git = "https://github.com/succinctlabs/sp1.git", rev = "v1.0.1" }
-risc0-zkvm = { git = "https://github.com/risc0/risc0", tag="v1.0.1" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", tag = "v1.0.1" }
 halo2curves = { version = "0.6.0", default-features = false }
-halo2_backend = { git = "https://github.com/yetanotherco/yet-another-halo2-fork.git", rev = "a3a56819d9183ac0b11c8d0543c7673c4a4c71a6"}
-halo2_proofs = { git = "https://github.com/yetanotherco/yet-another-halo2-fork.git", rev = "a3a56819d9183ac0b11c8d0543c7673c4a4c71a6"}
-lazy_static = "1.4.0"
+halo2_backend = { git = "https://github.com/yetanotherco/yet-another-halo2-fork.git", rev = "a3a56819d9183ac0b11c8d0543c7673c4a4c71a6" }
+halo2_proofs = { git = "https://github.com/yetanotherco/yet-another-halo2-fork.git", rev = "a3a56819d9183ac0b11c8d0543c7673c4a4c71a6" }
 bincode = "1.3.3"
-aligned-sdk = { path = "../aligned-sdk"}
+aligned-sdk = { path = "../aligned-sdk" }

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -220,20 +220,7 @@ impl Batcher {
 
         match incoming
             .try_filter(|msg| future::ready(msg.is_text()))
-            .try_for_each(|msg| async {
-                let ws_conn_sink = outgoing.clone();
-                let batcher = self.clone();
-
-                tokio::spawn(async move {
-                    if let Err(e) = batcher.handle_message(msg, ws_conn_sink).await {
-                        error!("Error when handling message: {:?}", e);
-                    }
-                })
-                .await
-                .unwrap();
-
-                Ok(())
-            })
+            .try_for_each(|msg| self.clone().handle_message(msg, outgoing.clone()))
             .await
         {
             Err(e) => error!("Unexpected error: {}", e),

--- a/batcher/aligned-batcher/src/sp1/mod.rs
+++ b/batcher/aligned-batcher/src/sp1/mod.rs
@@ -6,7 +6,7 @@ static SP1_PROVER_CLIENT: OnceLock<ProverClient> = OnceLock::new();
 
 pub fn verify_sp1_proof(proof: &[u8], elf: &[u8]) -> bool {
     debug!("Verifying SP1 proof");
-    let prover_client = SP1_PROVER_CLIENT.get_or_init(|| ProverClient::new());
+    let prover_client = SP1_PROVER_CLIENT.get_or_init(ProverClient::new);
 
     let (_pk, vk) = prover_client.setup(elf);
     if let Ok(proof) = bincode::deserialize(proof) {

--- a/batcher/aligned-batcher/src/sp1/mod.rs
+++ b/batcher/aligned-batcher/src/sp1/mod.rs
@@ -1,16 +1,16 @@
-use lazy_static::lazy_static;
 use log::{debug, warn};
 use sp1_sdk::ProverClient;
+use std::sync::OnceLock;
 
-lazy_static! {
-    static ref SP1_PROVER_CLIENT: ProverClient = ProverClient::new();
-}
+static SP1_PROVER_CLIENT: OnceLock<ProverClient> = OnceLock::new();
 
 pub fn verify_sp1_proof(proof: &[u8], elf: &[u8]) -> bool {
     debug!("Verifying SP1 proof");
-    let (_pk, vk) = SP1_PROVER_CLIENT.setup(elf);
+    let prover_client = SP1_PROVER_CLIENT.get_or_init(|| ProverClient::new());
+
+    let (_pk, vk) = prover_client.setup(elf);
     if let Ok(proof) = bincode::deserialize(proof) {
-        let res = SP1_PROVER_CLIENT.verify(&proof, &vk).is_ok();
+        let res = prover_client.verify(&proof, &vk).is_ok();
         debug!("SP1 proof is valid: {}", res);
         if res {
             return true;

--- a/batcher/aligned-batcher/src/zk_utils/mod.rs
+++ b/batcher/aligned-batcher/src/zk_utils/mod.rs
@@ -6,7 +6,14 @@ use crate::sp1::verify_sp1_proof;
 use aligned_sdk::core::types::{ProvingSystemId, VerificationData};
 use log::{debug, warn};
 
-pub(crate) fn verify(verification_data: &VerificationData) -> bool {
+pub(crate) async fn verify(verification_data: &VerificationData) -> bool {
+    let verification_data = verification_data.clone();
+    tokio::task::spawn_blocking(move || verify_internal(&verification_data))
+        .await
+        .unwrap_or(false)
+}
+
+fn verify_internal(verification_data: &VerificationData) -> bool {
     match verification_data.proving_system {
         ProvingSystemId::SP1 => {
             if let Some(elf) = &verification_data.vm_program_code {


### PR DESCRIPTION
- Add spawn_blocking around zk_utils::verify 
- Remove lazy_static and replace with std::sync::OnceLock

# To test

Start everything normally

have one terminal running `make batcher_send_burst_groth16` with a .env file at batcher/aligned with the following content:

```
PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
```

Make sure to fund that key by running 
```
cast send 0x7969c5eD335650692Bc04293B07F5BF2e7A673C0 --interactive --value 1ether
```

Then send sp1 task with:

```
make batcher_send_sp1_task
```

Everything should work fine (this is the flow that failed in stage)