### PR TITLE
chore: bump up sdk version in validating-public-inputs

### DIFF
--- a/docs/3_guides/3_validating_public_input.md
+++ b/docs/3_guides/3_validating_public_input.md
@@ -10,7 +10,7 @@ This guide assumes you are in the `examples/validating-public-input` directory.
 
 ## Generate your ZK Proof
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > To generate the proof ensure you have [docker](https://www.docker.com/get-started/) installed and the docker daemon running.
 > This is necessary to ensure deterministic builds of the binary we want to generate a proof of. If not used, builds may differ depending on the system you are running on. To know more about this, check [this link](https://dev.risczero.com/terminology#deterministic-builds) from RiscZero docs.
 
@@ -42,6 +42,7 @@ pragma solidity ^0.8.12;
 
 contract FibonacciValidator {
     address public alignedServiceManager;
+    address public paymentServiceAddr;
     bytes32 public fibonacciProgramId;
 
     bytes32 public fibonacciProgramIdCommitment =
@@ -49,8 +50,9 @@ contract FibonacciValidator {
 
     event FibonacciNumbers(uint32 fibN, uint32 fibNPlusOne);
 
-    constructor(address _alignedServiceManager) {
+    constructor(address _alignedServiceManager, address _paymentServiceAddr) {
         alignedServiceManager = _alignedServiceManager;
+        paymentServiceAddr = _paymentServiceAddr;
     }
 
     function verifyBatchInclusion(
@@ -61,7 +63,8 @@ contract FibonacciValidator {
         bytes32 batchMerkleRoot,
         bytes memory merkleProof,
         uint256 verificationDataBatchIndex,
-        bytes memory pubInputBytes
+        bytes memory pubInputBytes,
+
     ) public returns (bool) {
         require(
             fibonacciProgramIdCommitment == programIdCommitment,
@@ -78,14 +81,15 @@ contract FibonacciValidator {
             bytes memory proofIsIncluded
         ) = alignedServiceManager.staticcall(
                 abi.encodeWithSignature(
-                    "verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256)",
+                    "verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256,address)",
                     proofCommitment,
                     pubInputCommitment,
                     programIdCommitment,
                     proofGeneratorAddr,
                     batchMerkleRoot,
                     merkleProof,
-                    verificationDataBatchIndex
+                    verificationDataBatchIndex,
+                    paymentServiceAddr
                 )
             );
 
@@ -146,14 +150,15 @@ require(
     bytes memory proofIsIncluded
 ) = alignedServiceManager.staticcall(
     abi.encodeWithSignature(
-        "verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256)",
+        "verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256,address)",
         proofCommitment,
         pubInputCommitment,
         programIdCommitment,
         proofGeneratorAddr,
         batchMerkleRoot,
         merkleProof,
-        verificationDataBatchIndex
+        verificationDataBatchIndex,
+        paymentServiceAddr
         )
 );
 
@@ -192,6 +197,7 @@ To deploy the contract, first you will need to set up the `.env` file in the con
 RPC_URL=<rpc_url> #You can use publicnode RPC: https://ethereum-holesky-rpc.publicnode.com
 PRIVATE_KEY=<private_key>
 ALIGNED_SERVICE_MANAGER_ADDRESS=<service_manager_address> #0x58F280BeBE9B34c9939C3C39e0890C81f163B623 for Holesky
+PAYMENT_SERVICE_ADDR=<payment_service_address> #0x815aeCA64a974297942D2Bbf034ABEe22a38A003 for Holesky
 ```
 
 Then, run `make deploy_fibonacci_validator`.

--- a/examples/validating-public-input/aligned-integration/Cargo.lock
+++ b/examples/validating-public-input/aligned-integration/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "aligned-sdk"
 version = "0.1.0"
-source = "git+https://github.com/yetanotherco/aligned_layer?tag=v0.5.2#f2fac00afac9cb0fa4d07a3aea7cde1825a96419"
+source = "git+https://github.com/yetanotherco/aligned_layer?rev=94fbaee3c3fedcf1bebb02b8f16c317149c003ce#94fbaee3c3fedcf1bebb02b8f16c317149c003ce"
 dependencies = [
  "ciborium",
  "ethers",

--- a/examples/validating-public-input/aligned-integration/Cargo.toml
+++ b/examples/validating-public-input/aligned-integration/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag = "v0.5.2" }
+aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", rev = "94fbaee3c3fedcf1bebb02b8f16c317149c003ce" }
 tokio = { version = "1.37.0", features = [
     "io-std",
     "time",

--- a/examples/validating-public-input/aligned-integration/src/main.rs
+++ b/examples/validating-public-input/aligned-integration/src/main.rs
@@ -67,6 +67,7 @@ async fn main() -> Result<(), SubmitError> {
         &verification_data,
         wallet,
         nonce,
+        BATCHER_PAYMENTS_ADDRESS,
     )
     .await?;
 

--- a/examples/validating-public-input/contracts/.env.example
+++ b/examples/validating-public-input/contracts/.env.example
@@ -1,3 +1,4 @@
 RPC_URL=<rpc_url> #You can use publicnode RPC: https://ethereum-holesky-rpc.publicnode.com
 PRIVATE_KEY=<private_key>
 ALIGNED_SERVICE_MANAGER_ADDRESS=<service_manager_address> #0x58F280BeBE9B34c9939C3C39e0890C81f163B623 for Holesky
+PAYMENT_SERVICE_ADDR=<payment_service_address> #0x815aeCA64a974297942D2Bbf034ABEe22a38A003 for Holesky

--- a/examples/validating-public-input/contracts/deploy.sh
+++ b/examples/validating-public-input/contracts/deploy.sh
@@ -11,6 +11,11 @@ if [ -z "$ALIGNED_SERVICE_MANAGER_ADDRESS" ]; then
     exit 1
 fi
 
+if [ -z "$PAYMENT_SERVICE_ADDRESS" ]; then
+    echo "PAYMENT_SERVICE_ADDRESS is not set. Please set it in .env"
+    exit 1
+fi
+
 if [ -z "$RPC_URL" ]; then
     echo "RPC_URL is not set. Please set it in .env"
     exit 1
@@ -25,7 +30,8 @@ forge install
 
 forge script script/Deployer.s.sol \
     "$ALIGNED_SERVICE_MANAGER_ADDRESS" \
+    "$PAYMENT_SERVICE_ADDRESS" \
     --rpc-url "$RPC_URL" \
     --private-key "$PRIVATE_KEY" \
     --broadcast \
-    --sig "run(address _alignedServiceManager)"
+    --sig "run(address _alignedServiceManager,address _paymentServiceAddr)"

--- a/examples/validating-public-input/contracts/script/Deployer.s.sol
+++ b/examples/validating-public-input/contracts/script/Deployer.s.sol
@@ -7,11 +7,15 @@ import {FibonacciValidator} from "../src/FibonacciValidator.sol";
 contract FibonacciDeployer is Script {
     function setUp() public {}
 
-    function run(address _targetContract) external returns (address) {
+    function run(
+        address _alignedServiceManager,
+        address _paymentServiceAddr
+    ) external returns (address) {
         vm.startBroadcast();
 
         FibonacciValidator fibonacciContract = new FibonacciValidator(
-            _targetContract
+            _alignedServiceManager,
+            _paymentServiceAddr
         );
 
         vm.stopBroadcast();

--- a/examples/validating-public-input/contracts/src/FibonacciValidator.sol
+++ b/examples/validating-public-input/contracts/src/FibonacciValidator.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.12;
 
 contract FibonacciValidator {
     address public alignedServiceManager;
+    address public paymentServiceAddr;
     bytes32 public fibonacciProgramId;
 
     bytes32 public fibonacciProgramIdCommitment =
@@ -10,8 +11,9 @@ contract FibonacciValidator {
 
     event FibonacciNumbers(uint32 fibN, uint32 fibNPlusOne);
 
-    constructor(address _alignedServiceManager) {
+    constructor(address _alignedServiceManager, address _paymentServiceAddr) {
         alignedServiceManager = _alignedServiceManager;
+        paymentServiceAddr = _paymentServiceAddr;
     }
 
     function verifyBatchInclusion(
@@ -39,14 +41,15 @@ contract FibonacciValidator {
             bytes memory proofIsIncluded
         ) = alignedServiceManager.staticcall(
                 abi.encodeWithSignature(
-                    "verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256)",
+                    "verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256,address)",
                     proofCommitment,
                     pubInputCommitment,
                     programIdCommitment,
                     proofGeneratorAddr,
                     batchMerkleRoot,
                     merkleProof,
-                    verificationDataBatchIndex
+                    verificationDataBatchIndex,
+                    paymentServiceAddr
                 )
             );
 


### PR DESCRIPTION
> [!NOTE]
> This PR has been included in the V0.6.0 release
> This PR is thus marked as DRAFT for a short time, just in case
> But it should not be merged

# Description

- This PR bumps up the SDK validating-public-inputs example.

# To Test

- Go to `examples/validating-public-input`.
- Run `make generate_risc_zero_fibonacci_proof`.
- Run `make submit_fibonacci_proof`.