### PR TITLE
fix: get user balance method

### DIFF
--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -684,7 +684,7 @@ pub async fn get_user_balance(
     contract_address: Address,
     user_address: Address,
 ) -> Result<U256, ProviderError> {
-    let selector = &ethers::utils::keccak256("UserData(address)".as_bytes())[..4];
+    let selector = &ethers::utils::keccak256("user_balances(address)".as_bytes())[..4];
 
     let encoded_params = ethers::abi::encode(&[ethers::abi::Token::Address(user_address)]);
 
@@ -699,9 +699,8 @@ pub async fn get_user_balance(
 
     let result = provider.call_raw(&tx).await?;
 
-    // 3 * 32 bytes (one for each U256) because UserInfo has U256 balance, U256 unlockBlock and U256 nonce.
-    if result.len() == 96 {
-        let balance = U256::from_big_endian(&result[..32]);
+    if result.len() == 32 {
+        let balance = U256::from_big_endian(&result);
         Ok(balance)
     } else {
         Err(ProviderError::CustomError(

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -684,7 +684,7 @@ pub async fn get_user_balance(
     contract_address: Address,
     user_address: Address,
 ) -> Result<U256, ProviderError> {
-    let selector = &ethers::utils::keccak256("UserBalances(address)".as_bytes())[..4];
+    let selector = &ethers::utils::keccak256("UserData(address)".as_bytes())[..4];
 
     let encoded_params = ethers::abi::encode(&[ethers::abi::Token::Address(user_address)]);
 
@@ -699,8 +699,9 @@ pub async fn get_user_balance(
 
     let result = provider.call_raw(&tx).await?;
 
-    if result.len() == 32 {
-        let balance = U256::from_big_endian(&result);
+    // 3 * 32 bytes (one for each U256) because UserInfo has U256 balance, U256 unlockBlock and U256 nonce.
+    if result.len() == 96 {
+        let balance = U256::from_big_endian(&result[..32]);
         Ok(balance)
     } else {
         Err(ProviderError::CustomError(


### PR DESCRIPTION
# Description

- This PR updates the get user balance method to the new `user_balances` map in the batcher contract.

# To Test

- Run:
```
aligned deposit-to-batcher --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 --rpc https://ethereum-holesky-rpc.publicnode.com --chain holesky --keystore_path <keystore_path> --amount 0.1ether
```
- Then:
```
aligned get-user-balance --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 --rpc https://ethereum-holesky-rpc.publicnode.com --user_addr <user_addr>
```
You should see:
```
User <user_addr> has 0.100000000000000000 ether in the batcher
```