### PR TITLE
chore(telemetry): add operators information to responses spans

### DIFF
--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -369,7 +369,7 @@ func (agg *Aggregator) sendAggregatedResponse(batchMerkleRoot [32]byte, senderAd
 }
 
 func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, senderAddress [20]byte, taskCreatedBlock uint32) {
-	agg.telemetry.InitNewTrace(batchMerkleRoot)
+	agg.telemetry.InitNewTrace(batchMerkleRoot, agg.avsReader.GetTotalStake())
 
 	batchIdentifier := append(batchMerkleRoot[:], senderAddress[:]...)
 	var batchIdentifierHash = *(*[32]byte)(crypto.Keccak256(batchIdentifier))

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -197,6 +197,7 @@ func NewAggregator(aggregatorConfig config.AggregatorConfig) (*Aggregator, error
 		metricsReg:            reg,
 		metrics:               aggregatorMetrics,
 		telemetry:             aggregatorTelemetry,
+		operators:             operators,
 	}
 
 	return &aggregator, nil

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -49,7 +49,8 @@ func (agg *Aggregator) ServeOperators() error {
 //   - 0: Success
 //   - 1: Error
 func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *types.SignedTaskResponse, reply *uint8) error {
-	span := agg.telemetry.OperatorResponseTrace(signedTaskResponse.BatchMerkleRoot, signedTaskResponse.OperatorId)
+	operator := agg.operators[signedTaskResponse.OperatorId]
+	span := agg.telemetry.OperatorResponseTrace(signedTaskResponse.BatchMerkleRoot, operator)
 	defer span.End()
 
 	agg.AggregatorConfig.BaseConfig.Logger.Info("New task response",

--- a/core/chainio/avs_reader.go
+++ b/core/chainio/avs_reader.go
@@ -1,10 +1,14 @@
 package chainio
 
 import (
+	"context"
+	"encoding/hex"
+	eigentypes "github.com/Layr-Labs/eigensdk-go/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	contractERC20Mock "github.com/yetanotherco/aligned_layer/contracts/bindings/ERC20Mock"
 	"github.com/yetanotherco/aligned_layer/core/config"
+	"github.com/yetanotherco/aligned_layer/core/types"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients"
 	sdkavsregistry "github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
@@ -35,7 +39,14 @@ func NewAvsReaderFromConfig(baseConfig *config.BaseConfig, ecdsaConfig *config.E
 
 	chainReader := clients.AvsRegistryChainReader
 
-	avsServiceBindings, err := NewAvsServiceBindings(baseConfig.AlignedLayerDeploymentConfig.AlignedLayerServiceManagerAddr, baseConfig.AlignedLayerDeploymentConfig.AlignedLayerOperatorStateRetrieverAddr, baseConfig.EthRpcClient, baseConfig.EthRpcClientFallback, baseConfig.Logger)
+	avsServiceBindings, err := NewAvsServiceBindings(
+		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerServiceManagerAddr,
+		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerRegistryCoordinatorAddr,
+		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerOperatorStateRetrieverAddr,
+		baseConfig.EthRpcClient,
+		baseConfig.EthRpcClientFallback,
+		baseConfig.Logger,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -61,4 +72,33 @@ func (r *AvsReader) GetErc20Mock(tokenAddr gethcommon.Address) (*contractERC20Mo
 
 func (r *AvsReader) IsOperatorRegistered(address gethcommon.Address) (bool, error) {
 	return r.ChainReader.IsOperatorRegistered(&bind.CallOpts{}, address)
+}
+
+func (r *AvsReader) GetOperators() (map[eigentypes.OperatorId]types.OperatorData, error) {
+	blockNumber, err := r.AvsContractBindings.ethClient.BlockNumber(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	quorumNumbers := []byte{0}
+
+	operatorsByQuorum, err := r.AvsContractBindings.OperatorStateRetriever.GetOperatorState(
+		&bind.CallOpts{},
+		r.AvsContractBindings.ContractBindings.RegistryCoordinatorAddr,
+		quorumNumbers,
+		uint32(blockNumber), // Converted to uint32 because the contract expects it but ethClient.BlockNumber returns int64
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	operators := make(map[eigentypes.OperatorId]types.OperatorData)
+	for _, operator := range operatorsByQuorum[0] { // We only use one quorum (0x00)
+		operators[operator.OperatorId] = types.OperatorData{
+			Address: hex.EncodeToString(operator.Operator[:]),
+			Id:      hex.EncodeToString(operator.OperatorId[:]),
+			Name:    "dummy name", // TODO get the name from Metadata
+			Stake:   operator.Stake,
+		}
+	}
+	return operators, nil
 }

--- a/core/chainio/avs_reader.go
+++ b/core/chainio/avs_reader.go
@@ -94,8 +94,8 @@ func (r *AvsReader) GetOperators() (map[eigentypes.OperatorId]types.OperatorData
 	operators := make(map[eigentypes.OperatorId]types.OperatorData)
 	for _, operator := range operatorsByQuorum[0] { // We only use one quorum (0x00)
 		operators[operator.OperatorId] = types.OperatorData{
-			Address: hex.EncodeToString(operator.Operator[:]),
-			Id:      hex.EncodeToString(operator.OperatorId[:]),
+			Address: "0x" + hex.EncodeToString(operator.Operator[:]),
+			Id:      "0x" + hex.EncodeToString(operator.OperatorId[:]),
 			Name:    "dummy name", // TODO get the name from Metadata
 			Stake:   operator.Stake,
 		}

--- a/core/chainio/avs_reader.go
+++ b/core/chainio/avs_reader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yetanotherco/aligned_layer/core/types"
 	"io"
 	"log"
+	"math/big"
 	"net/http"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients"
@@ -76,6 +77,15 @@ func (r *AvsReader) GetErc20Mock(tokenAddr gethcommon.Address) (*contractERC20Mo
 
 func (r *AvsReader) IsOperatorRegistered(address gethcommon.Address) (bool, error) {
 	return r.ChainReader.IsOperatorRegistered(&bind.CallOpts{}, address)
+}
+
+func (r *AvsReader) GetTotalStake() *big.Int {
+	totalStake, err := r.AvsContractBindings.StakeRegistry.GetCurrentTotalStake(&bind.CallOpts{}, 0x00)
+	if err != nil {
+		r.logger.Error("Failed to fetch total stake", "err", err)
+		return nil
+	}
+	return totalStake
 }
 
 func (r *AvsReader) GetOperators() (map[eigentypes.OperatorId]types.OperatorData, error) {

--- a/core/chainio/avs_subscriber.go
+++ b/core/chainio/avs_subscriber.go
@@ -50,8 +50,12 @@ type AvsSubscriber struct {
 func NewAvsSubscriberFromConfig(baseConfig *config.BaseConfig) (*AvsSubscriber, error) {
 	avsContractBindings, err := NewAvsServiceBindings(
 		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerServiceManagerAddr,
+		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerRegistryCoordinatorAddr,
 		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerOperatorStateRetrieverAddr,
-		baseConfig.EthWsClient, baseConfig.EthWsClientFallback, baseConfig.Logger)
+		baseConfig.EthWsClient,
+		baseConfig.EthWsClientFallback,
+		baseConfig.Logger,
+	)
 
 	if err != nil {
 		baseConfig.Logger.Errorf("Failed to create contract bindings", "err", err)
@@ -64,7 +68,7 @@ func NewAvsSubscriberFromConfig(baseConfig *config.BaseConfig) (*AvsSubscriber, 
 		logger:                         baseConfig.Logger,
 	}, nil
 }
-	
+
 func (s *AvsSubscriber) SubscribeToNewTasks(newTaskCreatedChan chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3) (chan error, error) {
 	// Create a new channel to receive new tasks
 	internalChannel := make(chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3)
@@ -164,9 +168,9 @@ func (s *AvsSubscriber) processNewBatch(batch *servicemanager.ContractAlignedLay
 
 	if _, ok := batchesSet[batchIdentifierHash]; !ok {
 		s.logger.Info("Received new task",
-		"batchMerkleRoot", hex.EncodeToString(batch.BatchMerkleRoot[:]),
-		"senderAddress", hex.EncodeToString(batch.SenderAddress[:]),
-		"batchIdentifierHash", hex.EncodeToString(batchIdentifierHash[:]),)
+			"batchMerkleRoot", hex.EncodeToString(batch.BatchMerkleRoot[:]),
+			"senderAddress", hex.EncodeToString(batch.SenderAddress[:]),
+			"batchIdentifierHash", hex.EncodeToString(batchIdentifierHash[:]))
 
 		batchesSet[batchIdentifierHash] = struct{}{}
 		newTaskCreatedChan <- batch

--- a/core/chainio/avs_writer.go
+++ b/core/chainio/avs_writer.go
@@ -1,7 +1,6 @@
 package chainio
 
 import (
-
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
@@ -38,7 +37,14 @@ func NewAvsWriterFromConfig(baseConfig *config.BaseConfig, ecdsaConfig *config.E
 		return nil, err
 	}
 
-	avsServiceBindings, err := NewAvsServiceBindings(baseConfig.AlignedLayerDeploymentConfig.AlignedLayerServiceManagerAddr, baseConfig.AlignedLayerDeploymentConfig.AlignedLayerOperatorStateRetrieverAddr, baseConfig.EthRpcClient, baseConfig.EthRpcClientFallback, baseConfig.Logger)
+	avsServiceBindings, err := NewAvsServiceBindings(
+		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerServiceManagerAddr,
+		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerRegistryCoordinatorAddr,
+		baseConfig.AlignedLayerDeploymentConfig.AlignedLayerOperatorStateRetrieverAddr,
+		baseConfig.EthRpcClient,
+		baseConfig.EthRpcClientFallback,
+		baseConfig.Logger,
+	)
 
 	if err != nil {
 		baseConfig.Logger.Error("Cannot create avs service bindings", "err", err)
@@ -61,7 +67,6 @@ func NewAvsWriterFromConfig(baseConfig *config.BaseConfig, ecdsaConfig *config.E
 		Client:              baseConfig.EthRpcClient,
 	}, nil
 }
-
 
 func (w *AvsWriter) SendAggregatedResponse(batchMerkleRoot [32]byte, senderAddress [20]byte, nonSignerStakesAndSignature servicemanager.IBLSSignatureCheckerNonSignerStakesAndSignature) (*common.Hash, error) {
 	txOpts := *w.Signer.GetTxOpts()

--- a/core/chainio/bindings.go
+++ b/core/chainio/bindings.go
@@ -5,9 +5,9 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	operatorStateRetriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
+	stakeregistry "github.com/Layr-Labs/eigensdk-go/contracts/bindings/StakeRegistry"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	gethcommon "github.com/ethereum/go-ethereum/common"
-
 	csservicemanager "github.com/yetanotherco/aligned_layer/contracts/bindings/AlignedLayerServiceManager"
 )
 
@@ -15,6 +15,7 @@ type AvsServiceBindings struct {
 	ServiceManager         *csservicemanager.ContractAlignedLayerServiceManager
 	ServiceManagerFallback *csservicemanager.ContractAlignedLayerServiceManager
 	OperatorStateRetriever *operatorStateRetriever.ContractOperatorStateRetriever
+	StakeRegistry          *stakeregistry.ContractStakeRegistry
 	DelegationManager      *DelegationManager.DelegationManager
 	ContractBindings       *avsregistry.ContractBindings
 	ethClient              eth.Client
@@ -57,6 +58,7 @@ func NewAvsServiceBindings(
 		ServiceManager:         contractServiceManager,
 		ServiceManagerFallback: contractServiceManagerFallback,
 		OperatorStateRetriever: contractBindings.OperatorStateRetriever,
+		StakeRegistry:          contractBindings.StakeRegistry,
 		DelegationManager:      delegationManager,
 		ContractBindings:       contractBindings,
 		ethClient:              ethClient,

--- a/core/chainio/bindings.go
+++ b/core/chainio/bindings.go
@@ -1,6 +1,7 @@
 package chainio
 
 import (
+	"github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/DelegationManager"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	operatorStateRetriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
@@ -14,6 +15,7 @@ type AvsServiceBindings struct {
 	ServiceManager         *csservicemanager.ContractAlignedLayerServiceManager
 	ServiceManagerFallback *csservicemanager.ContractAlignedLayerServiceManager
 	OperatorStateRetriever *operatorStateRetriever.ContractOperatorStateRetriever
+	DelegationManager      *DelegationManager.DelegationManager
 	ContractBindings       *avsregistry.ContractBindings
 	ethClient              eth.Client
 	ethClientFallback      eth.Client
@@ -45,10 +47,17 @@ func NewAvsServiceBindings(
 		return nil, err
 	}
 
+	delegationManager, err := DelegationManager.NewDelegationManager(contractBindings.DelegationManagerAddr, ethClient)
+	if err != nil {
+		logger.Error("Failed to fetch DelegationManager contract", "err", err)
+		return nil, err
+	}
+
 	return &AvsServiceBindings{
 		ServiceManager:         contractServiceManager,
 		ServiceManagerFallback: contractServiceManagerFallback,
 		OperatorStateRetriever: contractBindings.OperatorStateRetriever,
+		DelegationManager:      delegationManager,
 		ContractBindings:       contractBindings,
 		ethClient:              ethClient,
 		ethClientFallback:      ethClientFallback,

--- a/core/chainio/bindings.go
+++ b/core/chainio/bindings.go
@@ -1,9 +1,10 @@
 package chainio
 
 import (
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/avsregistry"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
+	operatorStateRetriever "github.com/Layr-Labs/eigensdk-go/contracts/bindings/OperatorStateRetriever"
 	"github.com/Layr-Labs/eigensdk-go/logging"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	csservicemanager "github.com/yetanotherco/aligned_layer/contracts/bindings/AlignedLayerServiceManager"
@@ -12,12 +13,18 @@ import (
 type AvsServiceBindings struct {
 	ServiceManager         *csservicemanager.ContractAlignedLayerServiceManager
 	ServiceManagerFallback *csservicemanager.ContractAlignedLayerServiceManager
+	OperatorStateRetriever *operatorStateRetriever.ContractOperatorStateRetriever
+	ContractBindings       *avsregistry.ContractBindings
 	ethClient              eth.Client
 	ethClientFallback      eth.Client
 	logger                 logging.Logger
 }
 
-func NewAvsServiceBindings(serviceManagerAddr, blsOperatorStateRetrieverAddr gethcommon.Address, ethClient eth.Client, ethClientFallback eth.Client, logger logging.Logger) (*AvsServiceBindings, error) {
+func NewAvsServiceBindings(
+	serviceManagerAddr, registryCoordinatorAddr, blsOperatorStateRetrieverAddr gethcommon.Address,
+	ethClient, ethClientFallback eth.Client,
+	logger logging.Logger,
+) (*AvsServiceBindings, error) {
 	contractServiceManager, err := csservicemanager.NewContractAlignedLayerServiceManager(serviceManagerAddr, ethClient)
 	if err != nil {
 		logger.Error("Failed to fetch AlignedLayerServiceManager contract", "err", err)
@@ -30,9 +37,19 @@ func NewAvsServiceBindings(serviceManagerAddr, blsOperatorStateRetrieverAddr get
 		return nil, err
 	}
 
+	contractBindings, err := avsregistry.NewBindingsFromConfig(avsregistry.Config{
+		RegistryCoordinatorAddress:    registryCoordinatorAddr,
+		OperatorStateRetrieverAddress: blsOperatorStateRetrieverAddr,
+	}, ethClient, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	return &AvsServiceBindings{
 		ServiceManager:         contractServiceManager,
 		ServiceManagerFallback: contractServiceManagerFallback,
+		OperatorStateRetriever: contractBindings.OperatorStateRetriever,
+		ContractBindings:       contractBindings,
 		ethClient:              ethClient,
 		ethClientFallback:      ethClientFallback,
 		logger:                 logger,

--- a/core/types/operator_data.go
+++ b/core/types/operator_data.go
@@ -2,17 +2,21 @@ package types
 
 import (
 	"fmt"
+	eigentypes "github.com/Layr-Labs/eigensdk-go/types"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"math/big"
 )
 
 type OperatorData struct {
-	Address string // Store the address as a string instead of a gethcommon.Address to avoid encoding/decoding
-	Id      string // Store the id as a string instead of a eigentypes.OperatorId to avoid encoding/decoding
-	Name    string
-	Stake   *big.Int
+	Address       gethcommon.Address
+	Id            eigentypes.OperatorId
+	AddressString string // Store the address as a string to avoid encoding/decoding
+	IdString      string // Store the id as a string to avoid encoding/decoding
+	Name          string
+	Stake         *big.Int
 }
 
 // Print prints the OperatorData struct
 func (o *OperatorData) String() string {
-	return fmt.Sprintf("OperatorData{Address: %s, Id: %s, Name: %s, Stake: %d}", o.Address, o.Id, o.Name, o.Stake)
+	return fmt.Sprintf("OperatorData{Address: %s, Id: %s, Name: %s, Stake: %d}", o.AddressString, o.IdString, o.Name, o.Stake)
 }

--- a/core/types/operator_data.go
+++ b/core/types/operator_data.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+)
+
+type OperatorData struct {
+	Address string // Store the address as a string instead of a gethcommon.Address to avoid encoding/decoding
+	Id      string // Store the id as a string instead of a eigentypes.OperatorId to avoid encoding/decoding
+	Name    string
+	Stake   *big.Int
+}
+
+// Print prints the OperatorData struct
+func (o *OperatorData) String() string {
+	return fmt.Sprintf("OperatorData{Address: %s, Id: %s, Name: %s, Stake: %d}", o.Address, o.Id, o.Name, o.Stake)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/Layr-Labs/eigenlayer-contracts v0.4.2-mainnet-pepe
 	github.com/consensys/gnark v0.10.0
 	github.com/consensys/gnark-crypto v0.12.2-0.20240215234832-d72fcb379d3e
 	github.com/ugorji/go/codec v1.2.12

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/Layr-Labs/eigenlayer-contracts v0.4.2-mainnet-pepe h1:hI0QKvHWu+PU0DEr2YjV4m6WSZTi3blwWBN7AbPOkdQ=
+github.com/Layr-Labs/eigenlayer-contracts v0.4.2-mainnet-pepe/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -130,12 +130,12 @@ func (t *Telemetry) OperatorResponseTrace(batchMerkleRoot [32]byte, operator typ
 	ctx := t.getCtx(batchMerkleRoot)
 	_, span := t.Tracer.Start(
 		ctx,
-		fmt.Sprintf("Operator: %s (%s)", operator.Name, operator.Address),
+		fmt.Sprintf("Operator: %s (%s)", operator.Name, operator.AddressString),
 		trace.WithAttributes(
 			attribute.String("merkle_root", fmt.Sprintf("0x%s", hex.EncodeToString(batchMerkleRoot[:]))),
-			attribute.String("operator_id", fmt.Sprintf("0x%s", operator.Id)),
+			attribute.String("operator_id", fmt.Sprintf("0x%s", operator.IdString)),
 			attribute.String("operator_name", operator.Name),
-			attribute.String("operator_address", operator.Address),
+			attribute.String("operator_address", operator.AddressString),
 			attribute.Int64("operator_stake", operator.Stake.Int64()),
 		),
 	)


### PR DESCRIPTION
# Description

Add the following data to the responses spans
- Operator address
- Operator address

On aggregator start, load all operators data and keep tracking of updates. This way, traces can have information about operator that did not respond to a task

# Tasks

- [x] Get list of all operators registered to the AVS
- [x] Get metadata of all operators registered to the AVS
- [x] Show operators data on responses spans
- [ ] Update operators lists on new events
- [ ] Show operator that did not respond to task