### PR TITLE
feat(audit): Remove use of storage gaps in upgradeable contracts

### DIFF
--- a/contracts/src/core/AlignedLayerServiceManagerStorage.sol
+++ b/contracts/src/core/AlignedLayerServiceManagerStorage.sol
@@ -15,8 +15,4 @@ abstract contract AlignedLayerServiceManagerStorage {
     mapping(address => uint256) public batchersBalances;
 
     address public alignedAggregator;
-
-    // storage gap for upgradeability
-    // solhint-disable-next-line var-name-mixedcase
-    uint256[47] private __GAP;
 }

--- a/contracts/src/core/BatcherPaymentServiceStorage.sol
+++ b/contracts/src/core/BatcherPaymentServiceStorage.sol
@@ -22,8 +22,4 @@ abstract contract BatcherPaymentServiceStorage {
     mapping(address => UserInfo) public userData;
 
     bytes32 public noncedVerificationDataTypeHash;
-
-    // storage gap for upgradeability
-    // solhint-disable-next-line var-name-mixedcase
-    uint256[23] private __GAP;
 }


### PR DESCRIPTION
closes: #1068 

To Test:
- [x] Run Local Testnet with deployed contracts by first running `anvil_deploy_aligned_contract` before `anvil_start_with_block_time`
- [x] Re run Local testnet and ensure nothing breaks
- [x] Upgrade the contracts by running `anvil_upgrade_aligned_contracts` & `anvil_upgrade_batcher_payment_service`
