### PR TITLE
feat: add context timeout to avoid dos

### DIFF
--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -55,6 +55,10 @@ type Operator struct {
 	//Timeout time.Duration
 }
 
+const (
+	BatchDownloadTimeout = 1 * time.Minute
+)
+
 func NewOperatorFromConfig(configuration config.OperatorConfig) (*Operator, error) {
 	logger := configuration.BaseConfig.Logger
 
@@ -177,7 +181,10 @@ func (o *Operator) ProcessNewBatchLog(newBatchLog *servicemanager.ContractAligne
 		"batch merkle root", "0x"+hex.EncodeToString(newBatchLog.BatchMerkleRoot[:]),
 	)
 
-	verificationDataBatch, err := o.getBatchFromS3(newBatchLog.BatchDataPointer, newBatchLog.BatchMerkleRoot)
+	ctx, cancel := context.WithTimeout(context.Background(), BatchDownloadTimeout)
+	defer cancel()
+
+	verificationDataBatch, err := o.getBatchFromS3(ctx, newBatchLog.BatchDataPointer, newBatchLog.BatchMerkleRoot)
 	if err != nil {
 		o.Logger.Errorf("Could not get proofs from S3 bucket: %v", err)
 		return err

--- a/operator/pkg/s3.go
+++ b/operator/pkg/s3.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,12 +10,25 @@ import (
 	"github.com/yetanotherco/aligned_layer/operator/merkle_tree"
 )
 
-func (o *Operator) getBatchFromS3(batchURL string, expectedMerkleRoot [32]byte) ([]VerificationData, error) {
+func (o *Operator) getBatchFromS3(ctx context.Context, batchURL string, expectedMerkleRoot [32]byte) ([]VerificationData, error) {
 	o.Logger.Infof("Getting batch from S3..., batchURL: %s", batchURL)
-	resp, err := http.Head(batchURL)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", batchURL, nil)
+
 	if err != nil {
 		return nil, err
 	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			fmt.Println("error closing body: ", err)
+		}
+	}(resp.Body)
 
 	// Check if the response is OK
 	if resp.StatusCode != http.StatusOK {
@@ -26,17 +40,6 @@ func (o *Operator) getBatchFromS3(batchURL string, expectedMerkleRoot [32]byte) 
 		return nil, fmt.Errorf("proof size %d exceeds max batch size %d",
 			contentLength, o.Config.Operator.MaxBatchSize)
 	}
-
-	resp, err = http.Get(batchURL)
-	if err != nil {
-		return nil, err
-	}
-	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-			fmt.Println("error closing body: ", err)
-		}
-	}(resp.Body)
 
 	// Use io.LimitReader to limit the size of the response body
 	// This is to prevent the operator from downloading a larger than expected file


### PR DESCRIPTION
# Description

- This PR adds a timeout to the `getBatchFromS3` function in order to avoid DoS from a malicious server.

# To Test

- Make sure everything is working as usual.
- To test the timeout, in `operator.go` change the `BatchDownloadTimeout` constant to `BatchDownloadTimeout = 1 * time.Millisecond`. You should see an error like so:
```
ERROR (pkg/operator.go:189) Could not get proofs from S3 bucket: Get "http://localhost:4566/aligned.storage/c8eba46fe76b26356f6edb2c66badd4b94e1daa3871aed90ce73d3dcb0a2289b.json": context deadline exceeded
```
But the operator will continue to work normally.