### PR TITLE
fix: set LD_LIBRARY_PATH on operator build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ operator_register_and_start: operator_full_registration operator_start
 
 build_operator: deps
 	@echo "Building Operator..."
-	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION)" -o ./operator/build/aligned-operator ./operator/cmd/main.go
+	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION) -r $(LD_LIBRARY_PATH):$(CURDIR)/operator/risc_zero/lib" -o ./operator/build/aligned-operator ./operator/cmd/main.go
 	@echo "Operator built into /operator/build/aligned-operator"
 
 update_operator:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OS := $(shell uname -s)
 CONFIG_FILE?=config-files/config.yaml
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
-OPERATOR_VERSION=v0.7.2
+OPERATOR_VERSION=v0.7.3
 
 ifeq ($(OS),Linux)
 	BUILD_ALL_FFI = $(MAKE) build_all_ffi_linux

--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -1,7 +1,7 @@
 # Register as an Aligned operator in testnet
 
 > **CURRENT VERSION:**
-> Aligned Operator [v0.7.2](https://github.com/yetanotherco/aligned_layer/releases/tag/v0.7.2)
+> Aligned Operator [v0.7.3](https://github.com/yetanotherco/aligned_layer/releases/tag/v0.7.3)
 
 > **IMPORTANT:** 
 > You must be [whitelisted](https://docs.google.com/forms/d/e/1FAIpQLSdH9sgfTz4v33lAvwj6BvYJGAeIshQia3FXz36PFfF-WQAWEQ/viewform) to become an Aligned operator.
@@ -26,7 +26,7 @@ Minimum hardware requirements:
 To start with, clone the Aligned repository and move inside it
 
 ```bash
-git clone https://github.com/yetanotherco/aligned_layer.git --branch v0.7.2
+git clone https://github.com/yetanotherco/aligned_layer.git --branch v0.7.3
 cd aligned_layer
 ```
 


### PR DESCRIPTION
# Description
When running the operator on new builds, the operator throws the following error
```
error while loading shared libraries: librisc_zero_verifier_ffi.so: cannot open shared object file: No such file or directory
```

References:
https://github.com/mediremi/rust-plus-golang?tab=readme-ov-file
https://github.com/mediremi/rust-plus-golang/blob/97e8444573698bdf2c82316074b112f7d6209e13/Makefile#L12-L15