### PR TITLE
feat(sdk): Add Max Fee Estimate. Update zkQuiz to better represent how the SDK should be used

### DIFF
--- a/batcher/Cargo.lock
+++ b/batcher/Cargo.lock
@@ -128,6 +128,7 @@ name = "aligned-sdk"
 version = "0.1.0"
 dependencies = [
  "ciborium",
+ "dialoguer",
  "ethers 2.0.14 (git+https://github.com/yetanotherco/ethers-rs.git?tag=v2.0.15-fix-reconnections)",
  "futures-util",
  "hex",
@@ -191,7 +192,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -207,7 +208,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -223,7 +224,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn-solidity",
 ]
 
@@ -575,13 +576,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -609,20 +610,20 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848d7b9b605720989929279fa644ce8f244d0ce3146fcca5b70e4eb7b3c020fc"
+checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -688,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.49.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e518950d4ac43508c8bfc2fe4e24b0752d99eab80134461d5e162dcda0214b55"
+checksum = "f571deb0a80c20d21d9f3e8418c1712af9ff4bf399d057e5549a934eca4844e2"
 dependencies = [
  "ahash",
  "aws-credential-types",
@@ -723,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.42.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bf24cd0d389daa923e974b0e7c38daf308fc21e963c049f57980235017175e"
+checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -745,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.43.0"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43b3220f1c46ac0e9dcc0a97d94b93305dacb36d1dd393996300c6b9b74364"
+checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -767,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.42.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c46924fb1add65bba55636e12812cae2febf68c0f37361766f627ddcca91ce"
+checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -946,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03701449087215b5369c7ea17fef0dd5d24cb93439ec5af0c7615f58c3f22605"
+checksum = "147100a7bea70fa20ef224a6bad700358305f5dc0f84649c53769761395b355b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1029,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1042,7 +1043,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1144,7 +1145,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.77",
+ "syn 2.0.79",
  "which",
 ]
 
@@ -1264,7 +1265,7 @@ name = "bonsai-sdk"
 version = "0.8.0"
 source = "git+https://github.com/risc0/risc0?tag=v1.0.1#79de616506543634cb5d75b9db7f3aee3640d68c"
 dependencies = [
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "risc0-groth16",
  "serde",
  "thiserror",
@@ -1309,7 +1310,7 @@ checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1320,9 +1321,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde",
 ]
@@ -1392,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.20"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "jobserver",
  "libc",
@@ -1479,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1489,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1501,14 +1502,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1596,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1771,7 +1772,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1795,7 +1796,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1806,7 +1807,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1866,7 +1867,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.77",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -2296,7 +2310,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.79",
  "toml",
  "walkdir",
 ]
@@ -2319,7 +2333,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.79",
  "toml",
  "walkdir",
 ]
@@ -2337,7 +2351,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2352,7 +2366,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2378,7 +2392,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.77",
+ "syn 2.0.79",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2407,7 +2421,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.77",
+ "syn 2.0.79",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2715,9 +2729,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2835,7 +2849,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3277,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -3369,7 +3383,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -3390,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3403,7 +3417,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -3646,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9",
@@ -3690,7 +3703,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3704,7 +3717,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
 ]
 
 [[package]]
@@ -3746,9 +3759,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libgit2-sys"
@@ -4099,7 +4112,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4128,9 +4141,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oneshot"
@@ -4192,7 +4208,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4674,9 +4690,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4733,7 +4749,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4771,7 +4787,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4808,15 +4824,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "postcard"
@@ -4858,7 +4874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4877,9 +4893,9 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560bcab673ff7f6ca9e270c17bf3affd8a05e3bd9207f123b0d45076fd8197e8"
+checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
 dependencies = [
  "autocfg",
  "equivalent",
@@ -4902,7 +4918,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.21",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -4952,7 +4968,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -4978,7 +4994,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5129,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -5149,14 +5165,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5170,13 +5186,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5193,9 +5209,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -5240,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5268,7 +5284,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.13",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5285,7 +5301,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
  "windows-registry",
 ]
 
@@ -5298,7 +5314,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.1.0",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "serde",
  "thiserror",
  "tower-service",
@@ -5690,19 +5706,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -5793,9 +5808,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.17"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c947adb109a8afce5fc9c7bf951f87f146e9147b3a6a58413105628fb1d1e66"
+checksum = "836f1e0f4963ef5288b539b643b35e043e76a32d0f4e47e67febf69576527f50"
 dependencies = [
  "sdd",
 ]
@@ -5886,9 +5901,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5959,7 +5974,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5992,14 +6007,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -6043,7 +6058,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6081,7 +6096,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6146,6 +6161,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -6547,7 +6568,7 @@ dependencies = [
  "p3-fri",
  "p3-matrix",
  "prost",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -6654,7 +6675,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6705,9 +6726,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6723,7 +6744,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6806,9 +6827,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -6830,22 +6851,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6941,7 +6962,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7017,7 +7038,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tungstenite 0.23.0",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -7042,7 +7063,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.21",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -7067,15 +7088,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -7126,7 +7147,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7280,7 +7301,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "prost",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "serde",
  "serde_json",
  "thiserror",
@@ -7297,9 +7318,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -7342,15 +7363,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -7508,7 +7529,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -7542,7 +7563,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7555,9 +7576,9 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -7594,9 +7615,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.5"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7852,9 +7873,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -7927,7 +7948,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7947,7 +7968,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -15,10 +15,18 @@ use std::iter::repeat;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use aligned_sdk::core::types::{
-    BatchInclusionData, ClientMessage, NoncedVerificationData, ResponseMessage,
-    ValidityResponseMessage, VerificationCommitmentBatch, VerificationData,
-    VerificationDataCommitment,
+use aligned_sdk::core::{
+    constants::{
+        ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF, AGGREGATOR_GAS_COST, CONSTANT_GAS_COST,
+        DEFAULT_AGGREGATOR_FEE_DIVIDER, DEFAULT_AGGREGATOR_FEE_MULTIPLIER,
+        DEFAULT_MAX_FEE_PER_PROOF, MIN_FEE_PER_PROOF, RESPOND_TO_TASK_FEE_LIMIT_DIVIDER,
+        RESPOND_TO_TASK_FEE_LIMIT_MULTIPLIER,
+    },
+    types::{
+        BatchInclusionData, ClientMessage, NoncedVerificationData, ResponseMessage,
+        ValidityResponseMessage, VerificationCommitmentBatch, VerificationData,
+        VerificationDataCommitment,
+    },
 };
 use aws_sdk_s3::client::Client as S3Client;
 use eth::{try_create_new_task, BatcherPaymentService, CreateNewTaskFeeParams, SignerMiddlewareT};
@@ -48,20 +56,6 @@ pub mod s3;
 pub mod sp1;
 pub mod types;
 mod zk_utils;
-
-const AGGREGATOR_GAS_COST: u128 = 400_000;
-const BATCHER_SUBMISSION_BASE_GAS_COST: u128 = 125_000;
-pub(crate) const ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF: u128 = 13_000;
-pub(crate) const CONSTANT_GAS_COST: u128 =
-    ((AGGREGATOR_GAS_COST * DEFAULT_AGGREGATOR_FEE_MULTIPLIER) / DEFAULT_AGGREGATOR_FEE_DIVIDER)
-        + BATCHER_SUBMISSION_BASE_GAS_COST;
-
-const DEFAULT_MAX_FEE_PER_PROOF: u128 = ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * 100_000_000_000; // gas_price = 100 Gwei = 0.0000001 ether (high gas price)
-const MIN_FEE_PER_PROOF: u128 = ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * 100_000_000; // gas_price = 0.1 Gwei = 0.0000000001 ether (low gas price)
-const RESPOND_TO_TASK_FEE_LIMIT_MULTIPLIER: u128 = 5; // to set the respondToTaskFeeLimit variable higher than fee_for_aggregator
-const RESPOND_TO_TASK_FEE_LIMIT_DIVIDER: u128 = 2;
-const DEFAULT_AGGREGATOR_FEE_MULTIPLIER: u128 = 3; // to set the feeForAggregator variable higher than what was calculated
-const DEFAULT_AGGREGATOR_FEE_DIVIDER: u128 = 2;
 
 struct BatchState {
     batch_queue: BatchQueue,

--- a/batcher/aligned-sdk/Cargo.toml
+++ b/batcher/aligned-sdk/Cargo.toml
@@ -4,16 +4,28 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ethers = { tag = "v2.0.15-fix-reconnections", features = ["ws", "rustls", "eip712"], git = "https://github.com/yetanotherco/ethers-rs.git" }
-log = { version = "0.4.21"}
+ethers = { tag = "v2.0.15-fix-reconnections", features = [
+    "ws",
+    "rustls",
+    "eip712",
+], git = "https://github.com/yetanotherco/ethers-rs.git" }
+log = { version = "0.4.21" }
 serde_json = "1.0.117"
 tokio-tungstenite = { version = "0.23.1", features = ["native-tls"] }
 futures-util = "0.3.30"
-tokio = { version = "1.37.0", features = ["io-std", "time", "macros", "rt", "rt-multi-thread", "sync"] }
+tokio = { version = "1.37.0", features = [
+    "io-std",
+    "time",
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+] }
 lambdaworks-crypto = { version = "0.7.0", features = ["serde"] }
 serde = { version = "1.0.201", features = ["derive"] }
-sha3 = { version = "0.10.8"}
+sha3 = { version = "0.10.8" }
 url = "2.5.0"
 hex = "0.4.3"
 ciborium = "=0.2.2"
 serde_repr = "0.1.19"
+dialoguer = "0.11.0"

--- a/batcher/aligned-sdk/src/core/constants.rs
+++ b/batcher/aligned-sdk/src/core/constants.rs
@@ -14,9 +14,10 @@ pub const DEFAULT_AGGREGATOR_FEE_MULTIPLIER: u128 = 3; // to set the feeForAggre
 pub const DEFAULT_AGGREGATOR_FEE_DIVIDER: u128 = 2;
 
 /// SDK ///
-/// Estimated number of proofs in batch for computing instant batch submission.
-/// This is the number of proofs in a batch of size n i.e. the user pays for the entire batch.
-pub const MAX_FEE_INSTANT_PROOF_NUMBER: usize = 32;
+/// Number of proofs we a batch for estimation.
+/// This is the number of proofs in a batch of size n, where we set n = 32.
+/// i.e. the user pays for the entire batch and his proof is instantly submitted.
+pub const MAX_FEE_BATCH_PROOF_NUMBER: usize = 32;
 /// Estimated number of proofs for batch submission.
 /// This corresponds to the number of proofs to compute for a default max_fee.
 pub const MAX_FEE_DEFAULT_PROOF_NUMBER: usize = 10;

--- a/batcher/aligned-sdk/src/core/constants.rs
+++ b/batcher/aligned-sdk/src/core/constants.rs
@@ -1,0 +1,20 @@
+/// Batcher ///
+pub const AGGREGATOR_GAS_COST: u128 = 400_000;
+pub const BATCHER_SUBMISSION_BASE_GAS_COST: u128 = 125_000;
+pub const ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF: u128 = 13_000;
+pub const CONSTANT_GAS_COST: u128 = ((AGGREGATOR_GAS_COST * DEFAULT_AGGREGATOR_FEE_MULTIPLIER)
+    / DEFAULT_AGGREGATOR_FEE_DIVIDER)
+    + BATCHER_SUBMISSION_BASE_GAS_COST;
+pub const DEFAULT_MAX_FEE_PER_PROOF: u128 =
+    ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * 100_000_000_000; // gas_price = 100 Gwei = 0.0000001 ether (high gas price)
+pub const MIN_FEE_PER_PROOF: u128 = ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * 100_000_000; // gas_price = 0.1 Gwei = 0.0000000001 ether (low gas price)
+pub const RESPOND_TO_TASK_FEE_LIMIT_MULTIPLIER: u128 = 5; // to set the respondToTaskFeeLimit variable higher than fee_for_aggregator
+pub const RESPOND_TO_TASK_FEE_LIMIT_DIVIDER: u128 = 2;
+pub const DEFAULT_AGGREGATOR_FEE_MULTIPLIER: u128 = 3; // to set the feeForAggregator variable higher than what was calculated
+pub const DEFAULT_AGGREGATOR_FEE_DIVIDER: u128 = 2;
+
+/// SDK ///
+/// Estimated number of proofs for instant batch submission.
+pub const MAX_FEE_INSTANT_BATCH_SIZE: usize = 32;
+/// Estimated number of proofs for instant batch submission.
+pub const MAX_FEE_DEFAULT_BATCH_SIZE: usize = 10;

--- a/batcher/aligned-sdk/src/core/constants.rs
+++ b/batcher/aligned-sdk/src/core/constants.rs
@@ -14,7 +14,9 @@ pub const DEFAULT_AGGREGATOR_FEE_MULTIPLIER: u128 = 3; // to set the feeForAggre
 pub const DEFAULT_AGGREGATOR_FEE_DIVIDER: u128 = 2;
 
 /// SDK ///
-/// Estimated number of proofs for instant batch submission.
-pub const MAX_FEE_INSTANT_BATCH_SIZE: usize = 32;
-/// Estimated number of proofs for instant batch submission.
-pub const MAX_FEE_DEFAULT_BATCH_SIZE: usize = 10;
+/// Estimated number of proofs in batch for computing instant batch submission.
+/// This is the number of proofs in a batch of size n i.e. the user pays for the entire batch.
+pub const MAX_FEE_INSTANT_PROOF_NUMBER: usize = 32;
+/// Estimated number of proofs for batch submission.
+/// This corresponds to the number of proofs to compute for a default max_fee.
+pub const MAX_FEE_DEFAULT_PROOF_NUMBER: usize = 10;

--- a/batcher/aligned-sdk/src/core/errors.rs
+++ b/batcher/aligned-sdk/src/core/errors.rs
@@ -15,6 +15,7 @@ pub enum AlignedError {
     VerificationError(VerificationError),
     NonceError(NonceError),
     ChainIdError(ChainIdError),
+    MaxFeeEstimateError(MaxFeeEstimateError),
 }
 
 impl From<SubmitError> for AlignedError {
@@ -41,6 +42,12 @@ impl From<ChainIdError> for AlignedError {
     }
 }
 
+impl From<MaxFeeEstimateError> for AlignedError {
+    fn from(e: MaxFeeEstimateError) -> Self {
+        AlignedError::MaxFeeEstimateError(e)
+    }
+}
+
 impl fmt::Display for AlignedError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -48,6 +55,7 @@ impl fmt::Display for AlignedError {
             AlignedError::VerificationError(e) => write!(f, "Verification error: {}", e),
             AlignedError::NonceError(e) => write!(f, "Nonce error: {}", e),
             AlignedError::ChainIdError(e) => write!(f, "Chain ID error: {}", e),
+            AlignedError::MaxFeeEstimateError(e) => write!(f, "Max fee estimate error: {}", e),
         }
     }
 }
@@ -247,6 +255,25 @@ impl fmt::Display for ChainIdError {
                 write!(f, "Ethereum provider error: {}", e)
             }
             ChainIdError::EthereumCallError(e) => write!(f, "Ethereum call error: {}", e),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum MaxFeeEstimateError {
+    EthereumProviderError(String),
+    EthereumGasPriceError(String),
+}
+
+impl fmt::Display for MaxFeeEstimateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MaxFeeEstimateError::EthereumProviderError(e) => {
+                write!(f, "Ethereum provider error: {}", e)
+            }
+            MaxFeeEstimateError::EthereumGasPriceError(e) => {
+                write!(f, "Failed to retreive the current gas price: {}", e)
+            }
         }
     }
 }

--- a/batcher/aligned-sdk/src/core/types.rs
+++ b/batcher/aligned-sdk/src/core/types.rs
@@ -71,6 +71,14 @@ impl NoncedVerificationData {
     }
 }
 
+// Defines an estimate price preference for the user.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum PriceEstimate {
+    Min,
+    Default,
+    Instant,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct VerificationDataCommitment {
     pub proof_commitment: [u8; 32],

--- a/batcher/aligned-sdk/src/lib.rs
+++ b/batcher/aligned-sdk/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod core {
+    pub mod constants;
     pub mod errors;
     pub mod types;
 }

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -114,7 +114,7 @@ pub async fn submit_multiple_and_wait_verification(
 /// # Errors
 /// * `EthereumProviderError` if there is an error in the connection with the RPC provider.
 /// * `EthereumGasPriceError` if there is an error retrieving the Ethereum gas price.
-pub async fn estimate_max_fee(
+pub async fn estimate_fee(
     eth_rpc_url: &str,
     estimate: PriceEstimate,
 ) -> Result<U256, errors::MaxFeeEstimateError> {
@@ -613,14 +613,14 @@ mod test {
     }
 
     #[tokio::test]
-    async fn estimate_max_fee_are_larger_than_one_another() {
-        let min_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Min)
+    async fn estimate_fee_are_larger_than_one_another() {
+        let min_fee = estimate_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Min)
             .await
             .unwrap();
-        let default_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Default)
+        let default_fee = estimate_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Default)
             .await
             .unwrap();
-        let instant_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Instant)
+        let instant_fee = estimate_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Instant)
             .await
             .unwrap();
 

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -115,11 +115,11 @@ pub async fn submit_multiple_and_wait_verification(
 /// * `EthereumProviderError` if there is an error in the connection with the RPC provider.
 /// * `EthereumGasPriceError` if there is an error retrieving the Ethereum gas price.
 pub async fn estimate_max_fee(
-    eth_rpc_provider: &Provider<Http>,
+    eth_rpc_url: &str,
     estimate: PriceEstimate,
 ) -> Result<U256, errors::MaxFeeEstimateError> {
     // Price of 1 proof in 32 proof batch
-    let fee_per_proof = fee_per_proof(eth_rpc_provider, MAX_FEE_INSTANT_BATCH_SIZE).await?;
+    let fee_per_proof = fee_per_proof(eth_rpc_url, MAX_FEE_INSTANT_BATCH_SIZE).await?;
 
     let proof_price = match estimate {
         PriceEstimate::Min => fee_per_proof,
@@ -142,7 +142,7 @@ pub async fn estimate_max_fee(
 /// * `EthereumProviderError` if there is an error in the connection with the RPC provider.
 /// * `EthereumGasPriceError` if there is an error retrieving the Ethereum gas price.
 pub async fn compute_max_fee(
-    eth_rpc_url: &Provider<Http>,
+    eth_rpc_url: &str,
     num_proofs: usize,
     num_proofs_per_batch: usize,
 ) -> Result<U256, errors::MaxFeeEstimateError> {
@@ -162,10 +162,14 @@ pub async fn compute_max_fee(
 /// * `EthereumProviderError` if there is an error in the connection with the RPC provider.
 /// * `EthereumGasPriceError` if there is an error retrieving the Ethereum gas price.
 pub async fn fee_per_proof(
-    eth_rpc_provider: &Provider<Http>,
+    eth_rpc_url: &str,
     num_proofs_per_batch: usize,
 ) -> Result<U256, errors::MaxFeeEstimateError> {
-    let gas_price = fetch_gas_price(eth_rpc_provider).await?;
+    let eth_rpc_provider =
+        Provider::<Http>::try_from(eth_rpc_url).map_err(|e: url::ParseError| {
+            errors::MaxFeeEstimateError::EthereumProviderError(e.to_string())
+        })?;
+    let gas_price = fetch_gas_price(&eth_rpc_provider).await?;
 
     // Cost for estimate `num_proofs_per_batch` proofs
     let estimated_gas_per_proof = (CONSTANT_GAS_COST
@@ -586,44 +590,37 @@ mod test {
 
     #[tokio::test]
     async fn computed_max_fee_for_larger_batch_is_smaller() {
-        let eth_rpc_provider = Provider::<Http>::try_from(HOLESKY_PUBLIC_RPC_URL)
-            .map_err(|e: url::ParseError| {
-                errors::MaxFeeEstimateError::EthereumProviderError(e.to_string())
-            })
+        let small_fee = compute_max_fee(HOLESKY_PUBLIC_RPC_URL, 2, 10)
+            .await
             .unwrap();
-        let small_fee = compute_max_fee(&eth_rpc_provider, 2, 10).await.unwrap();
-        let large_fee = compute_max_fee(&eth_rpc_provider, 5, 10).await.unwrap();
+        let large_fee = compute_max_fee(HOLESKY_PUBLIC_RPC_URL, 5, 10)
+            .await
+            .unwrap();
 
         assert!(small_fee < large_fee);
     }
 
     #[tokio::test]
     async fn computed_max_fee_for_more_proofs_larger_than_for_less_proofs() {
-        let eth_rpc_provider = Provider::<Http>::try_from(HOLESKY_PUBLIC_RPC_URL)
-            .map_err(|e: url::ParseError| {
-                errors::MaxFeeEstimateError::EthereumProviderError(e.to_string())
-            })
+        let small_fee = compute_max_fee(HOLESKY_PUBLIC_RPC_URL, 5, 20)
+            .await
             .unwrap();
-        let small_fee = compute_max_fee(&eth_rpc_provider, 5, 20).await.unwrap();
-        let large_fee = compute_max_fee(&eth_rpc_provider, 5, 10).await.unwrap();
+        let large_fee = compute_max_fee(HOLESKY_PUBLIC_RPC_URL, 5, 10)
+            .await
+            .unwrap();
 
         assert!(small_fee < large_fee);
     }
 
     #[tokio::test]
     async fn estimate_max_fee_are_larger_than_one_another() {
-        let eth_rpc_provider = Provider::<Http>::try_from(HOLESKY_PUBLIC_RPC_URL)
-            .map_err(|e: url::ParseError| {
-                errors::MaxFeeEstimateError::EthereumProviderError(e.to_string())
-            })
-            .unwrap();
-        let min_fee = estimate_max_fee(&eth_rpc_provider, PriceEstimate::Min)
+        let min_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Min)
             .await
             .unwrap();
-        let default_fee = estimate_max_fee(&eth_rpc_provider, PriceEstimate::Default)
+        let default_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Default)
             .await
             .unwrap();
-        let instant_fee = estimate_max_fee(&eth_rpc_provider, PriceEstimate::Instant)
+        let instant_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Instant)
             .await
             .unwrap();
 

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -7,7 +7,7 @@ use crate::{
     core::{
         constants::{
             ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF, CONSTANT_GAS_COST,
-            MAX_FEE_DEFAULT_BATCH_SIZE, MAX_FEE_INSTANT_BATCH_SIZE,
+            MAX_FEE_BATCH_PROOF_NUMBER, MAX_FEE_DEFAULT_PROOF_NUMBER,
         },
         errors,
         types::{
@@ -119,17 +119,17 @@ pub async fn estimate_fee(
     estimate: PriceEstimate,
 ) -> Result<U256, errors::MaxFeeEstimateError> {
     // Price of 1 proof in 32 proof batch
-    let fee_per_proof = fee_per_proof(eth_rpc_url, MAX_FEE_INSTANT_BATCH_SIZE).await?;
+    let fee_per_proof = fee_per_proof(eth_rpc_url, MAX_FEE_BATCH_PROOF_NUMBER).await?;
 
     let proof_price = match estimate {
         PriceEstimate::Min => fee_per_proof,
-        PriceEstimate::Default => U256::from(MAX_FEE_DEFAULT_BATCH_SIZE) * fee_per_proof,
-        PriceEstimate::Instant => U256::from(MAX_FEE_INSTANT_BATCH_SIZE) * fee_per_proof,
+        PriceEstimate::Default => U256::from(MAX_FEE_DEFAULT_PROOF_NUMBER) * fee_per_proof,
+        PriceEstimate::Instant => U256::from(MAX_FEE_BATCH_PROOF_NUMBER) * fee_per_proof,
     };
     Ok(proof_price)
 }
 
-/// Returns the compute `max_fee` for a proof based on the number of proofs in a batch (`num_proofs_per_batch`) and
+/// Returns the computed `max_fee` for a proof based on the number of proofs in a batch (`num_proofs_per_batch`) and
 /// number of proofs (`num_proofs`) in that batch the user would pay for i.e (`num_proofs` / `num_proofs_per_batch`).
 /// NOTE: The `max_fee` is computed from an rpc nodes max priority gas price.
 /// # Arguments

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -5,9 +5,13 @@ use crate::{
         protocol::check_protocol_version,
     },
     core::{
+        constants::{
+            ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF, CONSTANT_GAS_COST,
+            MAX_FEE_DEFAULT_BATCH_SIZE, MAX_FEE_INSTANT_BATCH_SIZE,
+        },
         errors,
         types::{
-            AlignedVerificationData, Network, ProvingSystemId, VerificationData,
+            AlignedVerificationData, Network, PriceEstimate, ProvingSystemId, VerificationData,
             VerificationDataCommitment,
         },
     },
@@ -90,6 +94,107 @@ pub async fn submit_multiple_and_wait_verification(
     }
 
     Ok(aligned_verification_data)
+}
+
+/// Returns the estimated `max_fee` depending on the batch inclusion preference of the user, based on the max priority gas price.
+/// NOTE: The `max_fee` is computed from an rpc nodes max priority gas price.
+/// To estimate the `max_fee` of a batch we use a compute the `max_fee` with respect to a batch of ~32 proofs present.
+/// The `max_fee` estimates therefore are:
+/// * `Min`: Specifies a `max_fee` equivalent to the cost of 1 proof in a 32 proof batch.
+///        This estimates the lowest possible `max_fee` the user should specify for there proof with lowest priority.
+/// * `Default`: Specifies a `max_fee` equivalent to the cost of 10 proofs in a 32 proof batch.
+///        This estimates the `max_fee` the user should specify for inclusion within the batch.
+/// * `Instant`: specifies a `max_fee` equivalent to the cost of all proofs within in a 32 proof batch.
+///        This estimates the `max_fee` the user should specify to pay for the entire batch of proofs and have there proof included instantly.
+/// # Arguments
+/// * `eth_rpc_url` - The URL of the Ethereum RPC node.
+/// * `estimate` - Enum specifying the type of price estimate: MIN, DEFAULT, INSTANT.
+/// # Returns
+/// The estimated `max_fee` in gas for a proof based on the users `PriceEstimate` as a `U256`.
+/// # Errors
+/// * `EthereumProviderError` if there is an error in the connection with the RPC provider.
+/// * `EthereumGasPriceError` if there is an error retrieving the Ethereum gas price.
+pub async fn estimate_max_fee(
+    eth_rpc_url: &str,
+    estimate: PriceEstimate,
+) -> Result<U256, errors::MaxFeeEstimateError> {
+    // Price of 1 proof in 32 proof batch
+    let fee_per_proof = fee_per_proof(eth_rpc_url, MAX_FEE_INSTANT_BATCH_SIZE).await?;
+
+    let proof_price = match estimate {
+        PriceEstimate::Min => fee_per_proof,
+        PriceEstimate::Default => U256::from(MAX_FEE_DEFAULT_BATCH_SIZE) * fee_per_proof,
+        PriceEstimate::Instant => U256::from(MAX_FEE_INSTANT_BATCH_SIZE) * fee_per_proof,
+    };
+    Ok(proof_price)
+}
+
+/// Returns the compute `max_fee` for a proof based on the number of proofs in a batch (`num_proofs_per_batch`) and
+/// number of proofs (`num_proofs`) in that batch the user would pay for i.e (`num_proofs` / `num_proofs_per_batch`).
+/// NOTE: The `max_fee` is computed from an rpc nodes max priority gas price.
+/// # Arguments
+/// * `eth_rpc_url` - The URL of the users Ethereum RPC node.
+/// * `num_proofs` - number of proofs in a batch the user would pay for.
+/// * `num_proofs_per_batch` - number of proofs within a batch.
+/// # Returns
+/// * The calculated `max_fee` as a `U256`.
+/// # Errors
+/// * `EthereumProviderError` if there is an error in the connection with the RPC provider.
+/// * `EthereumGasPriceError` if there is an error retrieving the Ethereum gas price.
+pub async fn compute_max_fee(
+    eth_rpc_url: &str,
+    num_proofs: usize,
+    num_proofs_per_batch: usize,
+) -> Result<U256, errors::MaxFeeEstimateError> {
+    let fee_per_proof = fee_per_proof(eth_rpc_url, num_proofs_per_batch).await?;
+    Ok(fee_per_proof * num_proofs)
+}
+
+/// Returns the `fee_per_proof` based on the current gas price for a batch compromised of `num_proofs_per_batch`
+/// i.e. (1 / `num_proofs_per_batch`).
+// NOTE: The `fee_per_proof` is computed from an rpc nodes max priority gas price.
+/// # Arguments
+/// * `eth_rpc_url` - The URL of the users Ethereum RPC node.
+/// * `num_proofs_per_batch` - number of proofs within a batch.
+/// # Returns
+/// * The fee per proof of a batch as a `U256`.
+/// # Errors
+/// * `EthereumProviderError` if there is an error in the connection with the RPC provider.
+/// * `EthereumGasPriceError` if there is an error retrieving the Ethereum gas price.
+pub async fn fee_per_proof(
+    eth_rpc_url: &str,
+    num_proofs_per_batch: usize,
+) -> Result<U256, errors::MaxFeeEstimateError> {
+    let eth_rpc_provider =
+        Provider::<Http>::try_from(eth_rpc_url).map_err(|e: url::ParseError| {
+            errors::MaxFeeEstimateError::EthereumProviderError(e.to_string())
+        })?;
+    let gas_price = fetch_gas_price(&eth_rpc_provider).await?;
+
+    // Cost for estimate `num_proofs_per_batch` proofs
+    let estimated_gas_per_proof = (CONSTANT_GAS_COST
+        + ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * num_proofs_per_batch as u128)
+        / num_proofs_per_batch as u128;
+
+    // Price of 1 proof in 32 proof batch
+    let fee_per_proof = U256::from(estimated_gas_per_proof) * gas_price;
+
+    Ok(fee_per_proof)
+}
+
+async fn fetch_gas_price(
+    eth_rpc_provider: &Provider<Http>,
+) -> Result<U256, errors::MaxFeeEstimateError> {
+    let gas_price = match eth_rpc_provider.get_gas_price().await {
+        Ok(price) => price,
+        Err(e) => {
+            return Err(errors::MaxFeeEstimateError::EthereumGasPriceError(
+                e.to_string(),
+            ))
+        }
+    };
+
+    Ok(gas_price)
 }
 
 /// Submits multiple proofs to the batcher to be verified in Aligned.
@@ -475,4 +580,51 @@ pub async fn get_chain_id(eth_rpc_url: &str) -> Result<u64, errors::ChainIdError
         .map_err(|e| errors::ChainIdError::EthereumCallError(e.to_string()))?;
 
     Ok(chain_id.as_u64())
+}
+
+#[cfg(test)]
+mod test {
+    //Public constants for convenience
+    pub const HOLESKY_PUBLIC_RPC_URL: &str = "https://ethereum-holesky-rpc.publicnode.com";
+    use super::*;
+
+    #[tokio::test]
+    async fn computed_max_fee_for_larger_batch_is_smaller() {
+        let small_fee = compute_max_fee(HOLESKY_PUBLIC_RPC_URL, 2, 10)
+            .await
+            .unwrap();
+        let large_fee = compute_max_fee(HOLESKY_PUBLIC_RPC_URL, 5, 10)
+            .await
+            .unwrap();
+
+        assert!(small_fee < large_fee);
+    }
+
+    #[tokio::test]
+    async fn computed_max_fee_for_more_proofs_larger_than_for_less_proofs() {
+        let small_fee = compute_max_fee(HOLESKY_PUBLIC_RPC_URL, 5, 20)
+            .await
+            .unwrap();
+        let large_fee = compute_max_fee(HOLESKY_PUBLIC_RPC_URL, 5, 10)
+            .await
+            .unwrap();
+
+        assert!(small_fee < large_fee);
+    }
+
+    #[tokio::test]
+    async fn estimate_max_fee_are_larger_than_one_another() {
+        let min_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Min)
+            .await
+            .unwrap();
+        let default_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Default)
+            .await
+            .unwrap();
+        let instant_fee = estimate_max_fee(HOLESKY_PUBLIC_RPC_URL, PriceEstimate::Instant)
+            .await
+            .unwrap();
+
+        assert!(min_fee < default_fee);
+        assert!(default_fee < instant_fee);
+    }
 }

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -165,7 +165,7 @@ pub async fn fee_per_proof(
     eth_rpc_provider: &Provider<Http>,
     num_proofs_per_batch: usize,
 ) -> Result<U256, errors::MaxFeeEstimateError> {
-    let gas_price = fetch_gas_price(&eth_rpc_provider).await?;
+    let gas_price = fetch_gas_price(eth_rpc_provider).await?;
 
     // Cost for estimate `num_proofs_per_batch` proofs
     let estimated_gas_per_proof = (CONSTANT_GAS_COST

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -302,3 +302,14 @@ wallet = wallet.with_chain_id(chain_id);
 
 - `EthereumProviderError` if there is an error in the connection with the RPC provider.
 - `EthereumCallError` if there is an error in the Ethereum call.
+
+## `estimate_fee`
+
+Estimates the fee the user would have to pay for submitting a proof to Aligned. Depending on the
+priority the user wants to have in the batch, the `estimate` parameter can be set.
+
+### Arguments
+
+- `eth_rpc_url` - The URL of the Ethereum RPC node.
+- `estimate` - The parameter to set the priority for the proof to be included in the batch. It can be one
+of `Min`, `Default` or `Max`.

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -308,8 +308,76 @@ wallet = wallet.with_chain_id(chain_id);
 Estimates the fee the user would have to pay for submitting a proof to Aligned. Depending on the
 priority the user wants to have in the batch, the `estimate` parameter can be set.
 
+```rust
+pub async fn estimate_fee(
+    eth_rpc_url: &str,
+    estimate: PriceEstimate,
+) -> Result<U256, errors::MaxFeeEstimateError>
+```
+
 ### Arguments
 
 - `eth_rpc_url` - The URL of the Ethereum RPC node.
 - `estimate` - The parameter to set the priority for the proof to be included in the batch. It can be one
-of `Min`, `Default` or `Max`.
+  of `Min`, `Default` or `Max`.
+
+#### Returns
+
+- `Result<U256, MaxFeeEstimateError>` - the estimated `max_fee` depending on the batch inclusion preference of the user.
+
+#### Errors
+
+- `EthereumProviderError` if there is an error in the connection with the RPC provider.
+- `EthereumCallError` if there is an error in the Ethereum call.
+
+## `compute_max_fee`
+
+Computes `max_fee` for a proof based on the number of proofs in a batch (`num_proofs_per_batch`) and number of proofs (`num_proofs`) in that batch the user would pay for i.e (`num_proofs` / `num_proofs_per_batch`).
+
+```rust
+pub async fn compute_max_fee(
+    eth_rpc_url: &str,
+    num_proofs: usize,
+    num_proofs_per_batch: usize,
+) -> Result<U256, errors::MaxFeeEstimateError>
+```
+
+### Arguments
+
+- `eth_rpc_url` - The URL of the Ethereum RPC node.
+- `num_proofs` - The number of proofs in a batch the user would pay for.
+- `num_proofs_per_batch` - The number of proofs within a batch.
+
+#### Returns
+
+- `Result<U256, MaxFeeEstimateError>` - The calculated `max_fee` as a `U256`.
+
+#### Errors
+
+- `EthereumProviderError` if there is an error in the connection with the RPC provider.
+- `EthereumCallError` if there is an error in the Ethereum call.
+
+## `fee_per_proof`
+
+Returns the `fee_per_proof` based on the current gas price for a batch compromised of `num_proofs_per_batch` i.e. (1 / `num_proofs_per_batch`).
+
+```rust
+pub async fn fee_per_proof(
+    eth_rpc_url: &str,
+    num_proofs_per_batch: usize,
+) -> Result<U256, errors::MaxFeeEstimateError>
+```
+
+### Arguments
+
+- `eth_rpc_url` - The URL of the users Ethereum RPC node.
+- `num_proofs_per_batch` - The number of proofs within a batch.
+
+#### Returns
+
+- `Result<U256, MaxFeeEstimateError>` - The fee per proof of a batch of `num_proofs_per_batch` proofs as a `U256`.
+
+#### Errors
+
+- `EthereumProviderError` if there is an error in the connection with the RPC provider.
+- `EthereumCallError` if there is an error in the Ethereum call.

--- a/docs/3_guides/1_SDK_how_to.md
+++ b/docs/3_guides/1_SDK_how_to.md
@@ -23,8 +23,8 @@ version of the release that has the `latest` badge.
 To get the SDK up and running in your project, you must first import it
 
 ```rust
-use aligned_sdk::core::types::{AlignedVerificationData, Network, ProvingSystemId, VerificationData};
-use aligned_sdk::sdk::{submit_and_wait, get_next_nonce};
+use aligned_sdk::core::types::{PriceEstimate, AlignedVerificationData, Network, ProvingSystemId, VerificationData};
+use aligned_sdk::sdk::{estimate_fee, submit_and_wait, get_next_nonce};
 ```
 
 And then you can do a simple call of, for example, `get_next_nonce`
@@ -67,7 +67,7 @@ fn main() {
     let wallet = LocalWallet::decrypt_keystore(args.keystore_path, &keystore_password)
         .expect("Failed to decrypt keystore")
         .with_chain_id(17000u64);
-    let max_fee: U256 = 10000000000000000; //0.01 ETH
+    let max_fee: U256 = estimate_fee(&rpc_url).await.unwrap();
 
     // Call to SDK:
     match submit_and_wait_verification(

--- a/docs/3_guides/1_SDK_how_to.md
+++ b/docs/3_guides/1_SDK_how_to.md
@@ -67,7 +67,7 @@ fn main() {
     let wallet = LocalWallet::decrypt_keystore(args.keystore_path, &keystore_password)
         .expect("Failed to decrypt keystore")
         .with_chain_id(17000u64);
-    let max_fee: U256 = estimate_fee(&rpc_url).await.unwrap();
+    let max_fee: U256 = estimate_fee(&rpc_url, PriceEstimate::Default).await.unwrap();
 
     // Call to SDK:
     match submit_and_wait_verification(

--- a/examples/zkquiz/quiz/script/Cargo.lock
+++ b/examples/zkquiz/quiz/script/Cargo.lock
@@ -75,6 +75,7 @@ name = "aligned-sdk"
 version = "0.1.0"
 dependencies = [
  "ciborium",
+ "dialoguer",
  "ethers 2.0.14 (git+https://github.com/yetanotherco/ethers-rs.git?tag=v2.0.15-fix-reconnections)",
  "futures-util",
  "hex",

--- a/examples/zkquiz/quiz/script/src/main.rs
+++ b/examples/zkquiz/quiz/script/src/main.rs
@@ -126,7 +126,6 @@ async fn main() {
         .expect("Failed to read user input")
     {   return; }
 
-    let max_fee = U256::from(5) * U256::from(100_000_000_000_000_000u128);
     let nonce = get_next_nonce(&rpc_url, wallet.address(), NETWORK)
         .await
         .expect("Failed to get next nonce");


### PR DESCRIPTION
Reopens #1045 due to merge issues.

## To Test
- Run test in batcher `cd batcher && cargo t`

## To test zkQuiz example in Devnet
* Start anvil, aggregator, operator and batcher as usual
* Go to the zkquiz examples folder
```bash
cd examples/zkquiz
```
* Change the `.env` file located in `examples/zkquiz/contracts`:
```bash
RPC_URL=http://localhost:8545
PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
ALIGNED_SERVICE_MANAGER_ADDRESS=0x1613beB3B2C4f22Ee086B2b38C1476A3cE7f78E8
BATCHER_PAYMENT_SERVICE_ADDRESS=0x7969c5eD335650692Bc04293B07F5BF2e7A673C0
```
* Deploy the verifier contract. Run it in the `zkquiz` folder. Note that this will output the deployed contract address. Make sure to save it
```bash
make deploy_verifier
```
* Change the `Makefile` environment variables to the following:
```bash
CONTRACT_ADDRESS=<YOUR_DEPLOYED_CONTRACT_ADDRESS>
RPC_URL=http://localhost:8545
KEYSTORE_PATH=../../../../config-files/devnet/keys/operator-3.ecdsa.key.json
```
* Now change some code in `examples/zkquiz/quiz/script/src/main.rs`:

Line 21:
```rust
const BATCHER_URL: &str = "ws://localhost:8080";
```

Line 24:
```rust
const NETWORK: Network = Network::Devnet;
```

Line 34:
```rust
        default_value = "http://localhost:8545"
```

Line 53:
```rust
.with_chain_id(31337u64);
```

* Now send proofs so that when the zkquiz proof is submitted, it is included in a batch and posted
```bash
make batcher_send_burst_groth16
```

* Finally, run zkquiz
```bash
make answer_quiz
```

**HELP**: Answers are C C A