### PR TITLE
fix: operator resets channel when updating latest block file

### DIFF
--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -176,7 +176,7 @@ func (o *Operator) UpdateLastProcessBatch(blockNumber uint32) error {
 		return nil
 	}
 
-	o.lastProcessedBatch = OperatorLastProcessedBatch{BlockNumber: blockNumber}
+	o.lastProcessedBatch.BlockNumber = blockNumber
 
 	// write to a file so it can be recovered in case of operator outage
 	json, err := json.Marshal(o.lastProcessedBatch)


### PR DESCRIPTION
**Changes**
The operator was resetting the channel when updating the json file.

Closes #1199 