### PR TITLE
fix(explorer): handle empty events from batcher payment system

### DIFF
--- a/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
@@ -49,23 +49,23 @@ defmodule BatcherPaymentServiceManager do
     |> Ethers.get_logs(fromBlock: @first_block)
     |> case do
       {:ok, []} ->
-        Logger.error("No events found for merkle root: #{merkle_root}")
+        Logger.warning("No fee per proof events found for merkle root: #{merkle_root}.")
         0
 
       {:ok, events} ->
         event = events |> hd()
         fee_per_proof = event.data |> hd()
-        Logger.debug("Fee per proof of #{merkle_root}: #{fee_per_proof} wei")
+        Logger.debug("Fee per proof of #{merkle_root}: #{fee_per_proof} WEI.")
 
         fee_per_proof
 
       {:error, reason} ->
-        Logger.error("Error getting gas per proof: #{inspect(reason)}")
-        raise("Error getting gas per proof")
+        Logger.error("Error getting fee per proof: #{inspect(reason)}.")
+        raise("Error getting fee per proof events.")
 
       other ->
-        Logger.error("Unexpected response: #{inspect(other)}")
-        raise("Unexpected response")
+        Logger.error("Unexpected response onfee per proof events: #{inspect(other)}")
+        raise("Unexpected response on fee per proof events.")
     end
   end
 end

--- a/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
@@ -48,6 +48,10 @@ defmodule BatcherPaymentServiceManager do
     )
     |> Ethers.get_logs(fromBlock: @first_block)
     |> case do
+      {:ok, []} ->
+        Logger.error("No events found for merkle root: #{merkle_root}")
+        0
+
       {:ok, events} ->
         event = events |> hd()
         fee_per_proof = event.data |> hd()

--- a/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
@@ -64,7 +64,7 @@ defmodule BatcherPaymentServiceManager do
         raise("Error getting fee per proof events.")
 
       other ->
-        Logger.error("Unexpected response onfee per proof events: #{inspect(other)}")
+        Logger.error("Unexpected response on fee per proof events: #{inspect(other)}")
         raise("Unexpected response on fee per proof events.")
     end
   end

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -34,7 +34,7 @@ defmodule Batches do
     |> validate_format(:submission_transaction_hash, ~r/0x[a-fA-F0-9]{64}/)
     |> validate_number(:response_block_number, greater_than: 0)
     |> validate_format(:response_transaction_hash, ~r/0x[a-fA-F0-9]{64}/)
-    |> validate_number(:fee_per_proof, greater_than: 0)
+    |> validate_number(:fee_per_proof, greater_than: -1)
   end
 
   def cast_to_batches(%BatchDB{} = batch_db) do

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -34,7 +34,7 @@ defmodule Batches do
     |> validate_format(:submission_transaction_hash, ~r/0x[a-fA-F0-9]{64}/)
     |> validate_number(:response_block_number, greater_than: 0)
     |> validate_format(:response_transaction_hash, ~r/0x[a-fA-F0-9]{64}/)
-    |> validate_number(:fee_per_proof, greater_than: -1)
+    |> validate_number(:fee_per_proof, greater_than_or_equal_to: 0)
   end
 
   def cast_to_batches(%BatchDB{} = batch_db) do

--- a/explorer/lib/explorer_web/live/pages/batch/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/batch/index.html.heex
@@ -39,19 +39,20 @@
         </h3>
         <p><%= @current_batch.amount_of_proofs %></p>
       </div>
-      <%= if @current_batch.fee_per_proof != nil do %>
-        <div class="flex flex-col sm:flex-row">
-          <h3>
-            Cost per Proof:
-          </h3>
-          <p>
-            <%= @current_batch.fee_per_proof |> EthConverter.wei_to_eth() %> ETH
-            <%= if @eth_usd_price != :empty and @eth_usd_price != "0.00000" do %>
-              <span class="inline-flex md:inline-block">(<%= @eth_usd_price %> USD)</span>
-            <% end %>
-          </p>
-        </div>
-      <% end %>
+      <div
+        :if={@current_batch.fee_per_proof != 0}
+        class="flex flex-col sm:flex-row"
+      >
+        <h3>
+          Fee per Proof:
+        </h3>
+        <p>
+          <%= @current_batch.fee_per_proof |> EthConverter.wei_to_eth() %> ETH
+          <%= if @eth_usd_price != :empty and @eth_usd_price != "0.00000" do %>
+            <span class="inline-flex md:inline-block">(<%= @eth_usd_price %> USD)</span>
+          <% end %>
+        </p>
+      </div>
       <div>
         <h3>
           Proofs in this batch:


### PR DESCRIPTION
# Changes

* update text to say fee
* add case when empty array from events and add log
* do not display batch fee that returned empty from logs