### PR TITLE
chore: install aligned from latest tag and update OPERATOR_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OS := $(shell uname -s)
 CONFIG_FILE?=config-files/config.yaml
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
-OPERATOR_VERSION=v0.7.3
+OPERATOR_VERSION=v0.8.0
 
 ifeq ($(OS),Linux)
 	BUILD_ALL_FFI = $(MAKE) build_all_ffi_linux

--- a/batcher/aligned/install_aligned.sh
+++ b/batcher/aligned/install_aligned.sh
@@ -8,14 +8,12 @@ BASE_DIR=$HOME
 ALIGNED_DIR="${ALIGNED_DIR-"$BASE_DIR/.aligned"}"
 ALIGNED_BIN_DIR="$ALIGNED_DIR/bin"
 ALIGNED_BIN_PATH="$ALIGNED_BIN_DIR/aligned"
-#CURRENT_TAG=$(curl -s -L \
-#  -H "Accept: application/vnd.github+json" \
-#  -H "X-GitHub-Api-Version: 2022-11-28" \
-#  https://api.github.com/repos/yetanotherco/aligned_layer/releases/latest \
-#  | grep '"tag_name":' | awk -F'"' '{print $4}')
-CURRENT_TAG=v0.6.0
+CURRENT_TAG=$(curl -s -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/yetanotherco/aligned_layer/releases/latest \
+  | grep '"tag_name":' | awk -F'"' '{print $4}')
 RELEASE_URL="https://github.com/yetanotherco/aligned_layer/releases/download/$CURRENT_TAG/"
-
 ARCH=$(uname -m)
 
 if [ "$ARCH" == "x86_64" ]; then


### PR DESCRIPTION
# Description

When running the Aligned installation, fetch the version from the latest release

# How to test

1. Run
`make install aligned`