### PR TITLE
feat: Add operators data periodic fetcher

### DIFF
--- a/telemetry_api/.env.dev
+++ b/telemetry_api/.env.dev
@@ -1,2 +1,3 @@
 ALIGNED_CONFIG_FILE="../contracts/script/output/devnet/alignedlayer_deployment_output.json"
+OPERATOR_FETCHER_WAIT_TIME_MS=5000
 ENVIRONMENT=devnet

--- a/telemetry_api/ecto_setup_db.sh
+++ b/telemetry_api/ecto_setup_db.sh
@@ -6,6 +6,7 @@ source .env
 env_vars=(
   "ENVIRONMENT"
   "ALIGNED_CONFIG_FILE"
+  "OPERATOR_FETCHER_WAIT_TIME_MS"
 )
 
 for var in "${env_vars[@]}"; do

--- a/telemetry_api/lib/telemetry_api/application.ex
+++ b/telemetry_api/lib/telemetry_api/application.ex
@@ -16,18 +16,15 @@ defmodule TelemetryApi.Application do
       # Start a worker by calling: TelemetryApi.Worker.start_link(arg)
       # {TelemetryApi.Worker, arg},
       # Start to serve requests, typically the last entry
-      TelemetryApiWeb.Endpoint
+      TelemetryApiWeb.Endpoint,
+      TelemetryApi.Periodic.OperatorFetcher
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: TelemetryApi.Supervisor]
-
-    # Now we fetch operators data from smart contract to fill db
-    with {:ok, pid} <- Supervisor.start_link(children, opts),
-      {:ok, _} <- TelemetryApi.Operators.fetch_all_operators() do
-        {:ok, pid}
-    end
+  
+    Supervisor.start_link(children, opts)
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/telemetry_api/lib/telemetry_api/periodic/operator_fetcher.ex
+++ b/telemetry_api/lib/telemetry_api/periodic/operator_fetcher.ex
@@ -1,0 +1,32 @@
+defmodule TelemetryApi.Periodic.OperatorFetcher do
+  use Task
+  alias TelemetryApi.Operators
+
+  wait_time_str = System.get_env("OPERATOR_FETCHER_WAIT_TIME_MS") ||
+    raise """
+    environment variable OPERATOR_FETCHER_WAIT_TIME_MS is missing.
+    """
+
+  @wait_time_ms (
+    case Integer.parse(wait_time_str) do
+      :error -> raise("OPERATOR_FETCHER_WAIT_TIME_MS is not a number")
+      {num, _} -> num
+    end
+  )
+
+  def start_link(_) do
+    Task.start_link(&poll_serivce/0)
+  end
+
+  defp poll_serivce() do
+    receive do
+    after
+      @wait_time_ms ->
+        case Operators.fetch_all_operators() do
+          {:ok, _} -> :ok
+          {:error, message} -> IO.inspect "Couldn't fetch operators: #{IO.inspect message}"
+        end
+        poll_serivce()
+    end
+  end
+end

--- a/telemetry_api/lib/telemetry_api/periodic/operator_fetcher.ex
+++ b/telemetry_api/lib/telemetry_api/periodic/operator_fetcher.ex
@@ -9,7 +9,7 @@ defmodule TelemetryApi.Periodic.OperatorFetcher do
 
   @wait_time_ms (
     case Integer.parse(wait_time_str) do
-      :error -> raise("OPERATOR_FETCHER_WAIT_TIME_MS is not a number")
+      :error -> raise("OPERATOR_FETCHER_WAIT_TIME_MS is not a number, received: #{wait_time_str}")
       {num, _} -> num
     end
   )
@@ -18,7 +18,7 @@ defmodule TelemetryApi.Periodic.OperatorFetcher do
     Task.start_link(&poll_serivce/0)
   end
 
-  defp poll_serivce() do
+  defp poll_service() do
     receive do
     after
       @wait_time_ms ->
@@ -26,7 +26,7 @@ defmodule TelemetryApi.Periodic.OperatorFetcher do
           {:ok, _} -> :ok
           {:error, message} -> IO.inspect "Couldn't fetch operators: #{IO.inspect message}"
         end
-        poll_serivce()
+        poll_service()
     end
   end
 end

--- a/telemetry_api/start.sh
+++ b/telemetry_api/start.sh
@@ -6,6 +6,7 @@ source .env
 env_vars=(
   "ENVIRONMENT"
   "ALIGNED_CONFIG_FILE"
+  "OPERATOR_FETCHER_WAIT_TIME_MS"
 )
 
 for var in "${env_vars[@]}"; do


### PR DESCRIPTION
### Description

This PR adds a periodic data fetch of operands data making use of a `Task`.

### How to test

1. Run telemetry service without any operator registered
2. Go to `localhost:4000` and data should be empty
3. Register an operator
4. Go to `localhost:4000` and data from operator should have appeared
5. Run the registered operator
6. Go to `localhost:4000` and the operator's version should appear.

Closes #1137 