### PR TITLE
docs: add halo2 to supported verifiers list with example

### DIFF
--- a/docs/guides/0_submitting_proofs.md
+++ b/docs/guides/0_submitting_proofs.md
@@ -66,8 +66,8 @@ To use it, you can use the `aligned` CLI, as shown with the following example:
 
 ```bash
 aligned deposit-to-batcher \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
+--rpc https://ethereum-holesky-rpc.publicnode.com \
 --chain holesky \
 --keystore_path <keystore_path> \
 --amount 0.1ether
@@ -75,8 +75,8 @@ aligned deposit-to-batcher \
 
 These commands allow the usage of the following flags:
 
-- `--payment_service_addr` to specify the address of the Batcher Payment Service smart contract.
-- `--rpc_url` to specify the rpc url to be used.
+- `--batcher_addr` to specify the address of the Batcher Payment Service smart contract.
+- `--rpc` to specify the rpc url to be used.
 - `--chain` to specify the chain id to be used. Could be holesky or devnet.
 - `--keystore_path` the path to the keystore.
 - `--amount` the number of ethers to transfer to the Batcher.
@@ -86,15 +86,15 @@ After depositing funds, you can verify the Service has correctly received them b
 
 ```bash
 aligned get-user-balance \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
+--rpc https://ethereum-holesky-rpc.publicnode.com \
 --user_addr <user_addr>
 ```
 
 These commands allow the usage of the following flags:
 
-- `--payment_service_addr` to specify the address of the Batcher Payment Service smart contract.
-- `--rpc_url` to specify the rpc url to be used.
+- `--batcher_addr` to specify the address of the Batcher Payment Service smart contract.
+- `--rpc` to specify the rpc url to be used.
 - `--user_addr` the address of the user that funded the Batcher.
 
 ## 3. Submit your proof to the batcher
@@ -125,12 +125,12 @@ aligned submit \
 --proving_system SP1 \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
---batcher_url wss://batcher.alignedlayer.com \
+--conn wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 **Example**
@@ -141,10 +141,10 @@ aligned submit \
 --proving_system SP1 \
 --proof ./scripts/test_files/sp1/sp1_fibonacci.proof \
 --vm_program ./scripts/test_files/sp1/sp1_fibonacci.elf \
---batcher_url wss://batcher.alignedlayer.com \
+--conn wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ### Risc0 proof
@@ -160,12 +160,12 @@ aligned submit \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
 --pub_input <pub_input_file> \
---batcher_url wss://batcher.alignedlayer.com \
+--conn wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 **Example**
@@ -177,11 +177,10 @@ aligned submit \
 --proof ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.proof \
 --vm_program ./scripts/test_files/risc_zero/fibonacci_proof_generator/fibonacci_id.bin \
 --public_input ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.pub \
---batcher_url wss://batcher.alignedlayer.com \
 --aligned_verification_data_path ~/.aligned/aligned_verification_data \
 --keystore_path ~/.aligned_keystore/keystore0 \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ### GnarkPlonkBn254, GnarkPlonkBls12_381 and Groth16Bn254
@@ -195,12 +194,12 @@ aligned submit \
 --proof <proof_file> \
 --public_input <public_input_file> \
 --vk <verification_key_file> \
---batcher_url wss://batcher.alignedlayer.com \
+--conn wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 **Examples**:
@@ -212,10 +211,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_plonk_bn254_script/plonk.proof \
 --public_input ./scripts/test_files/gnark_plonk_bn254_script/plonk_pub_input.pub \
 --vk ./scripts/test_files/gnark_plonk_bn254_script/plonk.vk \
---batcher_url wss://batcher.alignedlayer.com \
+--conn wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
 --eth_rpc_url https://ethereum-holesky-rpc.publicnode.com \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ```bash
@@ -225,10 +224,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_plonk_bls12_381_script/plonk.proof \
 --public_input ./scripts/test_files/gnark_plonk_bls12_381_script/plonk_pub_input.pub \
 --vk ./scripts/test_files/gnark_plonk_bls12_381_script/plonk.vk \
---batcher_url wss://batcher.alignedlayer.com \
+--conn wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ```bash
@@ -238,11 +237,12 @@ aligned submit \
 --proof ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.proof \
 --public_input ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.pub \
 --vk ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.vk \
---batcher_url wss://batcher.alignedlayer.com \
+--conn wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc https://ethereum-holesky-rpc.publicnode.com \
+--batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
+
 ### Halo2 KZG and Halo2 IPA
 
 The Halo2PlonkKzg and Halo2PlonkIpa proofs need the proof file, the public input file and the verification key file.
@@ -257,10 +257,10 @@ aligned submit \
   --vk <method_id_file_path> \
   --public_input <pub_input_file_path> \
   --conn wss://batcher.alignedlayer.com \
+  --keystore_path <path_to_ecdsa_keystore> \
   --proof_generator_addr <proof_generator_addr> \
   --rpc https://ethereum-holesky-rpc.publicnode.com \
   --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
-  --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 If you are using the Halo2PlonkIpa proving system, you need to specify the `--proving_system Halo2IPA` flag.
@@ -273,6 +273,7 @@ aligned submit \
   --vk <method_id_file_path> \
   --public_input <pub_input_file_path> \
   --conn wss://batcher.alignedlayer.com \
+  --keystore_path <path_to_ecdsa_keystore> \
   --proof_generator_addr <proof_generator_addr> \
   --rpc https://ethereum-holesky-rpc.publicnode.com \
   --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
@@ -288,6 +289,7 @@ aligned submit \
   --vk ./scripts/test_files/halo2_kzg/params.bin \
   --public_input ./scripts/test_files/halo2_kzg/pub_input.bin \
   --conn wss://batcher.alignedlayer.com \
+  --keystore_path ~/.aligned_keystore/keystore0 \
   --proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
   --rpc https://ethereum-holesky-rpc.publicnode.com \
   --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
@@ -301,6 +303,7 @@ aligned submit \
   --vk ./scripts/test_files/halo2_ipa/params.bin \
   --public_input ./scripts/test_files/halo2_ipa/pub_input.bin \
   --conn wss://batcher.alignedlayer.com \
+  --keystore_path ~/.aligned_keystore/keystore0 \
   --proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
   --rpc https://ethereum-holesky-rpc.publicnode.com \
   --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003

--- a/docs/guides/0_submitting_proofs.md
+++ b/docs/guides/0_submitting_proofs.md
@@ -177,6 +177,7 @@ aligned submit \
 --proof ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.proof \
 --vm_program ./scripts/test_files/risc_zero/fibonacci_proof_generator/fibonacci_id.bin \
 --public_input ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.pub \
+--batcher_url wss://batcher.alignedlayer.com \
 --aligned_verification_data_path ~/.aligned/aligned_verification_data \
 --keystore_path ~/.aligned_keystore/keystore0 \
 --rpc_url https://ethereum-holesky-rpc.publicnode.com \

--- a/docs/guides/0_submitting_proofs.md
+++ b/docs/guides/0_submitting_proofs.md
@@ -12,12 +12,10 @@ The following is the list of the verifiers currently supported by Aligned:
 - :white_check_mark: gnark - Plonk (with BN254 and BLS12-381)
 - :white_check_mark: SP1 [(v1.0.1)](https://github.com/succinctlabs/sp1/releases/tag/v1.0.1)
 - :white_check_mark: Risc0 [(v1.0.1)](https://github.com/risc0/risc0/releases/tag/v1.0.1)
+- :white_check_mark: Halo2 - Plonk/KZG
+- :white_check_mark: Halo2 - Plonk/IPA
 
-The following proof systems are going to be added soon:
-
-- :black_square_button: Kimchi
-- :black_square_button: Halo2 - Plonk/KZG
-- :black_square_button: Halo2 - Plonk/IPA
+Learn more about future verifiers [here](../architecture/0_supported_verifiers.md).
 
 ## 1. Import/Create Keystore file
 
@@ -33,7 +31,7 @@ You need to have installed [Foundry](https://book.getfoundry.sh/getting-started/
     cast wallet new-mnemonic --words 12
     ```
 
-    It will show you a new mnemonic phrase, and a public-private key pair, similar to the following example:
+    It will show you a new mnemonic phrase and a public-private key pair, similar to the following example:
 
     ```
     Phrase:
@@ -58,13 +56,13 @@ This will create the ECDSA keystore file in `~/.aligned_keystore/keystore0`
 
 ### Alternative 2: With EigenLayer CLI
 
-- If you have the EigenLayer CLI installed, the keystore can be generated following [this](https://docs.eigenlayer.xyz/eigenlayer/operator-guides/operator-installation#import-keys) instructions. The key will be stored into `~/.eigenlayer/operator_keys`.
+- If you have the EigenLayer CLI installed, the keystore can be generated following [these](https://docs.eigenlayer.xyz/eigenlayer/operator-guides/operator-installation#import-keys) instructions. The key will be stored into `~/.eigenlayer/operator_keys`.
 
 ## 2. Fund the batcher
 
 To be able to send proofs to Aligned using the Batcher, the user must fund its transactions. For this, there is a simple Batcher Payment System.
 
-To use it you can use the `aligned` CLI, as shown with the following example:
+To use it, you can use the `aligned` CLI, as shown with the following example:
 
 ```bash
 aligned deposit-to-batcher \
@@ -75,13 +73,13 @@ aligned deposit-to-batcher \
 --amount 0.1ether
 ```
 
-These commands allows the usage of the following flags:
+These commands allow the usage of the following flags:
 
 - `--payment_service_addr` to specify the address of the Batcher Payment Service smart contract.
 - `--rpc_url` to specify the rpc url to be used.
 - `--chain` to specify the chain id to be used. Could be holesky or devnet.
 - `--keystore_path` the path to the keystore.
-- `--amount` the amount of ethers to transfer to the Batcher.
+- `--amount` the number of ethers to transfer to the Batcher.
 - Note: `--amount` flag parameter must be with the shown format. The amount followed by the `ether` keyword to specify how many ethers you wish to deposit to the Batcher.
 
 After depositing funds, you can verify the Service has correctly received them by executing the following command:
@@ -93,7 +91,7 @@ aligned get-user-balance \
 --user_addr <user_addr>
 ```
 
-These commands allows the usage of the following flags:
+These commands allow the usage of the following flags:
 
 - `--payment_service_addr` to specify the address of the Batcher Payment Service smart contract.
 - `--rpc_url` to specify the rpc url to be used.
@@ -111,7 +109,7 @@ Proof submission is done via the `submit` command of the Aligned CLI. The argume
 * `conn`: The batcher websocket URL.
 * `rpc`: The RPC Ethereum node URL.
 * `batcher_addr`: The Ethereum address of the Batcher Payments System contract.
-* `proof_generator_addr`: An optional parameter that can be used in some applications to avoid frontrunning.
+* `proof_generator_addr`: An optional parameter that can be used in some applications to avoid front-running.
 * `batch_inclusion_data_directory_path`: An optional parameter indicating the directory where to store the batcher response data. If not provided, the folder with the responses will be created in the current directory.
 
 ### SP1 proof
@@ -244,3 +242,61 @@ aligned submit \
 --rpc_url https://ethereum-holesky-rpc.publicnode.com \
 --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
+### Halo2 KZG and Halo2 IPA
+
+The Halo2PlonkKzg and Halo2PlonkIpa proofs need the proof file, the public input file and the verification key file.
+
+If you are using the Halo2PlonkKzg proving system, you need to specify the `--proving_system Halo2KZG` flag.
+
+```bash
+aligned submit \
+  --proving_system Halo2KZG \
+  --proof <proof_file_path> \
+  --vk <method_id_file_path> \
+  --public_input <pub_input_file_path> \
+  --conn wss://batcher.alignedlayer.com \
+  --proof_generator_addr <proof_generator_addr> \
+  --rpc https://ethereum-holesky-rpc.publicnode.com \
+  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+```
+
+If you are using the Halo2PlonkIpa proving system, you need to specify the `--proving_system Halo2IPA` flag.
+
+```bash
+aligned submit \
+  --proving_system Halo2IPA \
+  --proof <proof_file_path> \
+  --vk <method_id_file_path> \
+  --public_input <pub_input_file_path> \
+  --conn wss://batcher.alignedlayer.com \
+  --proof_generator_addr <proof_generator_addr> \
+  --rpc https://ethereum-holesky-rpc.publicnode.com \
+  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+```
+
+**Examples**:
+
+```bash
+aligned submit \
+  --proving_system Halo2KZG \
+  --proof ./scripts/test_files/halo2_kzg/proof.bin \
+  --vk ./scripts/test_files/halo2_kzg/params.bin \
+  --public_input ./scripts/test_files/halo2_kzg/pub_input.bin \
+  --conn wss://batcher.alignedlayer.com \
+  --proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
+  --rpc https://ethereum-holesky-rpc.publicnode.com \
+  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+```
+
+```bash
+aligned submit \
+  --proving_system Halo2IPA \
+  --proof ./scripts/test_files/halo2_ipa/proof.bin \
+  --vk ./scripts/test_files/halo2_ipa/params.bin \
+  --public_input ./scripts/test_files/halo2_ipa/pub_input.bin \
+  --conn wss://batcher.alignedlayer.com \
+  --proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
+  --rpc https://ethereum-holesky-rpc.publicnode.com \
+  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+```
+

--- a/docs/guides/0_submitting_proofs.md
+++ b/docs/guides/0_submitting_proofs.md
@@ -101,7 +101,8 @@ These commands allow the usage of the following flags:
 
 This guide will focus on how to submit proofs using the Aligned CLI. To integrate the proof submission process into your application, check the [Aligned SDK guide](../guides/1_SDK.md).
 
-Proof submission is done via the `submit` command of the Aligned CLI. The arguments for the submit command are
+Proof submission is done via the `submit` command of the Aligned CLI. The arguments for the submit command are:
+
 * `proving_system`: The proving system corresponding to the proof you want to submit.
 * `proof`: The path of the proof associated to the computation to be verified.
 * `vm_program`: When the proving system involves the execution of a program in a zkVM, this argument is associated with the compiled program or some other identifier of the program. 
@@ -249,6 +250,7 @@ The Halo2PlonkKzg and Halo2PlonkIpa proofs need the proof file, the public input
 If you are using the Halo2PlonkKzg proving system, you need to specify the `--proving_system Halo2KZG` flag.
 
 ```bash
+rm -rf ./aligned_verification_data/ &&
 aligned submit \
   --proving_system Halo2KZG \
   --proof <proof_file_path> \
@@ -257,12 +259,14 @@ aligned submit \
   --conn wss://batcher.alignedlayer.com \
   --proof_generator_addr <proof_generator_addr> \
   --rpc https://ethereum-holesky-rpc.publicnode.com \
-  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
+  --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 If you are using the Halo2PlonkIpa proving system, you need to specify the `--proving_system Halo2IPA` flag.
 
 ```bash
+rm -rf ./aligned_verification_data/ &&
 aligned submit \
   --proving_system Halo2IPA \
   --proof <proof_file_path> \
@@ -277,6 +281,7 @@ aligned submit \
 **Examples**:
 
 ```bash
+rm -rf ./aligned_verification_data/ &&
 aligned submit \
   --proving_system Halo2KZG \
   --proof ./scripts/test_files/halo2_kzg/proof.bin \
@@ -289,6 +294,7 @@ aligned submit \
 ```
 
 ```bash
+rm -rf ./aligned_verification_data/ &&
 aligned submit \
   --proving_system Halo2IPA \
   --proof ./scripts/test_files/halo2_ipa/proof.bin \

--- a/docs/guides/0_submitting_proofs.md
+++ b/docs/guides/0_submitting_proofs.md
@@ -66,8 +66,8 @@ To use it, you can use the `aligned` CLI, as shown with the following example:
 
 ```bash
 aligned deposit-to-batcher \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
---rpc https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
 --chain holesky \
 --keystore_path <keystore_path> \
 --amount 0.1ether
@@ -75,8 +75,8 @@ aligned deposit-to-batcher \
 
 These commands allow the usage of the following flags:
 
-- `--batcher_addr` to specify the address of the Batcher Payment Service smart contract.
-- `--rpc` to specify the rpc url to be used.
+- `--payment_service_addr` to specify the address of the Batcher Payment Service smart contract.
+- `--rpc_url` to specify the rpc url to be used.
 - `--chain` to specify the chain id to be used. Could be holesky or devnet.
 - `--keystore_path` the path to the keystore.
 - `--amount` the number of ethers to transfer to the Batcher.
@@ -86,15 +86,15 @@ After depositing funds, you can verify the Service has correctly received them b
 
 ```bash
 aligned get-user-balance \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
---rpc https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
 --user_addr <user_addr>
 ```
 
 These commands allow the usage of the following flags:
 
-- `--batcher_addr` to specify the address of the Batcher Payment Service smart contract.
-- `--rpc` to specify the rpc url to be used.
+- `--payment_service_addr` to specify the address of the Batcher Payment Service smart contract.
+- `--rpc_url` to specify the rpc url to be used.
 - `--user_addr` the address of the user that funded the Batcher.
 
 ## 3. Submit your proof to the batcher
@@ -107,9 +107,9 @@ Proof submission is done via the `submit` command of the Aligned CLI. The argume
 * `proof`: The path of the proof associated to the computation to be verified.
 * `vm_program`: When the proving system involves the execution of a program in a zkVM, this argument is associated with the compiled program or some other identifier of the program. 
 * `pub_input`: The path to the file with the public input associated with the proof.
-* `conn`: The batcher websocket URL.
-* `rpc`: The RPC Ethereum node URL.
-* `batcher_addr`: The Ethereum address of the Batcher Payments System contract.
+* `batcher_url`: The batcher websocket URL.
+* `rpc_url`: The RPC Ethereum node URL.
+* `payment_service_addr`: The Ethereum address of the Batcher Payments System contract.
 * `proof_generator_addr`: An optional parameter that can be used in some applications to avoid front-running.
 * `batch_inclusion_data_directory_path`: An optional parameter indicating the directory where to store the batcher response data. If not provided, the folder with the responses will be created in the current directory.
 
@@ -125,12 +125,12 @@ aligned submit \
 --proving_system SP1 \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
---conn wss://batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---rpc https://ethereum-holesky-rpc.publicnode.com \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 **Example**
@@ -141,10 +141,10 @@ aligned submit \
 --proving_system SP1 \
 --proof ./scripts/test_files/sp1/sp1_fibonacci.proof \
 --vm_program ./scripts/test_files/sp1/sp1_fibonacci.elf \
---conn wss://batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---rpc https://ethereum-holesky-rpc.publicnode.com \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ### Risc0 proof
@@ -160,12 +160,12 @@ aligned submit \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
 --pub_input <pub_input_file> \
---conn wss://batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---rpc https://ethereum-holesky-rpc.publicnode.com \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 **Example**
@@ -179,8 +179,8 @@ aligned submit \
 --public_input ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.pub \
 --aligned_verification_data_path ~/.aligned/aligned_verification_data \
 --keystore_path ~/.aligned_keystore/keystore0 \
---rpc https://ethereum-holesky-rpc.publicnode.com \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ### GnarkPlonkBn254, GnarkPlonkBls12_381 and Groth16Bn254
@@ -194,12 +194,12 @@ aligned submit \
 --proof <proof_file> \
 --public_input <public_input_file> \
 --vk <verification_key_file> \
---conn wss://batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---rpc https://ethereum-holesky-rpc.publicnode.com \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 **Examples**:
@@ -211,10 +211,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_plonk_bn254_script/plonk.proof \
 --public_input ./scripts/test_files/gnark_plonk_bn254_script/plonk_pub_input.pub \
 --vk ./scripts/test_files/gnark_plonk_bn254_script/plonk.vk \
---conn wss://batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
 --eth_rpc_url https://ethereum-holesky-rpc.publicnode.com \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ```bash
@@ -224,10 +224,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_plonk_bls12_381_script/plonk.proof \
 --public_input ./scripts/test_files/gnark_plonk_bls12_381_script/plonk_pub_input.pub \
 --vk ./scripts/test_files/gnark_plonk_bls12_381_script/plonk.vk \
---conn wss://batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---rpc https://ethereum-holesky-rpc.publicnode.com \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ```bash
@@ -237,10 +237,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.proof \
 --public_input ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.pub \
 --vk ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.vk \
---conn wss://batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---rpc https://ethereum-holesky-rpc.publicnode.com \
---batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ### Halo2 KZG and Halo2 IPA
@@ -256,11 +256,11 @@ aligned submit \
   --proof <proof_file_path> \
   --vk <method_id_file_path> \
   --public_input <pub_input_file_path> \
-  --conn wss://batcher.alignedlayer.com \
+  --batcher_url wss://batcher.alignedlayer.com \
   --keystore_path <path_to_ecdsa_keystore> \
   --proof_generator_addr <proof_generator_addr> \
-  --rpc https://ethereum-holesky-rpc.publicnode.com \
-  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
+  --rpc_url https://ethereum-holesky-rpc.publicnode.com \
+  --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003 \
 ```
 
 If you are using the Halo2PlonkIpa proving system, you need to specify the `--proving_system Halo2IPA` flag.
@@ -272,11 +272,11 @@ aligned submit \
   --proof <proof_file_path> \
   --vk <method_id_file_path> \
   --public_input <pub_input_file_path> \
-  --conn wss://batcher.alignedlayer.com \
+  --batcher_url wss://batcher.alignedlayer.com \
   --keystore_path <path_to_ecdsa_keystore> \
   --proof_generator_addr <proof_generator_addr> \
-  --rpc https://ethereum-holesky-rpc.publicnode.com \
-  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+  --rpc_url https://ethereum-holesky-rpc.publicnode.com \
+  --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 **Examples**:
@@ -288,11 +288,11 @@ aligned submit \
   --proof ./scripts/test_files/halo2_kzg/proof.bin \
   --vk ./scripts/test_files/halo2_kzg/params.bin \
   --public_input ./scripts/test_files/halo2_kzg/pub_input.bin \
-  --conn wss://batcher.alignedlayer.com \
+  --batcher_url wss://batcher.alignedlayer.com \
   --keystore_path ~/.aligned_keystore/keystore0 \
   --proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
-  --rpc https://ethereum-holesky-rpc.publicnode.com \
-  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+  --rpc_url https://ethereum-holesky-rpc.publicnode.com \
+  --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
 ```bash
@@ -302,10 +302,10 @@ aligned submit \
   --proof ./scripts/test_files/halo2_ipa/proof.bin \
   --vk ./scripts/test_files/halo2_ipa/params.bin \
   --public_input ./scripts/test_files/halo2_ipa/pub_input.bin \
-  --conn wss://batcher.alignedlayer.com \
+  --batcher_url wss://batcher.alignedlayer.com \
   --keystore_path ~/.aligned_keystore/keystore0 \
   --proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
-  --rpc https://ethereum-holesky-rpc.publicnode.com \
-  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
+  --rpc_url https://ethereum-holesky-rpc.publicnode.com \
+  --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 


### PR DESCRIPTION
# Changes

* fix typos in submitting proofs page
* add halo2 to supported verifiers
* add halo2 commands

## Test

These two commands params are taken from the makefile and are used as Halo2 examples (keystore param is not included in these commands for testing purposes).

```bash
aligned submit \
  --proving_system Halo2KZG \
  --proof ./scripts/test_files/halo2_kzg/proof.bin \
  --vk ./scripts/test_files/halo2_kzg/params.bin \
  --public_input ./scripts/test_files/halo2_kzg/pub_input.bin \
  --conn wss://batcher.alignedlayer.com \
  --proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
  --rpc https://ethereum-holesky-rpc.publicnode.com \
  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
```

```
aligned submit \
  --proving_system Halo2IPA \
  --proof ./scripts/test_files/halo2_ipa/proof.bin \
  --vk ./scripts/test_files/halo2_ipa/params.bin \
  --public_input ./scripts/test_files/halo2_ipa/pub_input.bin \
  --conn wss://batcher.alignedlayer.com \
  --proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
  --rpc https://ethereum-holesky-rpc.publicnode.com \
  --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
```