### PR TITLE
ci: fix risc0 test failing

### DIFF
--- a/.github/workflows/test-risc-zero.yml
+++ b/.github/workflows/test-risc-zero.yml
@@ -33,7 +33,5 @@ jobs:
           toolchain: stable
       - name: Test Risc Zero Rust
         run: make test_risc_zero_rust_ffi
-      - name: Print LD_LIBRARY_PATH
-        run: echo $LD_LIBRARY_PATH
       - name: Test Risc Zero go bindings
         run: make test_risc_zero_go_bindings_linux

--- a/.github/workflows/test-risc-zero.yml
+++ b/.github/workflows/test-risc-zero.yml
@@ -7,31 +7,35 @@ on:
   pull_request:
     branches: ["*"]
     paths:
-      - 'operator/risc_zero/**'
-      - '.github/workflows/test-risc-zero.yml'
+      - "operator/risc_zero/**"
+      - ".github/workflows/test-risc-zero.yml"
 
 jobs:
-    test:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Clear device space
-          run: |
-            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-            sudo rm -rf /usr/local/lib/android
-            sudo rm -rf /opt/ghc
-            sudo rm -rf /usr/local/.ghcup
-            sudo rm -rf /usr/share/dotnet
-            sudo rm -rf /opt/ghc
-            sudo rm -rf "/usr/local/share/boost"
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version: '1.22'
-            cache: false
-        - uses: actions-rs/toolchain@v1
-          with:
-            toolchain: stable
-        - name: Test Risc Zero Rust
-          run: make test_risc_zero_rust_ffi
-        - name: Test Risc Zero go bindings
-          run: make test_risc_zero_go_bindings_linux
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear device space
+        run: |
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: false
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Test Risc Zero Rust
+        run: make test_risc_zero_rust_ffi
+      - name: Print LD_LIBRARY_PATH
+        run: echo $LD_LIBRARY_PATH
+      - name: Test Risc Zero go bindings
+        run: |
+          export LD_LIBRARY_PATH=operator/risc_zero/lib:$LD_LIBRARY_PATH
+          make test_risc_zero_go_bindings_linux

--- a/.github/workflows/test-risc-zero.yml
+++ b/.github/workflows/test-risc-zero.yml
@@ -36,6 +36,4 @@ jobs:
       - name: Print LD_LIBRARY_PATH
         run: echo $LD_LIBRARY_PATH
       - name: Test Risc Zero go bindings
-        run: |
-          export LD_LIBRARY_PATH=operator/risc_zero/lib:$LD_LIBRARY_PATH
-          make test_risc_zero_go_bindings_linux
+        run: make test_risc_zero_go_bindings_linux

--- a/Makefile
+++ b/Makefile
@@ -503,6 +503,7 @@ build_risc_zero_macos:
 build_risc_zero_linux:
 	@cd operator/risc_zero/lib && cargo build $(RELEASE_FLAG)
 	@cp operator/risc_zero/lib/target/$(TARGET_REL_PATH)/librisc_zero_verifier_ffi.so operator/risc_zero/lib/librisc_zero_verifier_ffi.so
+	@ls -la operator/risc_zero/lib
 
 test_risc_zero_rust_ffi:
 	@echo "Testing RISC Zero Rust FFI source code..."

--- a/Makefile
+++ b/Makefile
@@ -514,7 +514,7 @@ test_risc_zero_go_bindings_macos: build_risc_zero_macos
 
 test_risc_zero_go_bindings_linux: build_risc_zero_linux
 	@echo "Testing RISC Zero Go bindings..."
-	@export LD_LIBRARY_PATH=operator/risc_zero/lib:$LD_LIBRARY_PATH
+	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(CURDIR)/operator/risc_zero/lib \
 	go test ./operator/risc_zero/... -v
 
 generate_risc_zero_fibonacci_proof:

--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,6 @@ build_risc_zero_macos:
 build_risc_zero_linux:
 	@cd operator/risc_zero/lib && cargo build $(RELEASE_FLAG)
 	@cp operator/risc_zero/lib/target/$(TARGET_REL_PATH)/librisc_zero_verifier_ffi.so operator/risc_zero/lib/librisc_zero_verifier_ffi.so
-	@ls -la operator/risc_zero/lib
 
 test_risc_zero_rust_ffi:
 	@echo "Testing RISC Zero Rust FFI source code..."
@@ -515,6 +514,7 @@ test_risc_zero_go_bindings_macos: build_risc_zero_macos
 
 test_risc_zero_go_bindings_linux: build_risc_zero_linux
 	@echo "Testing RISC Zero Go bindings..."
+	@export LD_LIBRARY_PATH=operator/risc_zero/lib:$LD_LIBRARY_PATH
 	go test ./operator/risc_zero/... -v
 
 generate_risc_zero_fibonacci_proof:

--- a/operator/risc_zero/risc_zero.go
+++ b/operator/risc_zero/risc_zero.go
@@ -16,6 +16,7 @@ func VerifyRiscZeroReceipt(innerReceiptBuffer []byte, innerReceiptLen uint32, im
 		return false
 	}
 
+	// Test
 	receiptPtr := (*C.uchar)(unsafe.Pointer(&innerReceiptBuffer[0]))
 	imageIdPtr := (*C.uchar)(unsafe.Pointer(&imageIdBuffer[0]))
 

--- a/operator/risc_zero/risc_zero.go
+++ b/operator/risc_zero/risc_zero.go
@@ -1,7 +1,7 @@
 package risc_zero
 
 /*
-#cgo linux LDFLAGS: -L${SRCDIR}/lib -lrisc_zero_verifier_ffi -ldl -lrt -lm -lssl -lcrypto -Wl,--allow-multiple-definition
+#cgo linux LDFLAGS: ${SRCDIR}/lib/librisc_zero_verifier_ffi.so -ldl -lrt -lm -lssl -lcrypto -Wl,--allow-multiple-definition
 #cgo darwin LDFLAGS: -L./lib -lrisc_zero_verifier_ffi
 
 #include "lib/risc_zero.h"
@@ -16,7 +16,6 @@ func VerifyRiscZeroReceipt(innerReceiptBuffer []byte, innerReceiptLen uint32, im
 		return false
 	}
 
-	// Test
 	receiptPtr := (*C.uchar)(unsafe.Pointer(&innerReceiptBuffer[0]))
 	imageIdPtr := (*C.uchar)(unsafe.Pointer(&imageIdBuffer[0]))
 

--- a/operator/risc_zero/risc_zero.go
+++ b/operator/risc_zero/risc_zero.go
@@ -1,7 +1,7 @@
 package risc_zero
 
 /*
-#cgo linux LDFLAGS: -L${SRCDIR}/lib/librisc_zero_verifier_ffi.so -lrisc_zero_verifier_ffi -ldl -lrt -lm -lssl -lcrypto -Wl,--allow-multiple-definition
+#cgo linux LDFLAGS: -L${SRCDIR}/lib -lrisc_zero_verifier_ffi -ldl -lrt -lm -lssl -lcrypto -Wl,--allow-multiple-definition
 #cgo darwin LDFLAGS: -L./lib -lrisc_zero_verifier_ffi
 
 #include "lib/risc_zero.h"

--- a/operator/risc_zero/risc_zero.go
+++ b/operator/risc_zero/risc_zero.go
@@ -1,7 +1,7 @@
 package risc_zero
 
 /*
-#cgo linux LDFLAGS: ${SRCDIR}/lib/librisc_zero_verifier_ffi.so -ldl -lrt -lm -lssl -lcrypto -Wl,--allow-multiple-definition
+#cgo linux LDFLAGS: -L${SRCDIR}/lib/librisc_zero_verifier_ffi.so -lrisc_zero_verifier_ffi -ldl -lrt -lm -lssl -lcrypto -Wl,--allow-multiple-definition
 #cgo darwin LDFLAGS: -L./lib -lrisc_zero_verifier_ffi
 
 #include "lib/risc_zero.h"


### PR DESCRIPTION
# Description

- Fix risc0 CI.

# To Test

- You should be in Linux OS.
- Run `make test_risc_zero_go_bindings_linux`
- You should see:
```
Testing RISC Zero Go bindings...
LD_LIBRARY_PATH=:/app/aligned_layer/operator/risc_zero/lib \
go test ./operator/risc_zero/... -v
=== RUN   TestFibonacciRiscZeroProofVerifies
--- PASS: TestFibonacciRiscZeroProofVerifies (0.01s)
PASS
ok  	github.com/yetanotherco/aligned_layer/operator/risc_zero	(cached)
```