### PR TITLE
feat: handle new batch log on separate go routine

### DIFF
--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -179,7 +179,6 @@ func (o *Operator) HandleNewBatchLog(newBatchLog *servicemanager.ContractAligned
 		OperatorId:          o.OperatorId,
 	}
 
-	// o.Logger.Infof("Signed Task Response to send: %+v", signedTaskResponse)
 	o.Logger.Infof("Signed Task Response to send: BatchIdentifierHash=%s, BatchMerkleRoot=%s, SenderAddress=%s",
 		hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
 		hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -154,34 +154,39 @@ func (o *Operator) Start(ctx context.Context) error {
 				o.Logger.Fatal("Could not subscribe to new tasks")
 			}
 		case newBatchLog := <-o.NewTaskCreatedChan:
-			err := o.ProcessNewBatchLog(newBatchLog)
-			if err != nil {
-				o.Logger.Infof("batch %x did not verify. Err: %v", newBatchLog.BatchMerkleRoot, err)
-				continue
-			}
-			batchIdentifier := append(newBatchLog.BatchMerkleRoot[:], newBatchLog.SenderAddress[:]...)
-			var batchIdentifierHash = *(*[32]byte)(crypto.Keccak256(batchIdentifier))
-
-			responseSignature := o.SignTaskResponse(batchIdentifierHash)
-			o.Logger.Debugf("responseSignature about to send: %x", responseSignature)
-
-			signedTaskResponse := types.SignedTaskResponse{
-				BatchIdentifierHash: batchIdentifierHash,
-				BatchMerkleRoot: newBatchLog.BatchMerkleRoot,
-				SenderAddress:   newBatchLog.SenderAddress,
-				BlsSignature:    *responseSignature,
-				OperatorId:      o.OperatorId,
-			}
-
-			// o.Logger.Infof("Signed Task Response to send: %+v", signedTaskResponse)
-			o.Logger.Infof("Signed Task Response to send: BatchIdentifierHash=%s, BatchMerkleRoot=%s, SenderAddress=%s",
-				hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
-				hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),
-				hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
-			)
-			go o.aggRpcClient.SendSignedTaskResponseToAggregator(&signedTaskResponse)
+			go o.HandleNewBatchLog(newBatchLog)
 		}
 	}
+}
+
+func (o *Operator) HandleNewBatchLog(newBatchLog *servicemanager.ContractAlignedLayerServiceManagerNewBatch) {
+	err := o.ProcessNewBatchLog(newBatchLog)
+	if err != nil {
+		o.Logger.Infof("batch %x did not verify. Err: %v", newBatchLog.BatchMerkleRoot, err)
+		return
+	}
+	batchIdentifier := append(newBatchLog.BatchMerkleRoot[:], newBatchLog.SenderAddress[:]...)
+	var batchIdentifierHash = *(*[32]byte)(crypto.Keccak256(batchIdentifier))
+
+	responseSignature := o.SignTaskResponse(batchIdentifierHash)
+	o.Logger.Debugf("responseSignature about to send: %x", responseSignature)
+
+	signedTaskResponse := types.SignedTaskResponse{
+		BatchIdentifierHash: batchIdentifierHash,
+		BatchMerkleRoot:     newBatchLog.BatchMerkleRoot,
+		SenderAddress:       newBatchLog.SenderAddress,
+		BlsSignature:        *responseSignature,
+		OperatorId:          o.OperatorId,
+	}
+
+	// o.Logger.Infof("Signed Task Response to send: %+v", signedTaskResponse)
+	o.Logger.Infof("Signed Task Response to send: BatchIdentifierHash=%s, BatchMerkleRoot=%s, SenderAddress=%s",
+		hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
+		hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),
+		hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
+	)
+
+	o.aggRpcClient.SendSignedTaskResponseToAggregator(&signedTaskResponse)
 }
 
 // Takes a NewTaskCreatedLog struct as input and returns a TaskResponseHeader struct.


### PR DESCRIPTION
Download batches separately to avoid locking for too long while downloading. Easiest way is to handle the new batch entirely in a different go routine.

Test normal flow. you can test with two batcher to see two batchers at the same time. bigger batches work better for this since they are heavier to download, ideally test with remote bucket for added latency.