### PR TITLE
fix: operator commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help tests
 
+SHELL := /bin/bash
 OS := $(shell uname -s)
 
 CONFIG_FILE?=config-files/config.yaml
@@ -15,6 +16,11 @@ ifeq ($(OS),Darwin)
 	BUILD_ALL_FFI = $(MAKE) build_all_ffi_macos
 endif
 
+ifeq ($(OS),Linux)
+	export LD_LIBRARY_PATH := $(CURDIR)/operator/risc_zero/lib
+endif
+
+
 FFI_FOR_RELEASE ?= true
 
 ifeq ($(FFI_FOR_RELEASE),true)
@@ -26,13 +32,13 @@ else
 endif
 
 help:
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.?## .$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 submodules:
 	git submodule update --init --recursive
 	@echo "Updated submodules"
 
-deps: submodules build_all_ffi ## Install deps
+deps: submodules go_deps build_all_ffi ## Install deps
 
 go_deps:
 	@echo "Installing Go dependencies..."
@@ -94,6 +100,8 @@ anvil_start_with_block_time:
 	@echo "Starting Anvil..."
 	anvil --load-state contracts/scripts/anvil/state/alignedlayer-deployed-anvil-state.json --block-time 7
 
+_AGGREGATOR_:
+
 aggregator_start:
 	@echo "Starting Aggregator..."
 	@go run aggregator/cmd/main.go --config $(AGG_CONFIG_FILE) \
@@ -103,16 +111,21 @@ aggregator_send_dummy_responses:
 	@echo "Sending dummy responses to Aggregator..."
 	@cd aggregator && go run dummy/submit_task_responses.go
 
+
+__OPERATOR__:
+
 operator_start:
 	@echo "Starting Operator..."
 	go run operator/cmd/main.go start --config $(CONFIG_FILE) \
 	2>&1 | zap-pretty
 
+operator_full_registration: operator_get_eth operator_register_with_eigen_layer operator_mint_mock_tokens operator_deposit_into_mock_strategy operator_whitelist_devnet operator_register_with_aligned_layer
+
 operator_register_and_start: operator_full_registration operator_start
 
 build_operator: deps
 	@echo "Building Operator..."
-	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION) -r $(LD_LIBRARY_PATH):$(CURDIR)/operator/risc_zero/lib" -o ./operator/build/aligned-operator ./operator/cmd/main.go
+	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION) -r $(LD_LIBRARY_PATH)" -o ./operator/build/aligned-operator ./operator/cmd/main.go
 	@echo "Operator built into /operator/build/aligned-operator"
 
 update_operator:
@@ -126,7 +139,6 @@ operator_valid_marshall_fuzz_macos:
 
 operator_valid_marshall_fuzz_linux:
 	@cd operator/pkg && \
-	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(CURDIR)/operator/risc_zero/lib \
 	go test -fuzz=FuzzValidMarshall
 
 operator_marshall_unmarshall_fuzz_macos:
@@ -134,7 +146,6 @@ operator_marshall_unmarshall_fuzz_macos:
 
 operator_marshall_unmarshall_fuzz_linux:
 	@cd operator/pkg && \
-	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(CURDIR)/operator/risc_zero/lib \
 	go test -fuzz=FuzzMarshalUnmarshal
 
 bindings:
@@ -186,9 +197,8 @@ operator_whitelist:
 	@. contracts/scripts/.env && . contracts/scripts/whitelist_operator.sh $(OPERATOR_ADDRESS)
 
 operator_deposit_into_mock_strategy:
-	@echo "Depositing into strategy"
+	@echo "Depositing into mock strategy"
 	$(eval STRATEGY_ADDRESS = $(shell jq -r '.addresses.strategies.MOCK' contracts/script/output/devnet/eigenlayer_deployment_output.json))
-
 	@go run operator/cmd/main.go deposit-into-strategy \
 		--config $(CONFIG_FILE) \
 		--strategy-address $(STRATEGY_ADDRESS) \
@@ -207,7 +217,6 @@ operator_register_with_aligned_layer:
 
 operator_deposit_and_register: operator_deposit_into_strategy operator_register_with_aligned_layer
 
-operator_full_registration: operator_get_eth operator_register_with_eigen_layer operator_mint_mock_tokens operator_deposit_into_mock_strategy operator_whitelist_devnet operator_register_with_aligned_layer
 
 __BATCHER__:
 
@@ -504,7 +513,6 @@ test_risc_zero_go_bindings_macos: build_risc_zero_macos
 
 test_risc_zero_go_bindings_linux: build_risc_zero_linux
 	@echo "Testing RISC Zero Go bindings..."
-	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(CURDIR)/operator/risc_zero/lib \
 	go test ./operator/risc_zero/... -v
 
 generate_risc_zero_fibonacci_proof:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ else
 endif
 
 help:
-	@grep -E '^[a-zA-Z0-9_-]+:.?## .$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 submodules:
 	git submodule update --init --recursive


### PR DESCRIPTION
**Changes**
Fixes operator commands on linux.

**Test**
To test these commands now work, run the following commands on a linux machine:

- `make anvil_start_with_block_time`
- `make aggregator_start`
- `make build_operator`
- `make operator_register_and_start`
- `make batcher_start_local`
- `make batcher_send_burst_groth16`

You should be able to run this without any issues.

Closes #1182