### PR TITLE
fix(explorer): fetch_batch_data_pointer in explorer reads the entire response body without any limitation

### DIFF
--- a/explorer/.env.dev
+++ b/explorer/.env.dev
@@ -20,3 +20,5 @@ DEBUG_ERRORS=true
 
 # Operator version tracker API
 TRACKER_API_URL=http://localhost:3030
+
+MAX_BATCH_SIZE=268435456 # 256 MiB

--- a/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
@@ -136,7 +136,8 @@ defmodule AlignedLayerServiceManager do
       proof_hashes: nil,
       fee_per_proof: BatcherPaymentServiceManager.get_fee_per_proof(%{merkle_root: created_batch.batchMerkleRoot}),
       sender_address: Utils.string_to_bytes32(created_batch.senderAddress),
-      max_aggregator_fee: created_batch.maxAggregatorFee
+      max_aggregator_fee: created_batch.maxAggregatorFee,
+      is_valid: true # set to false later if a process determines it is invalid
     }
   end
 
@@ -166,7 +167,8 @@ defmodule AlignedLayerServiceManager do
           fee_per_proof: unverified_batch.fee_per_proof,
           proof_hashes: nil,
           sender_address: unverified_batch.sender_address,
-          max_aggregator_fee: unverified_batch.max_aggregator_fee
+          max_aggregator_fee: unverified_batch.max_aggregator_fee,
+          is_valid: true # set to false later if a process determines it is invalid
         }
     end
   end

--- a/explorer/lib/explorer/models/batch_structs.ex
+++ b/explorer/lib/explorer/models/batch_structs.ex
@@ -32,7 +32,8 @@ defmodule BatchDB do
     :proof_hashes,
     :fee_per_proof,
     :sender_address,
-    :max_aggregator_fee
+    :max_aggregator_fee,
+    :is_valid
   ]
   defstruct [
     :merkle_root,
@@ -48,6 +49,7 @@ defmodule BatchDB do
     :proof_hashes,
     :fee_per_proof,
     :sender_address,
-    :max_aggregator_fee
+    :max_aggregator_fee,
+    :is_valid
   ]
 end

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -18,6 +18,7 @@ defmodule Batches do
     field :fee_per_proof, :integer
     field :sender_address, :binary
     field :max_aggregator_fee, :decimal
+    field :is_valid, :boolean, default: true
 
     timestamps()
   end
@@ -25,8 +26,8 @@ defmodule Batches do
   @doc false
   def changeset(new_batch, updates) do
     new_batch
-    |> cast(updates, [:merkle_root, :amount_of_proofs, :is_verified, :submission_block_number, :submission_transaction_hash, :submission_timestamp, :response_block_number, :response_transaction_hash, :response_timestamp, :data_pointer, :fee_per_proof, :sender_address, :max_aggregator_fee])
-    |> validate_required([:merkle_root, :amount_of_proofs, :is_verified, :submission_block_number, :submission_transaction_hash, :fee_per_proof, :sender_address])
+    |> cast(updates, [:merkle_root, :amount_of_proofs, :is_verified, :submission_block_number, :submission_transaction_hash, :submission_timestamp, :response_block_number, :response_transaction_hash, :response_timestamp, :data_pointer, :fee_per_proof, :sender_address, :max_aggregator_fee, :is_valid])
+    |> validate_required([:merkle_root, :amount_of_proofs, :is_verified, :submission_block_number, :submission_transaction_hash, :fee_per_proof, :sender_address, :is_valid])
     |> validate_format(:merkle_root, ~r/0x[a-fA-F0-9]{64}/)
     |> unique_constraint(:merkle_root)
     |> validate_number(:amount_of_proofs, greater_than: 0)
@@ -37,6 +38,7 @@ defmodule Batches do
     |> validate_format(:response_transaction_hash, ~r/0x[a-fA-F0-9]{64}/)
     |> validate_number(:max_aggregator_fee, greater_than: 0)
     |> validate_number(:fee_per_proof, greater_than_or_equal_to: 0)
+    |> validate_inclusion(:is_valid, [true, false])
   end
 
   def cast_to_batches(%BatchDB{} = batch_db) do
@@ -53,7 +55,8 @@ defmodule Batches do
       data_pointer: batch_db.data_pointer,
       fee_per_proof: batch_db.fee_per_proof,
       sender_address: batch_db.sender_address,
-      max_aggregator_fee: batch_db.max_aggregator_fee
+      max_aggregator_fee: batch_db.max_aggregator_fee,
+      is_valid: batch_db.is_valid
     }
   end
 
@@ -113,7 +116,7 @@ defmodule Batches do
     threshold_datetime = DateTime.utc_now() |> DateTime.add(-43200, :second) # 12 hours ago
 
     query = from(b in Batches,
-    where: b.is_verified == false and b.submission_timestamp > ^threshold_datetime,
+    where: b.is_valid == true and b.is_verified == false and b.submission_timestamp > ^threshold_datetime,
     select: b)
 
     Explorer.Repo.all(query)
@@ -193,5 +196,4 @@ defmodule Batches do
         end
     end
   end
-
 end

--- a/explorer/lib/explorer/periodically.ex
+++ b/explorer/lib/explorer/periodically.ex
@@ -16,8 +16,10 @@ defmodule Explorer.Periodically do
     one_second = 1000
     seconds_in_an_hour = 60 * 60
 
-    :timer.send_interval(one_second * 12, :batches) # every 12 seconds, once per block
-    :timer.send_interval(one_second * seconds_in_an_hour, :restakings) # every 1 hour
+    # every 12 seconds, once per block
+    :timer.send_interval(one_second * 12, :batches)
+    # every 1 hour
+    :timer.send_interval(one_second * seconds_in_an_hour, :restakings)
   end
 
   # Reads and process last blocks for operators and restaking changes
@@ -45,6 +47,7 @@ defmodule Explorer.Periodically do
 
     run_every_n_iterations = 8
     new_count = rem(count + 1, run_every_n_iterations)
+
     if new_count == 0 do
       Task.start(&process_unverified_batches/0)
     end
@@ -79,36 +82,34 @@ defmodule Explorer.Periodically do
       {:ok, lock} ->
         "Processing batch: #{batch.merkle_root}" |> Logger.debug()
 
-        with {:ok, batch_info} <- Utils.extract_info_from_data_pointer(batch),
-             {batch_changeset, proofs} <- Batches.generate_changesets(batch_info) do
-          Batches.insert_or_update(batch_changeset, proofs)
-          |> case do
-            {:ok, _} ->
-              PubSub.broadcast(Explorer.PubSub, "update_views", %{
-                eth_usd:
-                  case EthConverter.get_eth_price_usd() do
-                    {:ok, eth_usd_price} -> eth_usd_price
-                    {:error, _error} -> :empty
-                  end
-              })
+        {batch_changeset, proofs} =
+          batch
+          |> Utils.extract_info_from_data_pointer()
+          |> Batches.generate_changesets()
 
-            {:error, error} ->
-              Logger.error(
-                "Some error in DB operation, not broadcasting update_views: #{inspect(error)}"
-              )
+        Batches.insert_or_update(batch_changeset, proofs)
+        |> case do
+          {:ok, _} ->
+            PubSub.broadcast(Explorer.PubSub, "update_views", %{
+              eth_usd:
+                case EthConverter.get_eth_price_usd() do
+                  {:ok, eth_usd_price} -> eth_usd_price
+                  {:error, _error} -> :empty
+                end
+            })
 
-            # no changes in DB
-            nil ->
-              nil
-          end
+          {:error, error} ->
+            Logger.error(
+              "Some error in DB operation, not broadcasting update_views: #{inspect(error)}"
+            )
 
-          "Done processing batch: #{batch.merkle_root}" |> Logger.debug()
-          Mutex.release(BatchMutex, lock)
-        else
-          {:error, {:http_error, reason}} ->
-            Logger.error("Error when procesing request body: #{inspect(reason)}")
-            # Maybe delete the batch
+          # no changes in DB
+          nil ->
+            nil
         end
+
+        "Done processing batch: #{batch.merkle_root}" |> Logger.debug()
+        Mutex.release(BatchMutex, lock)
     end
   end
 

--- a/explorer/lib/explorer/periodically.ex
+++ b/explorer/lib/explorer/periodically.ex
@@ -16,10 +16,8 @@ defmodule Explorer.Periodically do
     one_second = 1000
     seconds_in_an_hour = 60 * 60
 
-    # every 12 seconds, once per block
-    :timer.send_interval(one_second * 12, :batches)
-    # every 1 hour
-    :timer.send_interval(one_second * seconds_in_an_hour, :restakings)
+    :timer.send_interval(one_second * 12, :batches) # every 12 seconds, once per block
+    :timer.send_interval(one_second * seconds_in_an_hour, :restakings) # every 1 hour
   end
 
   # Reads and process last blocks for operators and restaking changes
@@ -47,7 +45,6 @@ defmodule Explorer.Periodically do
 
     run_every_n_iterations = 8
     new_count = rem(count + 1, run_every_n_iterations)
-
     if new_count == 0 do
       Task.start(&process_unverified_batches/0)
     end
@@ -99,9 +96,7 @@ defmodule Explorer.Periodically do
             })
 
           {:error, error} ->
-            Logger.error(
-              "Some error in DB operation, not broadcasting update_views: #{inspect(error)}"
-            )
+            Logger.error("Some error in DB operation, not broadcasting update_views: #{inspect(error)}")
 
           # no changes in DB
           nil ->

--- a/explorer/lib/explorer_web/components/core_components.ex
+++ b/explorer/lib/explorer_web/components/core_components.ex
@@ -417,15 +417,15 @@ defmodule ExplorerWeb.CoreComponents do
   end
 
   @doc """
-    Renders a dynamic badge compoent.
+    Renders a dynamic badge component.
   """
   attr :class, :string, default: nil
   attr :status, :boolean, default: true
-  attr :falsy_text, :string, default: "Pending"
-  attr :truthy_text, :string, default: "Verified"
+  attr :falsy_text, :string
+  attr :truthy_text, :string
   slot :inner_block, default: nil
 
-  def dynamic_badge(assigns) do
+  def dynamic_badge_boolean(assigns) do
     ~H"""
     <.badge
       variant={
@@ -443,6 +443,39 @@ defmodule ExplorerWeb.CoreComponents do
       <%= case @status do
         true -> @truthy_text
         false -> @falsy_text
+      end %>
+      <%= render_slot(@inner_block) %>
+    </.badge>
+    """
+  end
+
+  @doc """
+    Renders a dynamic badge component for the batcher.
+  """
+  attr :class, :string, default: nil
+  attr :status, :atom
+  slot :inner_block, default: nil
+
+  def dynamic_badge_for_batcher(assigns) do
+    ~H"""
+    <.badge
+      variant={
+        case @status do
+          :invalid -> "destructive"
+          :verified -> "accent"
+          :pending -> "foreground"
+        end
+      }
+      class={
+        classes([
+          @class
+        ])
+      }
+    >
+      <%= case @status do
+        :invalid -> "Invalid"
+        :verified -> "Verified"
+        :pending -> "Pending"
       end %>
       <%= render_slot(@inner_block) %>
     </.badge>

--- a/explorer/lib/explorer_web/live/pages/batch/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/batch/index.html.heex
@@ -25,7 +25,7 @@
         <h3>
           Status:
         </h3>
-        <.dynamic_badge class="w-fit" status={@current_batch.is_verified} />
+        <.dynamic_badge_for_batcher class="w-fit" status={Helpers.get_batch_status(@current_batch)} />
       </div>
       <div>
         <h3>

--- a/explorer/lib/explorer_web/live/pages/batches/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/batches/index.html.heex
@@ -14,7 +14,7 @@
         </.link>
       </:col>
       <:col :let={batch} label="Status">
-        <.dynamic_badge status={batch.is_verified} />
+        <.dynamic_badge_for_batcher status={Helpers.get_batch_status(batch)} />
       </:col>
       <:col :let={batch} label="Age">
         <span class="md:px-0" title={batch.submission_timestamp}>

--- a/explorer/lib/explorer_web/live/pages/operators/index.ex
+++ b/explorer/lib/explorer_web/live/pages/operators/index.ex
@@ -83,7 +83,7 @@ defmodule ExplorerWeb.Operators.Index do
             <%= operator.total_stake |> EthConverter.wei_to_eth(2) |> Helpers.format_number() %> ETH
           </:col>
           <:col :let={operator} label="Status">
-            <.dynamic_badge status={operator.is_active} truthy_text="Active" falsy_text="Inactive" />
+            <.dynamic_badge_boolean status={operator.is_active} truthy_text="Active" falsy_text="Inactive" />
           </:col>
         </.table>
       <% else %>

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -172,7 +172,7 @@ defmodule Utils do
     |> Enum.reverse()
   end
 
-  def calculate_proof_hashes({:ok, deserialized_batch}) do
+  def calculate_proof_hashes(deserialized_batch) do
     deserialized_batch
     |> Enum.map(fn s3_object ->
       :crypto.hash(:sha3_256, s3_object["proof"])

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -183,8 +183,8 @@ defmodule Utils do
   end
 
   defp stream_handler({:headers, headers}, acc) do
-    {_, batch_size} = List.keyfind(headers, "content-length", 0, {nil, 0})
-    check_batch_size(batch_size, acc)
+    {_, batch_size} = List.keyfind(headers, "content-length", 0, {nil, "0"})
+    check_batch_size(String.to_integer(batch_size), acc)
   end
 
   defp stream_handler({:status, 200}, acc), do: {:cont, acc}

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -183,7 +183,7 @@ defmodule Utils do
   end
 
   defp stream_handler({:headers, headers}, acc) do
-    {_, batch_size} = List.keyfind(headers, "content-length", 0)
+    {_, batch_size} = List.keyfind(headers, "content-length", 0, {nil, 0})
     check_batch_size(batch_size, acc)
   end
 

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -177,6 +177,7 @@ defmodule Utils do
 
   def calculate_proof_hashes({:error, reason}) do
     Logger.error("Error calculating proof hashes: #{inspect(reason)}")
+    # This ensures we avoid attempting to fetch the invalid data again.
     ["invalid"]
   end
 

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -132,7 +132,7 @@ end
 # Backend utils
 defmodule Utils do
   require Logger
-  @max_batch_size String.to_integer(System.get_env("POOL_SIZE") || "268435456")
+  @max_batch_size String.to_integer(System.get_env("MAX_BATCH_SIZE") || "268435456")
 
   def string_to_bytes32(hex_string) do
     # Remove the '0x' prefix

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -189,7 +189,7 @@ defmodule Utils do
 
   defp stream_handler({:data, chunk}, {_acc_body, size})
        when size + byte_size(chunk) > @max_body_size do
-    {:halt, {:error, :body_too_large}}
+    {:halt, {:error, {:http, :body_too_large}}}
   end
 
   defp stream_handler({:data, chunk}, {acc_body, size}) do
@@ -200,8 +200,8 @@ defmodule Utils do
   def fetch_batch_data_pointer(batch_data_pointer) do
     case Finch.build(:get, batch_data_pointer)
          |> Finch.stream_while(Explorer.Finch, {"", 0}, &stream_handler(&1, &2)) do
-      {:ok, {:error, :body_too_large}} ->
-        {:error, {:http_error, :body_too_large}}
+      {:ok, {:error, reason}} ->
+        {:error, reason}
 
       {:ok, {body, _size}} ->
         cond do

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -282,7 +282,7 @@ defmodule Utils do
             {:error, reason} ->
               Logger.error("Error fetching batch content: #{inspect(reason)}")
               # Returning something ensures we avoid attempting to fetch the invalid data again.
-              ["0"]
+              [<<0>>]
           end
 
         proof_hashes ->

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -175,12 +175,6 @@ defmodule Utils do
     end)
   end
 
-  def calculate_proof_hashes({:error, reason}) do
-    Logger.error("Error calculating proof hashes: #{inspect(reason)}")
-    # This ensures we avoid attempting to fetch the invalid data again.
-    ["invalid batch"]
-  end
-
   defp stream_handler({:headers, _headers}, acc), do: {:cont, acc}
   defp stream_handler({:status, 200}, acc), do: {:cont, acc}
 
@@ -264,9 +258,17 @@ defmodule Utils do
         nil ->
           Logger.debug("Fetching from S3")
 
-          batch.data_pointer
-          |> Utils.fetch_batch_data_pointer()
-          |> Utils.calculate_proof_hashes()
+          batch_content = batch.data_pointer |> Utils.fetch_batch_data_pointer()
+          case batch_content do
+            {:ok, batch_content} ->
+              batch_content
+              |> Utils.calculate_proof_hashes()
+
+            {:error, reason} ->
+              Logger.error("Error fetching batch content: #{inspect(reason)}")
+              # Returning something ensures we avoid attempting to fetch the invalid data again.
+              ["invalid batch"]
+          end
 
         proof_hashes ->
           # already processed and stored the S3 data

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -177,7 +177,7 @@ defmodule Utils do
 
   def calculate_proof_hashes({:error, reason}) do
     Logger.error("Error calculating proof hashes: #{inspect(reason)}")
-    []
+    ["invalid"]
   end
 
   defp stream_handler({:headers, _headers}, acc), do: {:cont, acc}

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -178,7 +178,7 @@ defmodule Utils do
   def calculate_proof_hashes({:error, reason}) do
     Logger.error("Error calculating proof hashes: #{inspect(reason)}")
     # This ensures we avoid attempting to fetch the invalid data again.
-    ["invalid"]
+    ["invalid batch"]
   end
 
   defp stream_handler({:headers, _headers}, acc), do: {:cont, acc}

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -1,5 +1,7 @@
 # Frontend Utils
 defmodule ExplorerWeb.Helpers do
+  @request_timeout 10_000
+
   def shorten_hash(hash, decimals \\ 6) do
     case String.length(hash) do
       n when n < decimals -> hash
@@ -181,7 +183,7 @@ defmodule Utils do
 
   def fetch_batch_data_pointer(batch_data_pointer) do
     case Finch.build(:get, batch_data_pointer)
-         |> Finch.request(Explorer.Finch, request_timeout: 10_000) do
+         |> Finch.request(Explorer.Finch, request_timeout: @request_timeout) do
       {:ok, %Finch.Response{status: 200, body: body}} ->
         cond do
           is_json?(body) ->

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -132,7 +132,11 @@ end
 # Backend utils
 defmodule Utils do
   require Logger
-  @max_batch_size String.to_integer(System.get_env("MAX_BATCH_SIZE") || "268435456")
+  @max_batch_size (case System.fetch_env("MAX_BATCH_SIZE") do
+    {:ok, ""} -> 268_435_456 #empty env var
+    {:ok, value} -> String.to_integer(value)
+    _ -> 268_435_456 # error
+  end)
 
   def string_to_bytes32(hex_string) do
     # Remove the '0x' prefix

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -132,8 +132,7 @@ end
 # Backend utils
 defmodule Utils do
   require Logger
-  # 256 KB
-  @max_body_size 256 * 1024
+  @max_batch_size String.to_integer(System.get_env("POOL_SIZE") || "268435456")
 
   def string_to_bytes32(hex_string) do
     # Remove the '0x' prefix
@@ -188,7 +187,7 @@ defmodule Utils do
     do: {:halt, {:error, {:http_error, status_code}}}
 
   defp stream_handler({:data, chunk}, {_acc_body, size})
-       when size + byte_size(chunk) > @max_body_size do
+       when size + byte_size(chunk) > @max_batch_size do
     {:halt, {:error, {:http, :body_too_large}}}
   end
 

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -282,7 +282,7 @@ defmodule Utils do
             {:error, reason} ->
               Logger.error("Error fetching batch content: #{inspect(reason)}")
               # Returning something ensures we avoid attempting to fetch the invalid data again.
-              ["invalid batch"]
+              ["0"]
           end
 
         proof_hashes ->

--- a/explorer/priv/repo/migrations/20241010133259_add_is_valid_field.exs
+++ b/explorer/priv/repo/migrations/20241010133259_add_is_valid_field.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddIsValidField do
+  use Ecto.Migration
+
+  def change do
+    alter table("batches") do
+      add :is_valid, :boolean, default: true
+    end
+  end
+end

--- a/explorer/start.sh
+++ b/explorer/start.sh
@@ -14,6 +14,7 @@ env_vars=(
   "ALIGNED_CONFIG_FILE"
   "DEBUG_ERRORS"
   "TRACKER_API_URL"
+  "MAX_BATCH_SIZE"
 )
 
 for var in "${env_vars[@]}"; do


### PR DESCRIPTION
**Motivation**

The function `fetch_batch_data_pointer` in the explorer reads the entire response body without any
limitations, which can lead to an OOM attack.

**Description**

Uses a `max_batch_size` limit when reading request bodies.

**How to Test**

See #1202 

Closes #1016 