### PR TITLE
fix (operator): handle empty inputs

### DIFF
--- a/operator/risc_zero/risc_zero.go
+++ b/operator/risc_zero/risc_zero.go
@@ -12,8 +12,17 @@ import (
 )
 
 func VerifyRiscZeroReceipt(receiptBuffer []byte, receiptLen uint32, imageIdBuffer []byte, imageIdLen uint32, publicInput []byte, publicInputLen uint32) bool {
+	if len(receiptBuffer) == 0 || len(imageIdBuffer) == 0 {
+		return false
+	}
+
 	receiptPtr := (*C.uchar)(unsafe.Pointer(&receiptBuffer[0]))
 	imageIdPtr := (*C.uchar)(unsafe.Pointer(&imageIdBuffer[0]))
+
+	if len(publicInput) == 0 { // allow empty public input
+		return (bool)(C.verify_risc_zero_receipt_ffi(receiptPtr, (C.uint32_t)(receiptLen), imageIdPtr, (C.uint32_t)(imageIdLen), nil, (C.uint32_t)(0)))
+	}
+
 	publicInputPtr := (*C.uchar)(unsafe.Pointer(&publicInput[0]))
 	return (bool)(C.verify_risc_zero_receipt_ffi(receiptPtr, (C.uint32_t)(receiptLen), imageIdPtr, (C.uint32_t)(imageIdLen), publicInputPtr, (C.uint32_t)(publicInputLen)))
 }

--- a/operator/sp1/sp1.go
+++ b/operator/sp1/sp1.go
@@ -10,6 +10,10 @@ import "C"
 import "unsafe"
 
 func VerifySp1Proof(proofBuffer []byte, proofLen uint32, elfBuffer []byte, elfLen uint32) bool {
+	if len(proofBuffer) == 0 || len(elfBuffer) == 0 {
+		return false
+	}
+
 	proofPtr := (*C.uchar)(unsafe.Pointer(&proofBuffer[0]))
 	elfPtr := (*C.uchar)(unsafe.Pointer(&elfBuffer[0]))
 


### PR DESCRIPTION
Add checks for zero length inputs

In risc0 allow empty public input (its possible)

# To test

First start everything normally and send risc0 & sp1 proofs

Then to test empty public input in risc0 you can generate a proof with no public inputs by commenting
 this on host.rs
 
 ```
    // let vars: (u32, u32) = receipt.journal.decode().unwrap();

    // let (a, b) = vars;

    // println!("a: {}", a);
    // println!("b: {}", b);
```

And this in guest.rs
```
    // env::commit(&(a, b));
```
