### PR TITLE
fix: update package version in `.toml` to fix `aligned --version`

### DIFF
--- a/batcher/Cargo.lock
+++ b/batcher/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "aligned"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "aligned-sdk",
  "clap",

--- a/batcher/aligned/Cargo.toml
+++ b/batcher/aligned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aligned"
-version = "0.1.0"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
If you installed the aligned CLI with the line of the official docs the latest version installs correctly but when the command `aligned --version` is used, it always throw the `0.1.0` version since the `.toml` file is outdated.

## How to test

- Delete the installed instance of aligned and try to install it again using the command in the official docs
```
curl -L https://raw.githubusercontent.com/yetanotherco/aligned_layer/main/batcher/aligned/install_aligned.sh | bash
```
- Run `aligned --version` and it should print the `0.8.0` version