### PR TITLE
feat(telemetry): modify the aggregator to use the elixir Tracker

### DIFF
--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/yetanotherco/aligned_layer/metrics"
 
-	"github.com/Layr-Labs/eigensdk-go/chainio/clients"
 	sdkclients "github.com/Layr-Labs/eigensdk-go/chainio/clients"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/services/avsregistry"
@@ -86,8 +85,12 @@ type Aggregator struct {
 
 	logger logging.Logger
 
+	// Metrics
 	metricsReg *prometheus.Registry
 	metrics    *metrics.Metrics
+
+	// Telemetry
+	telemetry *Telemetry
 }
 
 func NewAggregator(aggregatorConfig config.AggregatorConfig) (*Aggregator, error) {
@@ -125,7 +128,7 @@ func NewAggregator(aggregatorConfig config.AggregatorConfig) (*Aggregator, error
 	aggregatorPrivateKey := aggregatorConfig.EcdsaConfig.PrivateKey
 
 	logger := aggregatorConfig.BaseConfig.Logger
-	clients, err := clients.BuildAll(chainioConfig, aggregatorPrivateKey, logger)
+	clients, err := sdkclients.BuildAll(chainioConfig, aggregatorPrivateKey, logger)
 	if err != nil {
 		logger.Errorf("Cannot create sdk clients", "err", err)
 		return nil, err
@@ -154,6 +157,9 @@ func NewAggregator(aggregatorConfig config.AggregatorConfig) (*Aggregator, error
 	reg := prometheus.NewRegistry()
 	aggregatorMetrics := metrics.NewMetrics(aggregatorConfig.Aggregator.MetricsIpPortAddress, reg, logger)
 
+	// Telemetry
+	aggregatorTelemetry := NewTelemetry(aggregatorConfig.Aggregator.TelemetryIpPortAddress, logger)
+
 	nextBatchIndex := uint32(0)
 
 	aggregator := Aggregator{
@@ -176,6 +182,7 @@ func NewAggregator(aggregatorConfig config.AggregatorConfig) (*Aggregator, error
 		logger:                logger,
 		metricsReg:            reg,
 		metrics:               aggregatorMetrics,
+		telemetry:             aggregatorTelemetry,
 	}
 
 	return &aggregator, nil
@@ -216,9 +223,19 @@ func (agg *Aggregator) Start(ctx context.Context) error {
 const MaxSentTxRetries = 5
 
 func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsAggregationServiceResponse) {
+	agg.taskMutex.Lock()
+	agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Fetching task data")
+	batchIdentifierHash := agg.batchesIdentifierHashByIdx[blsAggServiceResp.TaskIndex]
+	batchData := agg.batchDataByIdentifierHash[batchIdentifierHash]
+	taskCreatedBlock := agg.batchCreatedBlockByIdx[blsAggServiceResp.TaskIndex]
+	agg.taskMutex.Unlock()
+	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Fetching task data")
+
+	// Finish task trace once the task is processed (either successfully or not)
+	defer agg.telemetry.FinishTrace(batchData.BatchMerkleRoot)
+
 	if blsAggServiceResp.Err != nil {
 		agg.taskMutex.Lock()
-		batchIdentifierHash := agg.batchesIdentifierHashByIdx[blsAggServiceResp.TaskIndex]
 		agg.logger.Error("BlsAggregationServiceResponse contains an error", "err", blsAggServiceResp.Err, "batchIdentifierHash", hex.EncodeToString(batchIdentifierHash[:]))
 		agg.logger.Info("- Locking task mutex: Delete task from operator map", "taskIndex", blsAggServiceResp.TaskIndex)
 
@@ -250,15 +267,11 @@ func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsA
 	}
 
 	agg.taskMutex.Lock()
-	agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Fetching merkle root")
-	batchIdentifierHash := agg.batchesIdentifierHashByIdx[blsAggServiceResp.TaskIndex]
-	batchData := agg.batchDataByIdentifierHash[batchIdentifierHash]
-	taskCreatedBlock := agg.batchCreatedBlockByIdx[blsAggServiceResp.TaskIndex]
 
 	// Delete the task from the map
 	delete(agg.operatorRespondedBatch, blsAggServiceResp.TaskIndex)
 
-	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Fetching merkle root")
+	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Freeing task data")
 	agg.taskMutex.Unlock()
 
 	agg.logger.Info("Threshold reached", "taskIndex", blsAggServiceResp.TaskIndex,
@@ -282,7 +295,7 @@ func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsA
 			agg.logger.Info("Aggregator successfully responded to task",
 				"taskIndex", blsAggServiceResp.TaskIndex,
 				"batchIdentifierHash", "0x"+hex.EncodeToString(batchIdentifierHash[:]))
-				
+
 			return
 		}
 
@@ -330,6 +343,7 @@ func (agg *Aggregator) sendAggregatedResponse(batchIdentifierHash [32]byte, batc
 }
 
 func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, senderAddress [20]byte, taskCreatedBlock uint32) {
+	agg.telemetry.InitNewTrace(batchMerkleRoot)
 	batchIdentifier := append(batchMerkleRoot[:], senderAddress[:]...)
 	var batchIdentifierHash = *(*[32]byte)(crypto.Keccak256(batchIdentifier))
 

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -274,6 +274,8 @@ func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsA
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Freeing task data")
 	agg.taskMutex.Unlock()
 
+	defer agg.telemetry.LogQuorumReached(batchData.BatchMerkleRoot)
+
 	agg.logger.Info("Threshold reached", "taskIndex", blsAggServiceResp.TaskIndex,
 		"batchIdentifierHash", "0x"+hex.EncodeToString(batchIdentifierHash[:]))
 

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -275,7 +275,7 @@ func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsA
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Freeing task data")
 	agg.taskMutex.Unlock()
 
-	defer agg.telemetry.LogQuorumReached(batchData.BatchMerkleRoot)
+	agg.telemetry.LogQuorumReached(batchData.BatchMerkleRoot)
 
 	agg.logger.Info("Threshold reached", "taskIndex", blsAggServiceResp.TaskIndex,
 		"batchIdentifierHash", "0x"+hex.EncodeToString(batchIdentifierHash[:]))

--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -235,6 +235,7 @@ func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsA
 	defer agg.telemetry.FinishTrace(batchData.BatchMerkleRoot)
 
 	if blsAggServiceResp.Err != nil {
+		agg.telemetry.LogTaskError(batchData.BatchMerkleRoot, blsAggServiceResp.Err)
 		agg.taskMutex.Lock()
 		agg.logger.Error("BlsAggregationServiceResponse contains an error", "err", blsAggServiceResp.Err, "batchIdentifierHash", hex.EncodeToString(batchIdentifierHash[:]))
 		agg.logger.Info("- Locking task mutex: Delete task from operator map", "taskIndex", blsAggServiceResp.TaskIndex)

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -54,7 +54,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 		"SenderAddress", "0x"+hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 		"BatchIdentifierHash", "0x"+hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
 		"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
-	defer agg.telemetry.LogOperatorResponse(signedTaskResponse.BatchMerkleRoot, signedTaskResponse.OperatorId)
+	agg.telemetry.LogOperatorResponse(signedTaskResponse.BatchMerkleRoot, signedTaskResponse.OperatorId)
 
 	taskIndex := uint32(0)
 	ok := false

--- a/aggregator/internal/pkg/server.go
+++ b/aggregator/internal/pkg/server.go
@@ -54,6 +54,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 		"SenderAddress", "0x"+hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 		"BatchIdentifierHash", "0x"+hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
 		"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
+	defer agg.telemetry.LogOperatorResponse(signedTaskResponse.BatchMerkleRoot, signedTaskResponse.OperatorId)
 
 	taskIndex := uint32(0)
 	ok := false

--- a/aggregator/internal/pkg/telemetry.go
+++ b/aggregator/internal/pkg/telemetry.go
@@ -1,0 +1,100 @@
+package pkg
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Layr-Labs/eigensdk-go/logging"
+)
+
+type Trace struct {
+	MerkleRoot string `json:"merkle_root"`
+}
+
+type Telemetry struct {
+	client  *http.Client
+	baseURL *url.URL
+	logger  logging.Logger
+}
+
+func NewTelemetry(serverAddress string, logger logging.Logger) *Telemetry {
+	client := &http.Client{}
+
+	baseURL := &url.URL{
+		Scheme: "http",
+		Host:   serverAddress,
+	}
+	logger.Info("[Telemetry] Starting Telemetry client with server address", "server_address",
+		serverAddress)
+
+	return &Telemetry{
+		client:  client,
+		baseURL: baseURL,
+		logger:  logger,
+	}
+}
+
+// Initializes a new trace for the given batchMerkleRoot.
+// User must call FinishTrace() to complete the trace.
+func (t *Telemetry) InitNewTrace(batchMerkleRoot [32]byte) error {
+	merkleRootString := hex.EncodeToString(batchMerkleRoot[:])
+	body := Trace{
+		MerkleRoot: fmt.Sprintf("0x%s", merkleRootString),
+	}
+	encodedBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	t.logger.Info("[Telemetry] Sending init task trace with merkle root", "merkle_root", body.MerkleRoot)
+	return t.sendAndReceiveResponse("/api/initTaskTrace", encodedBody)
+}
+
+// Finishes the trace for the given merkle root and frees resources
+// In order to wait for all operators responses, even if the quorum is reached, this function has a delayed execution
+func (t *Telemetry) FinishTrace(batchMerkleRoot [32]byte) {
+	go func() {
+		time.Sleep(10 * time.Second)
+		merkleRootString := hex.EncodeToString(batchMerkleRoot[:])
+		body := Trace{
+			MerkleRoot: fmt.Sprintf("0x%s", merkleRootString),
+		}
+		encodedBody, err := json.Marshal(body)
+		if err != nil {
+			t.logger.Error("[Telemetry] Error marshalling JSON: %v", err)
+			return
+		}
+		t.logger.Info("[Telemetry] Sending finish task trace with merkle root", "merkle_root", body.MerkleRoot)
+
+		if err := t.sendAndReceiveResponse("/api/finishTaskTrace", encodedBody); err != nil {
+
+			t.logger.Error("[Telemetry] Error finishing trace: %v", err)
+		}
+	}()
+}
+
+// Sends a POST request and processes the response.
+func (t *Telemetry) sendAndReceiveResponse(endpoint string, body []byte) error {
+
+	url := t.baseURL.ResolveReference(&url.URL{Path: endpoint})
+	resp, err := t.client.Post(url.String(), "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("error making POST request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %w", err)
+	}
+
+	t.logger.Info("[Telemetry] Response Status", "status", resp.Status)
+	t.logger.Info("[Telemetry] Response Body", "response_body", string(respBody))
+
+	return nil
+}

--- a/aggregator/internal/pkg/telemetry.go
+++ b/aggregator/internal/pkg/telemetry.go
@@ -92,6 +92,7 @@ func (t *Telemetry) LogTaskError(batchMerkleRoot [32]byte, taskError error) {
 }
 
 func (t *Telemetry) FinishTrace(batchMerkleRoot [32]byte) {
+	// In order to wait for all operator responses, even if the quorum is reached, this function has a delayed execution
 	go func() {
 		time.Sleep(10 * time.Second)
 		body := TraceMessage{

--- a/aggregator/internal/pkg/telemetry.go
+++ b/aggregator/internal/pkg/telemetry.go
@@ -42,17 +42,21 @@ func NewTelemetry(serverAddress string, logger logging.Logger) *Telemetry {
 
 // Initializes a new trace for the given batchMerkleRoot.
 // User must call FinishTrace() to complete the trace.
-func (t *Telemetry) InitNewTrace(batchMerkleRoot [32]byte) error {
+func (t *Telemetry) InitNewTrace(batchMerkleRoot [32]byte) {
 	merkleRootString := hex.EncodeToString(batchMerkleRoot[:])
 	body := Trace{
 		MerkleRoot: fmt.Sprintf("0x%s", merkleRootString),
 	}
 	encodedBody, err := json.Marshal(body)
 	if err != nil {
-		return err
+		t.logger.Error("[Telemetry] Error marshalling JSON: %v", err)
+		return
 	}
 	t.logger.Info("[Telemetry] Sending init task trace with merkle root", "merkle_root", body.MerkleRoot)
-	return t.sendAndReceiveResponse("/api/initTaskTrace", encodedBody)
+	if err := t.sendAndReceiveResponse("/api/initTaskTrace", encodedBody); err != nil {
+
+		t.logger.Error("[Telemetry] Error sending init task trace: %v", err)
+	}
 }
 
 // Finishes the trace for the given merkle root and frees resources

--- a/config-files/config-aggregator.yaml
+++ b/config-files/config-aggregator.yaml
@@ -34,6 +34,7 @@ aggregator:
   avs_service_manager_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
   enable_metrics: true
   metrics_ip_port_address: localhost:9091
+  telemetry_ip_port_address: localhost:4000
 ## Operator Configurations
 # operator:
 #   aggregator_rpc_server_ip_port_address: localhost:8090

--- a/core/config/aggregator.go
+++ b/core/config/aggregator.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"errors"
-	sdkutils "github.com/Layr-Labs/eigensdk-go/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"log"
 	"os"
+
+	sdkutils "github.com/Layr-Labs/eigensdk-go/utils"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type AggregatorConfig struct {
@@ -18,6 +19,7 @@ type AggregatorConfig struct {
 		AvsServiceManagerAddress      common.Address
 		EnableMetrics                 bool
 		MetricsIpPortAddress          string
+		TelemetryIpPortAddress        string
 	}
 }
 
@@ -28,6 +30,7 @@ type AggregatorConfigFromYaml struct {
 		AvsServiceManagerAddress      common.Address `yaml:"avs_service_manager_address"`
 		EnableMetrics                 bool           `yaml:"enable_metrics"`
 		MetricsIpPortAddress          string         `yaml:"metrics_ip_port_address"`
+		TelemetryIpPortAddress        string         `yaml:"telemetry_ip_port_address"`
 	} `yaml:"aggregator"`
 }
 
@@ -68,6 +71,7 @@ func NewAggregatorConfig(configFilePath string) *AggregatorConfig {
 			AvsServiceManagerAddress      common.Address
 			EnableMetrics                 bool
 			MetricsIpPortAddress          string
+			TelemetryIpPortAddress        string
 		}(aggregatorConfigFromYaml.Aggregator),
 	}
 }

--- a/telemetry_api/lib/telemetry_api/traces.ex
+++ b/telemetry_api/lib/telemetry_api/traces.ex
@@ -70,13 +70,6 @@ defmodule TelemetryApi.Traces do
           ]
         )
 
-        ctx = Ctx.get_current()
-
-        TraceStore.store_trace(
-          merkle_root,
-          %{trace | context: ctx}
-        )
-
         IO.inspect(
           "Operator response included. merkle_root: #{IO.inspect(merkle_root)} operator_id: #{IO.inspect(operator_id)}"
         )
@@ -107,13 +100,6 @@ defmodule TelemetryApi.Traces do
         Tracer.add_event(
           "Quorum Reached",
           []
-        )
-
-        ctx = Ctx.get_current()
-
-        TraceStore.store_trace(
-          merkle_root,
-          %{trace | context: ctx}
         )
 
         IO.inspect("Reached quorum registered. merkle_root: #{IO.inspect(merkle_root)}")
@@ -148,13 +134,6 @@ defmodule TelemetryApi.Traces do
             {:status, "error"},
             {:error, error}
           ]
-        )
-
-        ctx = Ctx.get_current()
-
-        TraceStore.store_trace(
-          merkle_root,
-          %{trace | context: ctx}
         )
 
         IO.inspect("Task error registered. merkle_root: #{IO.inspect(merkle_root)}")

--- a/telemetry_api/lib/telemetry_api_web/controllers/trace_controller.ex
+++ b/telemetry_api/lib/telemetry_api_web/controllers/trace_controller.ex
@@ -45,6 +45,18 @@ defmodule TelemetryApiWeb.TraceController do
   end
 
   @doc """
+  Registers an error in the trace of the given merkle_root
+  Method: POST taskError
+  """
+  def task_error(conn, %{"merkle_root" => merkle_root, "error" => error}) do
+    with {:ok, merkle_root} <- Traces.task_error(merkle_root, error) do
+      conn
+      |> put_status(:ok)
+      |> render(:show_merkle, merkle_root: merkle_root)
+    end
+  end
+
+  @doc """
   Finish a trace for the given merkle_root
   Method: POST finishTaskTrace
   """

--- a/telemetry_api/lib/telemetry_api_web/controllers/trace_controller.ex
+++ b/telemetry_api/lib/telemetry_api_web/controllers/trace_controller.ex
@@ -13,7 +13,34 @@ defmodule TelemetryApiWeb.TraceController do
     with {:ok, merkle_root} <- Traces.create_task_trace(merkle_root) do
       conn
       |> put_status(:created)
-      |> render(:show, merkle_root: merkle_root)
+      |> render(:show_merkle, merkle_root: merkle_root)
+    end
+  end
+
+  @doc """
+  Register an operator response in the trace of the given merkle_root
+  Method: POST operatorResponse
+  """
+  def register_operator_response(conn, %{
+        "merkle_root" => merkle_root,
+        "operator_id" => operator_id
+      }) do
+    with {:ok, operator_id} <- Traces.register_operator_response(merkle_root, operator_id) do
+      conn
+      |> put_status(:ok)
+      |> render(:show_operator, operator_id: operator_id)
+    end
+  end
+
+  @doc """
+  Registers a reached quorum in the trace of the given merkle_root
+  Method: POST quorumReached
+  """
+  def quorum_reached(conn, %{"merkle_root" => merkle_root}) do
+    with {:ok, merkle_root} <- Traces.quorum_reached(merkle_root) do
+      conn
+      |> put_status(:ok)
+      |> render(:show_merkle, merkle_root: merkle_root)
     end
   end
 
@@ -25,7 +52,7 @@ defmodule TelemetryApiWeb.TraceController do
     with :ok <- Traces.finish_task_trace(merkle_root) do
       conn
       |> put_status(:ok)
-      |> render(:show, merkle_root: merkle_root)
+      |> render(:show_merkle, merkle_root: merkle_root)
     end
   end
 end

--- a/telemetry_api/lib/telemetry_api_web/controllers/trace_json.ex
+++ b/telemetry_api/lib/telemetry_api_web/controllers/trace_json.ex
@@ -1,11 +1,19 @@
 defmodule TelemetryApiWeb.TraceJSON do
+  @doc """
+
+  """
+  def show_merkle(%{merkle_root: merkle_root}) do
+    %{
+      merkle_root: merkle_root
+    }
+  end
 
   @doc """
 
   """
-  def show(%{merkle_root: merkle_root}) do
+  def show_operator(%{operator_id: operator_id}) do
     %{
-      merkle_root: merkle_root
+      operator_id: operator_id
     }
   end
 end

--- a/telemetry_api/lib/telemetry_api_web/router.ex
+++ b/telemetry_api/lib/telemetry_api_web/router.ex
@@ -10,6 +10,8 @@ defmodule TelemetryApiWeb.Router do
     resources "/operators", OperatorController, only: [:index, :show, :create]
 
     post "/initTaskTrace", TraceController, :create_task_trace
+    post "/operatorResponse", TraceController, :register_operator_response
+    post "/quorumReached", TraceController, :quorum_reached
     post "/finishTaskTrace", TraceController, :finish_task_trace
   end
 

--- a/telemetry_api/lib/telemetry_api_web/router.ex
+++ b/telemetry_api/lib/telemetry_api_web/router.ex
@@ -12,6 +12,7 @@ defmodule TelemetryApiWeb.Router do
     post "/initTaskTrace", TraceController, :create_task_trace
     post "/operatorResponse", TraceController, :register_operator_response
     post "/quorumReached", TraceController, :quorum_reached
+    post "/taskError", TraceController, :task_error
     post "/finishTaskTrace", TraceController, :finish_task_trace
   end
 


### PR DESCRIPTION
**Motivation**

This PR introduces the basic structure for telemetry implementation in the aggregator.

**Description**

- Creates the `Telemetry` struct with the following methods:
    - `InitTaskTrace()`
    - `LogOperatorResponse()`
    - `LogQuorumReached()`
    - `LogTaskError()`
    - `FinishTaskTrace()`
- Each method sends an `HTTP POST` request to the new Elixir Tracker.
- Integrates the `Telemetry` struct into the `Aggregator` and invokes its methods as needed.
- This PR also implements the missing endpoints in the Elixir Tracker.

<img width="647" alt="image" src="https://github.com/user-attachments/assets/b01a4627-93c1-4e82-8f79-8a400d63b06e">
