### PR TITLE
chore: set operator version to v070

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OS := $(shell uname -s)
 CONFIG_FILE?=config-files/config.yaml
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
-OPERATOR_VERSION=v0.5.2
+OPERATOR_VERSION=v0.7.0
 
 ifeq ($(OS),Linux)
 	BUILD_ALL_FFI = $(MAKE) build_all_ffi_linux

--- a/docs/3_guides/1_SDK_how_to.md
+++ b/docs/3_guides/1_SDK_how_to.md
@@ -12,7 +12,7 @@ To use this SDK in your Rust project, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.6.0" }
+aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.7.0" }
 ```
 
 To find the latest release tag go to [releases](https://github.com/yetanotherco/aligned_layer/releases) and copy the

--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -1,7 +1,7 @@
 # Register as an Aligned operator in testnet
 
 > **CURRENT VERSION:**
-> Aligned Operator [v0.5.2](https://github.com/yetanotherco/aligned_layer/releases/tag/v0.5.2)
+> Aligned Operator [v0.7.0](https://github.com/yetanotherco/aligned_layer/releases/tag/v0.7.0)
 
 > **IMPORTANT:** 
 > You must be [whitelisted](https://docs.google.com/forms/d/e/1FAIpQLSdH9sgfTz4v33lAvwj6BvYJGAeIshQia3FXz36PFfF-WQAWEQ/viewform) to become an Aligned operator.
@@ -26,7 +26,7 @@ Minimum hardware requirements:
 To start with, clone the Aligned repository and move inside it
 
 ```bash
-git clone https://github.com/yetanotherco/aligned_layer.git --branch v0.5.2
+git clone https://github.com/yetanotherco/aligned_layer.git --branch v0.7.0
 cd aligned_layer
 ```
 


### PR DESCRIPTION
> [!IMPORTANT]  
> Merge this PR as the latest PR for the release

# Description
This PR sets the OPERATOR_VERSION to v0.7.0

# How to test
1. Build operator
```
make build_operator
```
2. Check operator version
```
./operator/build/aligned-operator --version
```

It shoud show the following message

> Aligned Layer Node Operator version v0.7.0