### PR TITLE
docs(zkrust): fix submit proof command

### DIFF
--- a/docs/3_guides/5_using_zkrust.md
+++ b/docs/3_guides/5_using_zkrust.md
@@ -65,9 +65,9 @@ For example, to generate a proof of a `fibonacci` program with Risc0 or SP1 and 
 
 ```sh
 cargo run --release --  prove-risc0 \
-    --submit-to-aligned-with-keystore \
-    <PATH_TO_KEYSTORE> \
-    examples/fibonacci .
+    --submit-to-aligned \
+    --keystore-path <PATH_TO_KEYSTORE> \
+    examples/fibonacci
 ```
 
 This command will generate a proof for the fibonacci example program and submit it to Aligned using the keystore
@@ -81,8 +81,9 @@ The same program can be proved using SP1 just changing the zkRust subcommand:
 
 ```bash
 cargo run --release -- prove-sp1 \
-    --submit-to-aligned-with-keystore <path_to_keystore> \
-    examples/fibonacci .
+    --submit-to-aligned \
+    --keystore-path <PATH_TO_KEYSTORE> \
+    examples/fibonacci
 ```
 
 ## Caveats

--- a/docs/3_guides/5_using_zkrust.md
+++ b/docs/3_guides/5_using_zkrust.md
@@ -36,7 +36,7 @@ cd zkRust
 and running the installation script:
 
 ```sh
-make install
+./install_aligned.sh
 ```
 
 ### 2. Generate a keystore:
@@ -64,7 +64,7 @@ You can find them in `zkRust/examples`.
 For example, to generate a proof of a `fibonacci` program with Risc0 or SP1 and submit it to aligned, run:
 
 ```sh
-cargo run --release --  prove-risc0 \
+zkrust prove-risc0 \
     --submit-to-aligned \
     --keystore-path <PATH_TO_KEYSTORE> \
     examples/fibonacci
@@ -80,7 +80,7 @@ Aligned.
 The same program can be proved using SP1 just changing the zkRust subcommand:
 
 ```bash
-cargo run --release -- prove-sp1 \
+zkrust prove-sp1 \
     --submit-to-aligned \
     --keystore-path <PATH_TO_KEYSTORE> \
     examples/fibonacci


### PR DESCRIPTION
# Description

Update docs with the latest version of zkrust

# How to test

> [!Warning] 
> You need to have a keystore

1. Send Risc0 proof

```
zkrust prove-risc0 \
    --submit-to-aligned \
    --keystore-path <PATH_TO_KEYSTORE> \
    examples/fibonacci
```

2. Send SP1 proof

```
zkrust prove-sp1 \
    --submit-to-aligned \
    --keystore-path <PATH_TO_KEYSTORE> \
    examples/fibonacci
```