### PR TITLE
fix(code quality): Remove panics from functions that return result

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -329,7 +329,7 @@ impl Batcher {
         // Create the event loop and TCP listener we'll accept connections on.
         let listener = TcpListener::bind(address)
             .await
-            .map_err(|e| BatcherError::EthereumSubscriptionError(e.to_string()))?;
+            .map_err(|e| BatcherError::TcpListenderError(e.to_string()))?;
         info!("Listening on: {}", address);
 
         // Let's spawn the handling of each connection in a separate task.

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -329,7 +329,7 @@ impl Batcher {
         // Create the event loop and TCP listener we'll accept connections on.
         let listener = TcpListener::bind(address)
             .await
-            .map_err(|e| BatcherError::TcpListenderError(e.to_string()))?;
+            .map_err(|e| BatcherError::TcpListenerError(e.to_string()))?;
         info!("Listening on: {}", address);
 
         // Let's spawn the handling of each connection in a separate task.

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -327,7 +327,9 @@ impl Batcher {
 
     pub async fn listen_connections(self: Arc<Self>, address: &str) -> Result<(), BatcherError> {
         // Create the event loop and TCP listener we'll accept connections on.
-        let listener = TcpListener::bind(address).await.expect("Failed to build");
+        let listener = TcpListener::bind(address)
+            .await
+            .map_err(|e| BatcherError::EthereumSubscriptionError(e.to_string()))?;
         info!("Listening on: {}", address);
 
         // Let's spawn the handling of each connection in a separate task.

--- a/batcher/aligned-batcher/src/main.rs
+++ b/batcher/aligned-batcher/src/main.rs
@@ -47,9 +47,9 @@ async fn main() -> Result<(), BatcherError> {
     tokio::spawn({
         let app = batcher.clone();
         async move {
-            if let Err(e) = app.listen_new_blocks().await {
-                log::error!("Error listening for new blocks: {:?}", e);
-            }
+            app.listen_new_blocks()
+                .await
+                .expect("Error listening for new blocks exiting")
         }
     });
 

--- a/batcher/aligned-batcher/src/main.rs
+++ b/batcher/aligned-batcher/src/main.rs
@@ -46,7 +46,11 @@ async fn main() -> Result<(), BatcherError> {
     // spawn task to listening for incoming blocks
     tokio::spawn({
         let app = batcher.clone();
-        async move { app.listen_new_blocks().await }
+        async move {
+            if let Err(e) = app.listen_new_blocks().await {
+                log::error!("Error listening for new blocks: {:?}", e);
+            }
+        }
     });
 
     batcher.listen_connections(&addr).await?;

--- a/batcher/aligned-batcher/src/main.rs
+++ b/batcher/aligned-batcher/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), BatcherError> {
     // spawn task to listening for incoming blocks
     tokio::spawn({
         let app = batcher.clone();
-        async move { app.listen_new_blocks().await.unwrap() }
+        async move { app.listen_new_blocks().await }
     });
 
     batcher.listen_connections(&addr).await?;

--- a/batcher/aligned-batcher/src/types/errors.rs
+++ b/batcher/aligned-batcher/src/types/errors.rs
@@ -4,7 +4,7 @@ use ethers::types::SignatureError;
 use tokio_tungstenite::tungstenite;
 
 pub enum BatcherError {
-    TcpListenderError(tungstenite::Error),
+    TcpListenderError(String),
     ConnectionError(tungstenite::Error),
     BatchVerifiedEventStreamError(String),
     EthereumSubscriptionError(String),

--- a/batcher/aligned-batcher/src/types/errors.rs
+++ b/batcher/aligned-batcher/src/types/errors.rs
@@ -4,6 +4,7 @@ use ethers::types::SignatureError;
 use tokio_tungstenite::tungstenite;
 
 pub enum BatcherError {
+    TcpListenderError(tungstenite::Error),
     ConnectionError(tungstenite::Error),
     BatchVerifiedEventStreamError(String),
     EthereumSubscriptionError(String),
@@ -31,6 +32,9 @@ impl From<SignatureError> for BatcherError {
 impl fmt::Debug for BatcherError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            BatcherError::TcpListenderError(e) => {
+                write!(f, "TCP Listener error: {}", e)
+            }
             BatcherError::ConnectionError(e) => {
                 write!(f, "Web Socket Connection error: {}", e)
             }

--- a/batcher/aligned-batcher/src/types/errors.rs
+++ b/batcher/aligned-batcher/src/types/errors.rs
@@ -4,7 +4,7 @@ use ethers::types::SignatureError;
 use tokio_tungstenite::tungstenite;
 
 pub enum BatcherError {
-    TcpListenderError(String),
+    TcpListenerError(String),
     ConnectionError(tungstenite::Error),
     BatchVerifiedEventStreamError(String),
     EthereumSubscriptionError(String),
@@ -32,7 +32,7 @@ impl From<SignatureError> for BatcherError {
 impl fmt::Debug for BatcherError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            BatcherError::TcpListenderError(e) => {
+            BatcherError::TcpListenerError(e) => {
                 write!(f, "TCP Listener error: {}", e)
             }
             BatcherError::ConnectionError(e) => {

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -307,7 +307,16 @@ async fn main() -> Result<(), AlignedError> {
                     .map_err(|e| SubmitError::GenericError(e.to_string()))?
             } else {
                 warn!("Missing keystore used for payment. This proof will not be included if sent to Eth Mainnet");
-                LocalWallet::from_str(ANVIL_PRIVATE_KEY).expect("Failed to create wallet")
+                match LocalWallet::from_str(ANVIL_PRIVATE_KEY) {
+                    Ok(wallet) => wallet,
+                    Err(e) => {
+                        warn!(
+                            "Failed to create wallet from anvil private key: {}",
+                            e.to_string()
+                        );
+                        return Ok(());
+                    }
+                }
             };
 
             let eth_rpc_url = submit_args.eth_rpc_url.clone();


### PR DESCRIPTION
closes #951 

Removes possible panics in `aligned_batcher` and `aligned::main`.