### PR TITLE
refactor(sdk): replace result option with result in function return values

### DIFF
--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -313,30 +313,26 @@ async fn main() -> Result<(), AlignedError> {
                     }
                 };
 
-            if let Some(aligned_verification_data_vec) = aligned_verification_data_vec {
-                let mut unique_batch_merkle_roots = HashSet::new();
+            let mut unique_batch_merkle_roots = HashSet::new();
 
-                for aligned_verification_data in aligned_verification_data_vec {
-                    save_response(
-                        batch_inclusion_data_directory_path.clone(),
-                        &aligned_verification_data,
-                    )?;
-                    unique_batch_merkle_roots.insert(aligned_verification_data.batch_merkle_root);
-                }
+            for aligned_verification_data in aligned_verification_data_vec {
+                save_response(
+                    batch_inclusion_data_directory_path.clone(),
+                    &aligned_verification_data,
+                )?;
+                unique_batch_merkle_roots.insert(aligned_verification_data.batch_merkle_root);
+            }
 
-                match unique_batch_merkle_roots.len() {
-                    1 => info!("Proofs submitted to aligned. See the batch in the explorer:"),
-                    _ => info!("Proofs submitted to aligned. See the batches in the explorer:"),
-                }
+            match unique_batch_merkle_roots.len() {
+                1 => info!("Proofs submitted to aligned. See the batch in the explorer:"),
+                _ => info!("Proofs submitted to aligned. See the batches in the explorer:"),
+            }
 
-                for batch_merkle_root in unique_batch_merkle_roots {
-                    info!(
-                        "https://explorer.alignedlayer.com/batches/0x{}",
-                        hex::encode(batch_merkle_root)
-                    );
-                }
-            } else {
-                error!("No batch inclusion data was received from the batcher");
+            for batch_merkle_root in unique_batch_merkle_roots {
+                info!(
+                    "https://explorer.alignedlayer.com/batches/0x{}",
+                    hex::encode(batch_merkle_root)
+                );
             }
         }
 

--- a/docs/guides/1_SDK.md
+++ b/docs/guides/1_SDK.md
@@ -31,7 +31,7 @@ pub async fn submit(
     verification_data: &VerificationData,
     wallet: Wallet<SigningKey>,
     nonce: U256,
-) -> Result<Option<AlignedVerificationData>, errors::SubmitError>
+) -> Result<AlignedVerificationData, errors::SubmitError>
 ```
 
 #### Arguments
@@ -43,7 +43,7 @@ pub async fn submit(
 
 #### Returns
 
-- `Result<Option<AlignedVerificationData>>, SubmitError>` - An aligned verification data or an error.
+- `Result<AlignedVerificationData, SubmitError>` - An aligned verification data or an error.
 
 #### Errors
 
@@ -71,7 +71,7 @@ pub async fn submit_multiple(
     verification_data: &[VerificationData],
     wallet: Wallet<SigningKey>,
     nonce: U256,
-) -> Result<Option<Vec<AlignedVerificationData>>, errors::SubmitError>
+) -> Result<Vec<AlignedVerificationData>, errors::SubmitError>
 ```
 
 #### Arguments
@@ -83,7 +83,7 @@ pub async fn submit_multiple(
 
 #### Returns
 
-- `Result<Option<Vec<AlignedVerificationData>>>, SubmitError>` - An aligned verification data array or an error.
+- `Result<Vec<AlignedVerificationData>, SubmitError>` - An aligned verification data array or an error.
 
 #### Errors
 
@@ -114,7 +114,7 @@ pub async fn submit_and_wait(
     verification_data: &VerificationData,
     wallet: Wallet<SigningKey>,
     nonce: U256,
-) -> Result<Option<AlignedVerificationData>, errors::SubmitError>
+) -> Result<AlignedVerificationData, errors::SubmitError>
 ```
 
 #### Arguments
@@ -128,7 +128,7 @@ pub async fn submit_and_wait(
 
 #### Returns
 
-- `Result<Option<AlignedVerificationData>>, SubmitError>` - An aligned verification data or an error.
+- `Result<AlignedVerificationData, SubmitError>` - An aligned verification data or an error.
 
 #### Errors
 
@@ -162,7 +162,7 @@ pub async fn submit_multiple_and_wait(
     verification_data: &[VerificationData],
     wallet: Wallet<SigningKey>,
     nonce: U256,
-) -> Result<Option<Vec<AlignedVerificationData>>, errors::SubmitError>
+) -> Result<Vec<AlignedVerificationData>, errors::SubmitError>
 ```
 
 #### Arguments
@@ -176,7 +176,7 @@ pub async fn submit_multiple_and_wait(
 
 #### Returns
 
-- `Result<Option<Vec<AlignedVerificationData>>>, SubmitError>` - An aligned verification data array or an error.
+- `Result<Vec<AlignedVerificationData>, SubmitError>` - An aligned verification data array or an error.
 
 #### Errors
 


### PR DESCRIPTION
> [!WARNING] 
> This will break the projects using the SDK if they don't have the version pinned.

# Description

- The SDK returned Result<Option<>> in most of its methods when it wasn't needed, now it just returns Result<>.

# To Test

- Run everything as usual and make sure it is working.