### PR TITLE
chore: fix errors when building operator dockerfile

### DIFF
--- a/operator/docker/operator.Dockerfile
+++ b/operator/docker/operator.Dockerfile
@@ -24,9 +24,10 @@ WORKDIR /usr/src/app
 # Copy the Makefile and the operator (for the FFI)
 COPY Makefile /usr/src/app
 COPY operator /usr/src/app/operator
+COPY batcher/aligned-sdk /usr/src/app/batcher/aligned-sdk
 
 # Build the FFI
-RUN make build_all_ffi_linux
+RUN RUSTUP_PERMIT_COPY_RENAME=1 make build_all_ffi_linux
 
 # Copy dependencies
 COPY go.mod go.sum ./
@@ -35,9 +36,6 @@ COPY contracts/script/output /usr/src/app/contracts/script/output
 COPY contracts/bindings /usr/src/app/contracts/bindings
 COPY core /usr/src/app/core
 COPY common /usr/src/app/common
-
-# Download dependencies
-RUN go mod download && go mod tidy && go mod verify
 
 # Build the operator
 RUN go build -v -o /usr/local/bin/operator /usr/src/app/operator/cmd/main.go

--- a/operator/docker/operator.Dockerfile.dockerignore
+++ b/operator/docker/operator.Dockerfile.dockerignore
@@ -6,6 +6,7 @@ prometheus
 explorer
 docs
 batcher
+!batcher/aligned-sdk
 aggregator
 task_sender
 .github


### PR DESCRIPTION
Hi, I'm an engineer at A41. We are operating node using Docker Compose, and I've applied some fixes due to an error when upgrading. Please review and feedback is welcome.

# Changes
1. Add `COPY batcher/aligned-sdk /usr/src/app/batcher/aligned-sdk` to avoid sdk not found error
2. Add `RUSTUP_PERMIT_COPY_RENAME=1` to avoid cross-device link error on docker context
3. Skip go dependency download & tidy to avoid `ambiguous import` error below:
```
13.03 	google.golang.org/grpc/status imports
13.03 	google.golang.org/genproto/googleapis/rpc/status: ambiguous import: found package google.golang.org/genproto/googleapis/rpc/status in multiple modules:
13.03 	google.golang.org/genproto v0.0.0-20230227214838-9b19f0bdc514 (/go/pkg/mod/google.golang.org/genproto@v0.0.0-20230227214838-9b19f0bdc514/googleapis/rpc/status)
13.03 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 (/go/pkg/mod/google.golang.org/genproto/googleapis/rpc@v0.0.0-20230711160842-782d3b101e98/status)
```