### PR TITLE
refactor: change panic to return false

### DIFF
--- a/batcher/aligned-batcher/src/gnark/mod.rs
+++ b/batcher/aligned-batcher/src/gnark/mod.rs
@@ -47,7 +47,7 @@ pub fn verify_gnark(
         ProvingSystemId::Groth16Bn254 => unsafe {
             VerifyGroth16ProofBN254(proof, public_input, verification_key)
         },
-        _ => panic!("Unsupported proving system"),
+        _ => false,
     }
 }
 


### PR DESCRIPTION
# Description

- This PR changes the `panic` present in the `verify_gnark` function in `batcher/aligned-batcher/src/gnark/mod.rs` to return  `false` in case the proving system is not matched.

# To Test

- In `batcher/aligned-batcher/src/gnark/mod.rs` change `line 104` from `&verification_data.proving_system` to `&ProvingSystemId::SP1`.
- Run everything as usual.
- Send:
```
make batcher_send_plonk_bn254_task
```
- It should fail but not panic.