### PR TITLE
fix: set v0.6.0 as latest release for client

### DIFF
--- a/batcher/aligned/install_aligned.sh
+++ b/batcher/aligned/install_aligned.sh
@@ -8,11 +8,12 @@ BASE_DIR=$HOME
 ALIGNED_DIR="${ALIGNED_DIR-"$BASE_DIR/.aligned"}"
 ALIGNED_BIN_DIR="$ALIGNED_DIR/bin"
 ALIGNED_BIN_PATH="$ALIGNED_BIN_DIR/aligned"
-CURRENT_TAG=$(curl -s -L \
-  -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  https://api.github.com/repos/yetanotherco/aligned_layer/releases/latest \
-  | grep '"tag_name":' | awk -F'"' '{print $4}')
+#CURRENT_TAG=$(curl -s -L \
+#  -H "Accept: application/vnd.github+json" \
+#  -H "X-GitHub-Api-Version: 2022-11-28" \
+#  https://api.github.com/repos/yetanotherco/aligned_layer/releases/latest \
+#  | grep '"tag_name":' | awk -F'"' '{print $4}')
+CURRENT_TAG=v0.6.0
 RELEASE_URL="https://github.com/yetanotherco/aligned_layer/releases/download/$CURRENT_TAG/"
 
 ARCH=$(uname -m)

--- a/docs/3_guides/1_SDK_how_to.md
+++ b/docs/3_guides/1_SDK_how_to.md
@@ -12,7 +12,7 @@ To use this SDK in your Rust project, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.7.0" }
+aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.6.0" }
 ```
 
 To find the latest release tag go to [releases](https://github.com/yetanotherco/aligned_layer/releases) and copy the


### PR DESCRIPTION
# How to test
1. Install aligned using the docs
```
make install_aligned
```
2. Send proofs