### PR TITLE
feat(tracker): update operators' version if they already exist

### DIFF
--- a/telemetry_api/lib/telemetry_api/operators.ex
+++ b/telemetry_api/lib/telemetry_api/operators.ex
@@ -22,20 +22,38 @@ defmodule TelemetryApi.Operators do
   end
 
   @doc """
-  Gets a single operator.
+  Gets a single operator by id.
 
   Raises `Ecto.NoResultsError` if the Operator does not exist.
 
   ## Examples
 
-      iex> get_operator!(123)
+      iex> get_operator_by_id!(123)
       %Operator{}
 
-      iex> get_operator!(456)
+      iex> get_operator_by_id!(456)
       ** (Ecto.NoResultsError)
 
   """
-  def get_operator!(id), do: Repo.get!(Operator, id)
+  def get_operator_by_id!(id), do: Repo.get!(Operator, id)
+
+  @doc """
+  Gets an operator by address.
+
+  ## Examples
+
+      iex> get_operator(%{field: value})
+      %Operator{}
+
+      iex> get_operator(%{field: value})
+      nil
+
+  """
+  def get_operator(attrs \\ %{}) do
+    address = SignatureVerifier.get_address(attrs["version"], attrs["signature"])
+    query = from o in Operator, where: o.address == ^address
+    Repo.one(query)
+  end
 
   @doc """
   Creates a operator.
@@ -53,6 +71,7 @@ defmodule TelemetryApi.Operators do
     # Get address from the signature
     address = SignatureVerifier.get_address(attrs["version"], attrs["signature"])
     attrs = Map.put(attrs, "address", address)
+
     %Operator{}
     |> Operator.changeset(attrs)
     |> Repo.insert()

--- a/telemetry_api/lib/telemetry_api/operators.ex
+++ b/telemetry_api/lib/telemetry_api/operators.ex
@@ -22,37 +22,19 @@ defmodule TelemetryApi.Operators do
   end
 
   @doc """
-  Gets a single operator by id.
-
-  Raises `Ecto.NoResultsError` if the Operator does not exist.
-
-  ## Examples
-
-      iex> get_operator_by_id!(123)
-      %Operator{}
-
-      iex> get_operator_by_id!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_operator_by_id!(id), do: Repo.get!(Operator, id)
-
-  @doc """
   Gets an operator by address.
 
   ## Examples
 
-      iex> get_operator(%{field: value})
+      iex> get_operator_by_address("some_address"})
       %Operator{}
 
-      iex> get_operator(%{field: value})
+      iex> get_operator_by_address("non_existent_address")
       nil
 
   """
-  def get_operator(attrs \\ %{}) do
-    address = SignatureVerifier.get_address(attrs["version"], attrs["signature"])
-    query = from o in Operator, where: o.address == ^address
-    Repo.one(query)
+  def get_operator(address) do
+    Repo.get(Operator, address)
   end
 
   @doc """
@@ -72,9 +54,13 @@ defmodule TelemetryApi.Operators do
     address = SignatureVerifier.get_address(attrs["version"], attrs["signature"])
     attrs = Map.put(attrs, "address", address)
 
-    %Operator{}
+    # We handle updates here as there is no patch method available at the moment.
+    case Repo.get(Operator, address) do
+      nil -> %Operator{}
+      operator -> operator
+    end
     |> Operator.changeset(attrs)
-    |> Repo.insert()
+    |> Repo.insert_or_update()
   end
 
   @doc """

--- a/telemetry_api/lib/telemetry_api/operators.ex
+++ b/telemetry_api/lib/telemetry_api/operators.ex
@@ -22,14 +22,14 @@ defmodule TelemetryApi.Operators do
   end
 
   @doc """
-  Gets an operator by address.
+  Gets a single operator.
 
   ## Examples
 
-      iex> get_operator_by_address("some_address"})
+      iex> get_operator("some_address"})
       %Operator{}
 
-      iex> get_operator_by_address("non_existent_address")
+      iex> get_operator("non_existent_address")
       nil
 
   """
@@ -51,7 +51,7 @@ defmodule TelemetryApi.Operators do
   """
   def create_operator(attrs \\ %{}) do
     # Get address from the signature
-    address = SignatureVerifier.get_address(attrs["version"], attrs["signature"])
+    address = "0x" <> SignatureVerifier.get_address(attrs["version"], attrs["signature"])
     attrs = Map.put(attrs, "address", address)
 
     # We handle updates here as there is no patch method available at the moment.

--- a/telemetry_api/lib/telemetry_api/operators/operator.ex
+++ b/telemetry_api/lib/telemetry_api/operators/operator.ex
@@ -2,9 +2,9 @@ defmodule TelemetryApi.Operators.Operator do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @primary_key {:address, :string, []}
   schema "operators" do
     field :version, :string
-    field :address, :string
 
     timestamps(type: :utc_datetime)
   end
@@ -15,4 +15,8 @@ defmodule TelemetryApi.Operators.Operator do
     |> cast(attrs, [:address, :version])
     |> validate_required([:address, :version])
   end
+end
+
+defimpl Phoenix.Param, for: TelemetryApi.Operators.Operator do
+  def to_param(%TelemetryApi.Operators.Operator{address: address}), do: address
 end

--- a/telemetry_api/lib/telemetry_api_web/controllers/operator_controller.ex
+++ b/telemetry_api/lib/telemetry_api_web/controllers/operator_controller.ex
@@ -11,21 +11,6 @@ defmodule TelemetryApiWeb.OperatorController do
     render(conn, :index, operators: operators)
   end
 
-  # def create(conn, operator_params) do
-  #   # We handle updates here as there is no patch method available at the moment.
-  #   case Operators.get_operator_by_attrs(operator_params) do
-  #     %Operator{} = operator ->
-  #       update(conn, operator, operator_params)
-
-  #     nil ->
-  #       with {:ok, %Operator{} = operator} <- Operators.create_operator(operator_params) do
-  #         conn
-  #         |> put_status(:created)
-  #         |> put_resp_header("location", ~p"/api/operators/#{operator}")
-  #         |> render(:show, operator: operator)
-  #       end
-  #   end
-  # end
   def create(conn, operator_params) do
     with {:ok, %Operator{} = operator} <- Operators.create_operator(operator_params) do
       conn

--- a/telemetry_api/lib/telemetry_api_web/controllers/operator_controller.ex
+++ b/telemetry_api/lib/telemetry_api_web/controllers/operator_controller.ex
@@ -11,34 +11,50 @@ defmodule TelemetryApiWeb.OperatorController do
     render(conn, :index, operators: operators)
   end
 
+  # def create(conn, operator_params) do
+  #   # We handle updates here as there is no patch method available at the moment.
+  #   case Operators.get_operator_by_attrs(operator_params) do
+  #     %Operator{} = operator ->
+  #       update(conn, operator, operator_params)
+
+  #     nil ->
+  #       with {:ok, %Operator{} = operator} <- Operators.create_operator(operator_params) do
+  #         conn
+  #         |> put_status(:created)
+  #         |> put_resp_header("location", ~p"/api/operators/#{operator}")
+  #         |> render(:show, operator: operator)
+  #       end
+  #   end
+  # end
   def create(conn, operator_params) do
-    # We handle updates here as there is no patch method available at the moment.
-    case Operators.get_operator(operator_params) do
-      %Operator{} = operator ->
-        update(conn, operator, operator_params)
-
-      nil ->
-        with {:ok, %Operator{} = operator} <- Operators.create_operator(operator_params) do
-          conn
-          |> put_status(:created)
-          |> put_resp_header("location", ~p"/api/operators/#{operator}")
-          |> render(:show, operator: operator)
-        end
-    end
-  end
-
-  def show(conn, %{"id" => id}) do
-    operator = Operators.get_operator_by_id!(id)
-    render(conn, :show, operator: operator)
-  end
-
-  defp update(conn, operator, operator_params) do
-    with {:ok, %Operator{} = operator} <- Operators.update_operator(operator, operator_params) do
+    with {:ok, %Operator{} = operator} <- Operators.create_operator(operator_params) do
       conn
-      |> put_status(:ok)
+      |> put_status(:created)
+      |> put_resp_header("location", ~p"/api/operators/#{operator}")
       |> render(:show, operator: operator)
     end
   end
+
+  def show(conn, %{"id" => address}) do
+    case Operators.get_operator(address) do
+      %Operator{} = operator ->
+        render(conn, :show, operator: operator)
+
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> put_view(TelemetryApiWeb.ErrorJSON)
+        |> render("404.json", %{})
+    end
+  end
+
+  # defp update(conn, operator, operator_params) do
+  #   with {:ok, %Operator{} = operator} <- Operators.update_operator(operator, operator_params) do
+  #     conn
+  #     |> put_status(:ok)
+  #     |> render(:show, operator: operator)
+  #   end
+  # end
 
   # def delete(conn, %{"id" => id}) do
   #   operator = Operators.get_operator!(id)

--- a/telemetry_api/lib/telemetry_api_web/controllers/operator_controller.ex
+++ b/telemetry_api/lib/telemetry_api_web/controllers/operator_controller.ex
@@ -12,26 +12,34 @@ defmodule TelemetryApiWeb.OperatorController do
   end
 
   def create(conn, operator_params) do
-    with {:ok, %Operator{} = operator} <- Operators.create_operator(operator_params) do
-      conn
-      |> put_status(:created)
-      |> put_resp_header("location", ~p"/api/operators/#{operator}")
-      |> render(:show, operator: operator)
+    # We handle updates here as there is no patch method available at the moment.
+    case Operators.get_operator(operator_params) do
+      %Operator{} = operator ->
+        update(conn, operator, operator_params)
+
+      nil ->
+        with {:ok, %Operator{} = operator} <- Operators.create_operator(operator_params) do
+          conn
+          |> put_status(:created)
+          |> put_resp_header("location", ~p"/api/operators/#{operator}")
+          |> render(:show, operator: operator)
+        end
     end
   end
 
   def show(conn, %{"id" => id}) do
-    operator = Operators.get_operator!(id)
+    operator = Operators.get_operator_by_id!(id)
     render(conn, :show, operator: operator)
   end
 
-  # def update(conn, %{"id" => id, "operator" => operator_params}) do
-  #   operator = Operators.get_operator!(id)
-
-  #   with {:ok, %Operator{} = operator} <- Operators.update_operator(operator, operator_params) do
-  #     render(conn, :show, operator: operator)
-  #   end
-  # end
+  defp update(conn, operator, operator_params) do
+    with {:ok, %Operator{} = operator} <- Operators.update_operator(operator, operator_params) do
+      conn
+      |> put_status(:updated)
+      |> put_resp_header("location", ~p"/api/operators/#{operator}")
+      |> render(:show, operator: operator)
+    end
+  end
 
   # def delete(conn, %{"id" => id}) do
   #   operator = Operators.get_operator!(id)

--- a/telemetry_api/lib/telemetry_api_web/controllers/operator_controller.ex
+++ b/telemetry_api/lib/telemetry_api_web/controllers/operator_controller.ex
@@ -35,8 +35,7 @@ defmodule TelemetryApiWeb.OperatorController do
   defp update(conn, operator, operator_params) do
     with {:ok, %Operator{} = operator} <- Operators.update_operator(operator, operator_params) do
       conn
-      |> put_status(:updated)
-      |> put_resp_header("location", ~p"/api/operators/#{operator}")
+      |> put_status(:ok)
       |> render(:show, operator: operator)
     end
   end

--- a/telemetry_api/lib/telemetry_api_web/controllers/operator_json.ex
+++ b/telemetry_api/lib/telemetry_api_web/controllers/operator_json.ex
@@ -17,7 +17,6 @@ defmodule TelemetryApiWeb.OperatorJSON do
 
   defp data(%Operator{} = operator) do
     %{
-      id: operator.id,
       address: operator.address,
       version: operator.version
     }

--- a/telemetry_api/lib/telemetry_api_web/router.ex
+++ b/telemetry_api/lib/telemetry_api_web/router.ex
@@ -10,6 +10,11 @@ defmodule TelemetryApiWeb.Router do
     resources "/operators", OperatorController, only: [:index, :show, :create]
   end
 
+  scope "/versions", TelemetryApiWeb do
+    pipe_through :api
+    resources "/", OperatorController, only: [:index, :show, :create]
+  end
+
   # Enable LiveDashboard in development
   if Application.compile_env(:telemetry_api, :dev_routes) do
     # If you want to use the LiveDashboard in production, you should put

--- a/telemetry_api/priv/repo/migrations/20240917212329_create_operators.exs
+++ b/telemetry_api/priv/repo/migrations/20240917212329_create_operators.exs
@@ -2,7 +2,7 @@ defmodule TelemetryApi.Repo.Migrations.CreateOperators do
   use Ecto.Migration
 
   def change do
-    create table(:operators) do
+    create table(:operators, primary_key: false) do
       add :address, :string, primary_key: true
       add :version, :string
 

--- a/telemetry_api/priv/repo/migrations/20240917212329_create_operators.exs
+++ b/telemetry_api/priv/repo/migrations/20240917212329_create_operators.exs
@@ -3,10 +3,12 @@ defmodule TelemetryApi.Repo.Migrations.CreateOperators do
 
   def change do
     create table(:operators) do
-      add :address, :string
+      add :address, :string, primary_key: true
       add :version, :string
 
       timestamps(type: :utc_datetime)
     end
+
+    create unique_index(:operators, [:address])
   end
 end


### PR DESCRIPTION
**Motivation**

We are currently creating an entry for every POST /api/operators, but we should update any existing ones.

**Description**
- Sets `address` as the primary key.
- Changes `GET operator/:id` to `GET operator/:address` since we now index operators by address.
- Checks whether an operator is already in the registry and updates its version if that is the case, or creates a new one if it is not.
- Enables the `/versions` endpoint which directly mirrors the operations defined for `/api/operators` for backwards compatibility reasons.