### PR TITLE
fix: do not require env file on batcher_start_local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ batcher_start: ./batcher/aligned-batcher/.env user_fund_payment_service
 	@echo "Starting Batcher..."
 	@cargo +nightly-2024-04-17 run --manifest-path ./batcher/aligned-batcher/Cargo.toml --release -- --config ./config-files/config-batcher.yaml --env-file ./batcher/aligned-batcher/.env
 
-batcher_start_local: ./batcher/aligned-batcher/.env user_fund_payment_service
+batcher_start_local: user_fund_payment_service
 	@echo "Starting Batcher..."
 	@$(MAKE) run_storage &
 	@cargo +nightly-2024-04-17 run --manifest-path ./batcher/aligned-batcher/Cargo.toml --release -- --config ./config-files/config-batcher.yaml --env-file ./batcher/aligned-batcher/.env.dev


### PR DESCRIPTION
# How to test
1. Run `make anvil_start_with_block_time`
2. Run `make batcher_start_local` without having a .env file. It should start as expected