### PR TITLE
ci: add job to run batcher tests

### DIFF
--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -45,6 +45,13 @@ jobs:
         run: |
           cd batcher
           cargo build --all
+
+  test:
+    runs-on: aligned-runner
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Run tests
         run: |
           cd batcher

--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -52,6 +52,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            batcher/target
+          key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-
       - name: Run tests
         run: |
           cd batcher

--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -1,4 +1,4 @@
-name: build-rust-projects
+name: build-and-test-rust-projects
 
 on:
   merge_group:
@@ -45,13 +45,7 @@ jobs:
         run: |
           cd batcher
           cargo build --all
-
-  batcher-test:
-    runs-on: aligned-runner
-    needs: build
-
-    steps:
-      - name: run-tests
+      - name: Run tests
         run: |
           cd batcher
           cargo test --all

--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -47,7 +47,7 @@ jobs:
           cargo build --all
 
   test:
-    runs-on: aligned-runner
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Checkout code

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -7,13 +7,13 @@ on:
   pull_request:
     branches: ["*"]
     paths:
-        - 'batcher/**'
-        - '.github/workflows/build-rust.yml'
+      - "batcher/**"
+      - ".github/workflows/build-rust.yml"
 
 jobs:
   build:
     runs-on: aligned-runner
-    
+
     steps:
       - uses: actions/checkout@v4
 
@@ -45,3 +45,13 @@ jobs:
         run: |
           cd batcher
           cargo build --all
+
+  batcher-test:
+    runs-on: aligned-runner
+    needs: build
+
+    steps:
+      - name: run-tests
+        run: |
+          cd batcher
+          cargo test --all


### PR DESCRIPTION
Adds a new job to run the tests of the batcher written in Rust.

This closes #1047.