### PR TITLE
fix: normalize address input for /versions/{address}

### DIFF
--- a/operator_tracker/src/lib.rs
+++ b/operator_tracker/src/lib.rs
@@ -193,8 +193,9 @@ pub async fn get_operator_version(
         return Err(OperatorVersionError::BadRequest);
     }
 
+    let lowercase_address = address.to_lowercase();
     sqlx::query_as::<_, OperatorVersion>("SELECT * FROM operator_versions WHERE address = $1")
-        .bind(address)
+        .bind(lowercase_address)
         .fetch_optional(db)
         .await
         .map_err(|_| OperatorVersionError::InternalServerError)


### PR DESCRIPTION
# Description
When you try the following command
```bash
curl https://holesky.tracker.alignedlayer.com/versions/0xab630768c48ea979559d475beb1301680ca9ee08
```
You get the following response
```json
{"address":"0xab630768c48ea979559d475beb1301680ca9ee08","version":"v0.5.2"}
```
Which is correct.

But, when you try the same command, using another format, like the checksum address
```bash
curl https://holesky.tracker.alignedlayer.com/versions/0xAB630768C48Ea979559D475bEB1301680Ca9eE08
```
You get a `404 Not Found` response.

The endpoint should accept all possible formats of the address.

# How to test
1. Run anvil
```bash
make anvil_start_with_block_time
```

2. Run aggregator
```bash
make aggregator_start
```

3. Run tracker
First we will clean the previous local db for the tracker. This is not needed in production
```bash
make tracker_clean_db
make tracker_run_db
make tracker_devnet_start
```

4. Run operator
```bash
export OPERATOR_ADDRESS=0x70997970C51812dc3A010C7d01b50e0d17dc79C8
make operator_full_registration CONFIG_FILE=config-files/config-operator-1.yaml
make build_operator
./operator/build/aligned-operator start --config ./config-files/config-operator-1.yaml
```

Note: We have to build the operator to inject the version in the binary

5. Once you have the operator running and the version has been successfully registered, you can test the following commands

- Checksum address
```bash
curl http://localhost:3030/versions/0x70997970C51812dc3A010C7d01b50e0d17dc79C8
```

- Lowercase address
```bash
curl http://localhost:3030/versions/0x70997970c51812dc3a010c7d01b50e0d17dc79c8
```

- Uppercase address
```bash
curl http://localhost:3030/versions/0x70997970C51812DC3A010C7D01B50E0D17DC79C8
```

In all cases, you have to get the following response
```json
{"address":"0x70997970c51812dc3a010c7d01b50e0d17dc79c8","version":"v0.4.1"}
```

Note: for this PR the displayed version is not relevant
