### PR TITLE
ci: add workflow to deploy explorer to stage

### DIFF
--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -39,7 +39,7 @@ jobs:
           APP_DIR: ${{ vars.EXPLORER_DIRECTORY }}
           SERVICE_NAME: ${{ vars.SERVICE_NAME }}
         run: |
-          ssh -o "StrictHostKeyChecking=no" ${USER_NAME}@${HOST_NAME} "
+          ssh -o "StrictHostKeyChecking=no" ${USERNAME}@${HOST_NAME} "
             cd ${APP_DIR} &&
             echo 'Pulling latest changes' > test.txt
           "

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
         run:
-          echo "Current Branch: $GITHUB_REF"
+          echo "Current Branch: ${GITHUB_REF}"
 
       - name: Deploy to server
         env:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -21,6 +21,7 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
+          version: 1.70.0
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -38,9 +39,10 @@ jobs:
           APP_DIR: ${{ vars.EXPLORER_DIRECTORY }}
           SERVICE_NAME: ${{ vars.SERVICE_NAME }}
         run: |
-          ssh -o StrictHostKeyChecking=no ${USER_NAME}@${HOST_NAME} "
+          ssh -o "StrictHostKeyChecking=no" ${USER_NAME}@${HOST_NAME} "
             cd ${APP_DIR} &&
-            echo 'Pulling latest changes' > test.txt "
+            echo 'Pulling latest changes' > test.txt
+          "
 #        run: TODO uncomment this after testing connection
 #          ssh -o StrictHostKeyChecking=no ${USER_NAME}@${HOST_NAME} "
 #          cd ${APP_DIR} &&

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -26,8 +26,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Display Branch Name
+        env:
+          GITHUB_REF: ${{ github.ref }}
         run:
-          echo "Current Branch: ${{ github.ref }}"
+          echo "Current Branch: $GITHUB_REF"
 
       - name: Deploy to server
         env:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Display Branch Name
         env:
-          GITHUB_REF: ${{ github.ref }}
+          GITHUB_REF: ${{ github.ref_name }}
         run: |
           echo "Current Branch: ${GITHUB_REF}"
 

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Display Branch Name
         env:
           GITHUB_REF: ${{ github.ref }}
-        run:
+        run: |
           echo "Current Branch: ${GITHUB_REF}"
 
       - name: Deploy to server
@@ -37,7 +37,7 @@ jobs:
           USERNAME: ${{ vars.USERNAME }}
           APP_DIR: ${{ vars.EXPLORER_DIRECTORY }}
           SERVICE_NAME: ${{ vars.SERVICE_NAME }}
-        run:
+        run: |
           ssh -o StrictHostKeyChecking=no ${USER_NAME}@${HOST_NAME} "
             cd ${APP_DIR} &&
             echo 'Pulling latest changes' > test.txt "

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Display Branch Name
         env:
-          GITHUB_REF: ${{ github.ref_name }}
+          REF: ${{ github.ref_name }}
         run: |
-          echo "Current Branch: ${GITHUB_REF}"
+          echo "Current Branch: ${REF}"
 
       - name: Deploy to server
         env:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -38,15 +38,12 @@ jobs:
           USERNAME: ${{ vars.USERNAME }}
           APP_DIR: ${{ vars.EXPLORER_DIRECTORY }}
           SERVICE_NAME: ${{ vars.SERVICE_NAME }}
+          REF: ${{ github.ref_name }}
         run: |
           ssh -o "StrictHostKeyChecking=no" ${USERNAME}@${HOST_NAME} "
             cd ${APP_DIR} &&
-            echo 'Pulling latest changes' > test.txt
+            git fetch &&
+            git checkout ${REF} &&
+            git pull &&
+            sudo systemctl restart ${SERVICE_NAME}
           "
-#        run: TODO uncomment this after testing connection
-#          ssh -o StrictHostKeyChecking=no ${USER_NAME}@${HOST_NAME} "
-#          cd ${APP_DIR} &&
-#          git fetch &&
-#          git checkout ${{ github.ref }} &&
-#          git pull &&
-#          sudo systemctl restart ${SERVICE_NAME} "


### PR DESCRIPTION
# How to Deploy Explorer to Stage
1. Select the `Deploy Explorer` workflow in `Actions` tab.
2. Choose the branch and environment you want to deploy
<img width="325" alt="image" src="https://github.com/user-attachments/assets/3b352b71-12d7-463e-b383-cbf2d1c46cde">

| For now there is only Stage environment. Adding new environment is very simple, just config, not coding