### PR TITLE
docs: fix missing broken links from dir rename

### DIFF
--- a/docs/1_introduction/1_getting_started.md
+++ b/docs/1_introduction/1_getting_started.md
@@ -1,6 +1,6 @@
 # Getting started!
 
-In this tutorial you will learn how to send your first SP1 proofs to get verified in Aligned in under 3 minutes.
+In this tutorial, you will learn how to send your first SP1 proofs to get verified in Aligned in under 3 minutes.
 
 ## Quickstart
 We will download a previously generated SP1 proof, send it to Aligned for verification, and retrieve the results from Ethereum Holesky testnet.
@@ -54,7 +54,7 @@ aligned verify-proof-onchain \
 --chain holesky
 ```
 
-This is reading the result of the verification of the proof in Ethereum.
+This is reading the result of the proof verification in Ethereum.
 
 7. You should get this result:
 
@@ -62,16 +62,16 @@ This is reading the result of the verification of the proof in Ethereum.
 [2024-06-17T21:58:43Z INFO  aligned] Your proof was verified in Aligned and included in the batch!
 ```
 
-If the proof wasn't verified you should get this result:
+If the proof wasn't verified, you should get this result:
 
 ```bash
 [2024-06-17T21:59:09Z INFO  aligned] Your proof was not included in the batch.
 ```
 
 Aligned works in:
-- MacOS Arm64 (M1 or higher)
+- macOS Arm64 (M1 or higher)
 - Linux x86 with GLIBC_2.32 or superior (For example, Ubuntu 22.04 or higher)
 
 If you don't meet these requirements, you can compile the binaries yourself following the [README](https://github.com/yetanotherco/aligned_layer)
 
-To try Aligned with other proving systems, check [this](https://docs.alignedlayer.com/guides/0_submitting_proofs) guide
+To try Aligned with other proving systems, check [this](../3_guides/0_submitting_proofs) guide

--- a/docs/3_guides/0_submitting_proofs.md
+++ b/docs/3_guides/0_submitting_proofs.md
@@ -1,6 +1,6 @@
 # Submitting Proofs
 
-Make sure you have Aligned installed as specified [here](../introduction/1_getting_started.md#Quickstart).
+Make sure you have Aligned installed as specified [here](../1_introduction/1_getting_started.md#Quickstart).
 
 If you run the examples below, make sure you are in Aligned's repository root.
 
@@ -15,7 +15,7 @@ The following is the list of the verifiers currently supported by Aligned:
 - :white_check_mark: Halo2 - Plonk/KZG
 - :white_check_mark: Halo2 - Plonk/IPA
 
-Learn more about future verifiers [here](../architecture/0_supported_verifiers.md).
+Learn more about future verifiers [here](../2_architecture/0_supported_verifiers.md).
 
 ## 1. Import/Create Keystore file
 
@@ -99,7 +99,7 @@ These commands allow the usage of the following flags:
 
 ## 3. Submit your proof to the batcher
 
-This guide will focus on how to submit proofs using the Aligned CLI. To integrate the proof submission process into your application, check the [Aligned SDK guide](../guides/1_SDK.md).
+This guide will focus on how to submit proofs using the Aligned CLI. To integrate the proof submission process into your application, check the [Aligned SDK guide](../3_guides/2_integrating_aligned_into_your_application.md).
 
 Proof submission is done via the `submit` command of the Aligned CLI. The arguments for the submit command are:
 

--- a/docs/3_guides/4_generating_proofs.md
+++ b/docs/3_guides/4_generating_proofs.md
@@ -9,7 +9,7 @@ This guide assumes that:
 - sp1 prover installed (instructions [here](https://succinctlabs.github.io/sp1/getting-started/install.html))
 - sp1 project to generate the proofs
   (instructions [here](https://succinctlabs.github.io/sp1/generating-proofs/setup.html))
-- aligned installed (instructions [here](../introduction/1_getting_started.md#quickstart))
+- aligned installed (instructions [here](../1_introduction/1_getting_started.md#quickstart))
 
 ### How to generate a proof
 
@@ -47,7 +47,7 @@ aligned submit \
 
 Where `proof_path` is the path to the proof file, `vm_program_path` is the path to the ELF file. `proof_generator_addr` is an optional parameter that works as a helper for some applications where you can be frontrunned.
 
-For more instructions on how to submit proofs, check the [Submitting proofs guide](../guides/0_submitting_proofs.md).
+For more instructions on how to submit proofs, check the [Submitting proofs guide](../3_guides/0_submitting_proofs.md).
 
 ## Gnark
 
@@ -98,7 +98,7 @@ aligned submit \
 Where proof path is the path to the proof file, `public_input_path` is the path to the public input file,
 and `verification_key_path` is the path to the verification key file.
 
-For more instructions on how to submit proofs, check the [Submitting proofs guide](../guides/0_submitting_proofs.md).
+For more instructions on how to submit proofs, check the [Submitting proofs guide](../3_guides/0_submitting_proofs.md).
 
 ## Risc0
 
@@ -108,7 +108,7 @@ This guide assumes that:
 
 - Risc0 toolchain installed (instructions [here](https://dev.risczero.com/api/zkvm/quickstart#1-install-the-risc-zero-toolchain))
 - Risc0 project to generate the proofs (instructions [here](https://dev.risczero.com/api/zkvm/quickstart#2-create-a-new-project))
-- Aligned installed (instructions [here](../introduction/1_getting_started.md#quickstart))
+- Aligned installed (instructions [here](../1_introduction/1_getting_started.md#quickstart))
 
 ### How to generate a proof
 
@@ -174,7 +174,7 @@ aligned submit \
   --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
-For more instructions on how to submit proofs, check the [Submitting proofs guide](../guides/0_submitting_proofs.md).
+For more instructions on how to submit proofs, check the [Submitting proofs guide](../3_guides/0_submitting_proofs.md).
 
 ## Halo2
 
@@ -184,7 +184,7 @@ This guide assumes that:
 
 - You are using PSE fork of the Halo2 [proof system](https://github.com/privacy-scaling-explorations/halo2).
 - You have a strong understanding of Halo2 circuit development and are familiar with the Halo2 proof system.
-- Aligned installed (instructions [here](../introduction/1_getting_started.md#quickstart)).
+- Aligned installed (instructions [here](../1_introduction/1_getting_started.md#quickstart)).
 
 ### Import the Halo2 fork library
 
@@ -280,4 +280,4 @@ aligned submit \
   --batcher_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 
-For more instructions on how to submit proofs, check the [Submitting proofs guide](../guides/0_submitting_proofs.md).
+For more instructions on how to submit proofs, check the [Submitting proofs guide](../3_guides/0_submitting_proofs.md).

--- a/docs/3_guides/6_setup_aligned.md
+++ b/docs/3_guides/6_setup_aligned.md
@@ -124,7 +124,7 @@ Note that when upgrading the contracts, you must also:
 
 ## Aggregator
 
-To start the [Aggregator](../architecture/components/5_aggregator.md):
+To start the [Aggregator](../2_architecture/components/5_aggregator.md):
 
 ```bash
 make aggregator_start
@@ -143,7 +143,7 @@ make aggregator_start CONFIG_FILE=<path_to_config_file>
 
 ## Operator
 
-To start an [Operator](../architecture/components/4_operator.md)
+To start an [Operator](../2_architecture/components/4_operator.md)
 (note it also registers it):
 
 ```bash
@@ -309,7 +309,7 @@ eigenlayer operator keys import --key-type bls <keystore-name> <private-key>
 
 ## Batcher
 
-To start the [Batcher](../architecture/components/1_batcher.md):
+To start the [Batcher](../2_architecture/components/1_batcher.md):
 
 ```bash
 make batcher_start

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -51,3 +51,4 @@
 * [Blog](https://mirror.xyz/0x7794D1c55568270A81D8Bf39e1bcE96BEaC10901)
 * [Website](https://alignedlayer.com)
 * [Github](https://github.com/yetanotherco/aligned_layer)
+* [YouTube](https://www.youtube.com/@alignedlayer)


### PR DESCRIPTION
# Changes

* fix links starting with /architecture instead of /2_architecture (same for guides and introduction)
* remove hardcoded docs.alignedlayer.com links
* add youtube link to socials
