### PR TITLE
fix: add 0x to the logs of the merkle roots

### DIFF
--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -249,11 +249,11 @@ func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsA
 	agg.taskMutex.Unlock()
 
 	agg.logger.Info("Threshold reached", "taskIndex", blsAggServiceResp.TaskIndex,
-		"merkleRoot", hex.EncodeToString(batchMerkleRoot[:]))
+		"merkleRoot", "0x"+hex.EncodeToString(batchMerkleRoot[:]))
 
 	agg.logger.Info("Maybe waiting one block to send aggregated response onchain",
 		"taskIndex", blsAggServiceResp.TaskIndex,
-		"merkleRoot", hex.EncodeToString(batchMerkleRoot[:]),
+		"merkleRoot", "0x"+hex.EncodeToString(batchMerkleRoot[:]),
 		"taskCreatedBlock", taskCreatedBlock)
 
 	err := agg.avsSubscriber.WaitForOneBlock(taskCreatedBlock)
@@ -262,14 +262,14 @@ func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsA
 	}
 
 	agg.logger.Info("Sending aggregated response onchain", "taskIndex", blsAggServiceResp.TaskIndex,
-		"merkleRoot", hex.EncodeToString(batchMerkleRoot[:]))
+		"merkleRoot", "0x"+hex.EncodeToString(batchMerkleRoot[:]))
 
 	for i := 0; i < MaxSentTxRetries; i++ {
 		_, err = agg.sendAggregatedResponse(batchMerkleRoot, nonSignerStakesAndSignature)
 		if err == nil {
 			agg.logger.Info("Aggregator successfully responded to task",
 				"taskIndex", blsAggServiceResp.TaskIndex,
-				"merkleRoot", hex.EncodeToString(batchMerkleRoot[:]))
+				"merkleRoot", "0x"+hex.EncodeToString(batchMerkleRoot[:]))
 
 			return
 		}
@@ -281,7 +281,7 @@ func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsA
 	agg.logger.Error("Aggregator failed to respond to task, this batch will be lost",
 		"err", err,
 		"taskIndex", blsAggServiceResp.TaskIndex,
-		"merkleRoot", hex.EncodeToString(batchMerkleRoot[:]))
+		"merkleRoot", "0x"+hex.EncodeToString(batchMerkleRoot[:]))
 }
 
 // / Sends response to contract and waits for transaction receipt
@@ -313,7 +313,7 @@ func (agg *Aggregator) sendAggregatedResponse(batchMerkleRoot [32]byte, nonSigne
 
 func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, taskCreatedBlock uint32) {
 	agg.AggregatorConfig.BaseConfig.Logger.Info("Adding new task",
-		"Batch merkle root", hex.EncodeToString(batchMerkleRoot[:]))
+		"Batch merkle root", "0x"+hex.EncodeToString(batchMerkleRoot[:]))
 
 	agg.taskMutex.Lock()
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Adding new task")
@@ -351,5 +351,5 @@ func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, taskCreatedBlock uin
 
 	agg.taskMutex.Unlock()
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Adding new task")
-	agg.logger.Info("New task added", "batchIndex", batchIndex, "batchMerkleRoot", hex.EncodeToString(batchMerkleRoot[:]))
+	agg.logger.Info("New task added", "batchIndex", batchIndex, "batchMerkleRoot", "0x"+hex.EncodeToString(batchMerkleRoot[:]))
 }

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -50,7 +50,7 @@ func (agg *Aggregator) ServeOperators() error {
 //   - 1: Error
 func (agg *Aggregator) ProcessOperatorSignedTaskResponse(signedTaskResponse *types.SignedTaskResponse, reply *uint8) error {
 	agg.AggregatorConfig.BaseConfig.Logger.Info("New task response",
-		"merkleRoot", hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),
+		"merkleRoot", "0x"+hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),
 		"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
 
 	taskIndex := uint32(0)

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -607,7 +607,7 @@ impl Batcher {
     ) -> Result<(), BatcherError> {
         let s3_client = self.s3_client.clone();
         let batch_merkle_root_hex = hex::encode(batch_merkle_root);
-        info!("Batch merkle root: {}", batch_merkle_root_hex);
+        info!("Batch merkle root: 0x{}", batch_merkle_root_hex);
         let file_name = batch_merkle_root_hex.clone() + ".json";
 
         info!("Uploading batch to S3...");
@@ -684,7 +684,7 @@ impl Batcher {
             gas_per_proof,
         );
 
-        info!("Creating task for: {}", hex::encode(batch_merkle_root));
+        info!("Creating task for: 0x{}", hex::encode(batch_merkle_root));
 
         let pending_tx = call
             .send()

--- a/core/chainio/avs_subscriber.go
+++ b/core/chainio/avs_subscriber.go
@@ -80,7 +80,7 @@ func (s *AvsSubscriber) SubscribeToNewTasks(newTaskCreatedChan chan *servicemana
 		batchesSet := make(map[[32]byte]struct{})
 		for {
 			newBatch := <-internalChannel
-			s.logger.Info("Received new task", "batchMerkleRoot", hex.EncodeToString(newBatch.BatchMerkleRoot[:]))
+			s.logger.Info("Received new task", "batchMerkleRoot", "0x"+hex.EncodeToString(newBatch.BatchMerkleRoot[:]))
 			newBatchMutex.Lock()
 
 			if _, ok := batchesSet[newBatch.BatchMerkleRoot]; !ok {

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"sync"
@@ -173,7 +174,7 @@ func (o *Operator) Start(ctx context.Context) error {
 func (o *Operator) ProcessNewBatchLog(newBatchLog *servicemanager.ContractAlignedLayerServiceManagerNewBatch) error {
 
 	o.Logger.Info("Received new batch with proofs to verify",
-		"batch merkle root", newBatchLog.BatchMerkleRoot,
+		"batch merkle root", "0x"+hex.EncodeToString(newBatchLog.BatchMerkleRoot[:]),
 	)
 
 	verificationDataBatch, err := o.getBatchFromS3(newBatchLog.BatchDataPointer, newBatchLog.BatchMerkleRoot)


### PR DESCRIPTION
# Description

- This PR adds missing `0x` from the logs of the merkle roots.

# To Test

- Run everything as usual, check the logs of the merkle roots have the `0x` prefix.