### PR TITLE
feat(explorer): add is_valid field to batches

### DIFF
--- a/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
@@ -136,7 +136,8 @@ defmodule AlignedLayerServiceManager do
       proof_hashes: nil,
       fee_per_proof: BatcherPaymentServiceManager.get_fee_per_proof(%{merkle_root: created_batch.batchMerkleRoot}),
       sender_address: Utils.string_to_bytes32(created_batch.senderAddress),
-      max_aggregator_fee: created_batch.maxAggregatorFee
+      max_aggregator_fee: created_batch.maxAggregatorFee,
+      is_valid: true
     }
   end
 
@@ -166,7 +167,8 @@ defmodule AlignedLayerServiceManager do
           fee_per_proof: unverified_batch.fee_per_proof,
           proof_hashes: nil,
           sender_address: unverified_batch.sender_address,
-          max_aggregator_fee: unverified_batch.max_aggregator_fee
+          max_aggregator_fee: unverified_batch.max_aggregator_fee,
+          is_valid: true
         }
     end
   end

--- a/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
@@ -137,7 +137,7 @@ defmodule AlignedLayerServiceManager do
       fee_per_proof: BatcherPaymentServiceManager.get_fee_per_proof(%{merkle_root: created_batch.batchMerkleRoot}),
       sender_address: Utils.string_to_bytes32(created_batch.senderAddress),
       max_aggregator_fee: created_batch.maxAggregatorFee,
-      is_valid: true
+      is_valid: true # set to false later if a process determines it is invalid
     }
   end
 
@@ -168,7 +168,7 @@ defmodule AlignedLayerServiceManager do
           proof_hashes: nil,
           sender_address: unverified_batch.sender_address,
           max_aggregator_fee: unverified_batch.max_aggregator_fee,
-          is_valid: true
+          is_valid: true # set to false later if a process determines it is invalid
         }
     end
   end

--- a/explorer/lib/explorer/models/batch_structs.ex
+++ b/explorer/lib/explorer/models/batch_structs.ex
@@ -32,7 +32,8 @@ defmodule BatchDB do
     :proof_hashes,
     :fee_per_proof,
     :sender_address,
-    :max_aggregator_fee
+    :max_aggregator_fee,
+    :is_valid
   ]
   defstruct [
     :merkle_root,
@@ -48,6 +49,7 @@ defmodule BatchDB do
     :proof_hashes,
     :fee_per_proof,
     :sender_address,
-    :max_aggregator_fee
+    :max_aggregator_fee,
+    :is_valid
   ]
 end

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -18,6 +18,7 @@ defmodule Batches do
     field :fee_per_proof, :integer
     field :sender_address, :binary
     field :max_aggregator_fee, :decimal
+    field :is_valid, :boolean
 
     timestamps()
   end
@@ -25,8 +26,8 @@ defmodule Batches do
   @doc false
   def changeset(new_batch, updates) do
     new_batch
-    |> cast(updates, [:merkle_root, :amount_of_proofs, :is_verified, :submission_block_number, :submission_transaction_hash, :submission_timestamp, :response_block_number, :response_transaction_hash, :response_timestamp, :data_pointer, :fee_per_proof, :sender_address, :max_aggregator_fee])
-    |> validate_required([:merkle_root, :amount_of_proofs, :is_verified, :submission_block_number, :submission_transaction_hash, :fee_per_proof, :sender_address])
+    |> cast(updates, [:merkle_root, :amount_of_proofs, :is_verified, :submission_block_number, :submission_transaction_hash, :submission_timestamp, :response_block_number, :response_transaction_hash, :response_timestamp, :data_pointer, :fee_per_proof, :sender_address, :max_aggregator_fee, :is_valid])
+    |> validate_required([:merkle_root, :amount_of_proofs, :is_verified, :submission_block_number, :submission_transaction_hash, :fee_per_proof, :sender_address, :is_valid])
     |> validate_format(:merkle_root, ~r/0x[a-fA-F0-9]{64}/)
     |> unique_constraint(:merkle_root)
     |> validate_number(:amount_of_proofs, greater_than: 0)
@@ -37,6 +38,7 @@ defmodule Batches do
     |> validate_format(:response_transaction_hash, ~r/0x[a-fA-F0-9]{64}/)
     |> validate_number(:max_aggregator_fee, greater_than: 0)
     |> validate_number(:fee_per_proof, greater_than_or_equal_to: 0)
+    |> validate_inclusion(:is_verified, [true, false])
   end
 
   def cast_to_batches(%BatchDB{} = batch_db) do
@@ -53,7 +55,8 @@ defmodule Batches do
       data_pointer: batch_db.data_pointer,
       fee_per_proof: batch_db.fee_per_proof,
       sender_address: batch_db.sender_address,
-      max_aggregator_fee: batch_db.max_aggregator_fee
+      max_aggregator_fee: batch_db.max_aggregator_fee,
+      is_valid: batch_db.is_valid
     }
   end
 
@@ -193,5 +196,4 @@ defmodule Batches do
         end
     end
   end
-
 end

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -38,7 +38,7 @@ defmodule Batches do
     |> validate_format(:response_transaction_hash, ~r/0x[a-fA-F0-9]{64}/)
     |> validate_number(:max_aggregator_fee, greater_than: 0)
     |> validate_number(:fee_per_proof, greater_than_or_equal_to: 0)
-    |> validate_inclusion(:is_verified, [true, false])
+    |> validate_inclusion(:is_valid, [true, false])
   end
 
   def cast_to_batches(%BatchDB{} = batch_db) do

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -18,7 +18,7 @@ defmodule Batches do
     field :fee_per_proof, :integer
     field :sender_address, :binary
     field :max_aggregator_fee, :decimal
-    field :is_valid, :boolean
+    field :is_valid, :boolean, default: true
 
     timestamps()
   end

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -116,7 +116,7 @@ defmodule Batches do
     threshold_datetime = DateTime.utc_now() |> DateTime.add(-43200, :second) # 12 hours ago
 
     query = from(b in Batches,
-    where: b.is_verified == false and b.submission_timestamp > ^threshold_datetime,
+    where: b.is_valid == true and b.is_verified == false and b.submission_timestamp > ^threshold_datetime,
     select: b)
 
     Explorer.Repo.all(query)

--- a/explorer/lib/explorer/periodically.ex
+++ b/explorer/lib/explorer/periodically.ex
@@ -45,6 +45,7 @@ defmodule Explorer.Periodically do
 
     run_every_n_iterations = 8
     new_count = rem(count + 1, run_every_n_iterations)
+
     if new_count == 0 do
       Task.start(&process_unverified_batches/0)
     end
@@ -79,28 +80,19 @@ defmodule Explorer.Periodically do
       {:ok, lock} ->
         "Processing batch: #{batch.merkle_root}" |> Logger.debug()
 
-        {batch_changeset, proofs} =
-          batch
-          |> Utils.extract_info_from_data_pointer()
-          |> Batches.generate_changesets()
-
-        Batches.insert_or_update(batch_changeset, proofs)
-        |> case do
-          {:ok, _} ->
-            PubSub.broadcast(Explorer.PubSub, "update_views", %{
-              eth_usd:
-                case EthConverter.get_eth_price_usd() do
-                  {:ok, eth_usd_price} -> eth_usd_price
-                  {:error, _error} -> :empty
-                end
-            })
-
-          {:error, error} ->
-            Logger.error("Some error in DB operation, not broadcasting update_views: #{inspect(error)}")
-
-          # no changes in DB
-          nil ->
-            nil
+        with {:ok, updated_batch} <- Utils.process_batch(batch),
+             {batch_changeset, proofs} <- Batches.generate_changesets(updated_batch),
+             {:ok, _} <- Batches.insert_or_update(batch_changeset, proofs) do
+          PubSub.broadcast(Explorer.PubSub, "update_views", %{
+            eth_usd:
+              case EthConverter.get_eth_price_usd() do
+                {:ok, eth_usd_price} -> eth_usd_price
+                {:error, _error} -> :empty
+              end
+          })
+        else
+          {:error, reason} ->
+            Logger.error("Error processing batch #{batch.merkle_root}. Error: #{inspect(reason)}")
         end
 
         "Done processing batch: #{batch.merkle_root}" |> Logger.debug()

--- a/explorer/lib/explorer/periodically.ex
+++ b/explorer/lib/explorer/periodically.ex
@@ -93,6 +93,9 @@ defmodule Explorer.Periodically do
         else
           {:error, reason} ->
             Logger.error("Error processing batch #{batch.merkle_root}. Error: #{inspect(reason)}")
+          # no changes in DB
+          nil ->
+            nil
         end
 
         "Done processing batch: #{batch.merkle_root}" |> Logger.debug()

--- a/explorer/lib/explorer_web/components/core_components.ex
+++ b/explorer/lib/explorer_web/components/core_components.ex
@@ -417,15 +417,15 @@ defmodule ExplorerWeb.CoreComponents do
   end
 
   @doc """
-    Renders a dynamic badge compoent.
+    Renders a dynamic badge component.
   """
   attr :class, :string, default: nil
   attr :status, :boolean, default: true
-  attr :falsy_text, :string, default: "Pending"
-  attr :truthy_text, :string, default: "Verified"
+  attr :falsy_text, :string
+  attr :truthy_text, :string
   slot :inner_block, default: nil
 
-  def dynamic_badge(assigns) do
+  def dynamic_badge_boolean(assigns) do
     ~H"""
     <.badge
       variant={
@@ -443,6 +443,39 @@ defmodule ExplorerWeb.CoreComponents do
       <%= case @status do
         true -> @truthy_text
         false -> @falsy_text
+      end %>
+      <%= render_slot(@inner_block) %>
+    </.badge>
+    """
+  end
+
+  @doc """
+    Renders a dynamic badge component for the batcher.
+  """
+  attr :class, :string, default: nil
+  attr :status, :atom
+  slot :inner_block, default: nil
+
+  def dynamic_badge_for_batcher(assigns) do
+    ~H"""
+    <.badge
+      variant={
+        case @status do
+          :invalid -> "destructive"
+          :verified -> "accent"
+          :pending -> "foreground"
+        end
+      }
+      class={
+        classes([
+          @class
+        ])
+      }
+    >
+      <%= case @status do
+        :invalid -> "Invalid"
+        :verified -> "Verified"
+        :pending -> "Pending"
       end %>
       <%= render_slot(@inner_block) %>
     </.badge>

--- a/explorer/lib/explorer_web/live/pages/batch/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/batch/index.html.heex
@@ -25,7 +25,7 @@
         <h3>
           Status:
         </h3>
-        <.dynamic_badge class="w-fit" status={@current_batch.is_verified} />
+        <.dynamic_badge_for_batcher class="w-fit" status={Helpers.get_batch_status(@current_batch)} />
       </div>
       <div>
         <h3>

--- a/explorer/lib/explorer_web/live/pages/batches/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/batches/index.html.heex
@@ -14,7 +14,7 @@
         </.link>
       </:col>
       <:col :let={batch} label="Status">
-        <.dynamic_badge status={batch.is_verified} />
+        <.dynamic_badge_for_batcher status={Helpers.get_batch_status(batch)} />
       </:col>
       <:col :let={batch} label="Age">
         <span class="md:px-0" title={batch.submission_timestamp}>

--- a/explorer/lib/explorer_web/live/pages/operators/index.ex
+++ b/explorer/lib/explorer_web/live/pages/operators/index.ex
@@ -83,7 +83,7 @@ defmodule ExplorerWeb.Operators.Index do
             <%= operator.total_stake |> EthConverter.wei_to_eth(2) |> Helpers.format_number() %> ETH
           </:col>
           <:col :let={operator} label="Status">
-            <.dynamic_badge status={operator.is_active} truthy_text="Active" falsy_text="Inactive" />
+            <.dynamic_badge_boolean status={operator.is_active} truthy_text="Active" falsy_text="Inactive" />
           </:col>
         </.table>
       <% else %>

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -264,6 +264,22 @@ defmodule Utils do
     end
   end
 
+  def extract_info_from_data_pointer(%BatchDB{} = batch) do
+    Logger.debug("Extracting batch's proofs info: #{batch.merkle_root}")
+
+    {status, proof_hashes} = get_proof_hashes(batch)
+
+    updated_batch =
+      batch
+      |> Map.put(:proof_hashes, proof_hashes)
+      |> Map.put(:amount_of_proofs, Enum.count(proof_hashes))
+
+    case status do
+      :error -> Map.put(updated_batch, :is_valid, false)
+      _ -> updated_batch
+    end
+  end
+
   defp get_proof_hashes(%BatchDB{} = batch) do
     # only get from s3 if not already in DB
     case Proofs.get_proofs_from_batch(%{merkle_root: batch.merkle_root}) do
@@ -290,22 +306,6 @@ defmodule Utils do
         # already processed and stored the S3 data
         Logger.debug("Fetching from DB")
         {:ok, proof_hashes}
-    end
-  end
-
-  def extract_info_from_data_pointer(%BatchDB{} = batch) do
-    Logger.debug("Extracting batch's proofs info: #{batch.merkle_root}")
-
-    {status, proof_hashes} = get_proof_hashes(batch)
-
-    updated_batch =
-      batch
-      |> Map.put(:proof_hashes, proof_hashes)
-      |> Map.put(:amount_of_proofs, Enum.count(proof_hashes))
-
-    case status do
-      :error -> Map.put(updated_batch, :is_valid, false)
-      _ -> updated_batch
     end
   end
 

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -278,6 +278,7 @@ defmodule Utils do
         {:ok, add_proof_hashes_to_batch(batch, proof_hashes)}
 
       {:error, {:invalid, reason}} ->
+        Logger.error("Invalid batch content for #{batch.merkle_root}: #{inspect(reason)}")
         # Returning something ensures we avoid attempting to fetch the invalid data again.
         updated_batch =
           batch
@@ -315,7 +316,7 @@ defmodule Utils do
             {:ok, proof_hashes}
 
           {:error, reason} ->
-            {:error, "Error fetching batch content: #{inspect(reason)}"}
+            {:error, reason}
         end
 
       proof_hashes ->

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -207,7 +207,7 @@ defmodule Utils do
 
   defp check_batch_size(size, acc) do
     if size > @max_batch_size do
-      {:halt, {:error, {:invalid, body_too_large}}}
+      {:halt, {:error, {:invalid, :body_too_large}}}
     else
       {:cont, acc}
     end
@@ -283,7 +283,7 @@ defmodule Utils do
         updated_batch =
           batch
           |> Map.put(:is_valid, false)
-          |> add_proof_hashes_to_batch(<<0>>)
+          |> add_proof_hashes_to_batch([<<0>>])
 
         {:ok, updated_batch}
 

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -127,6 +127,14 @@ defmodule ExplorerWeb.Helpers do
   def binary_to_hex_string(binary) do
     Utils.binary_to_hex_string(binary)
   end
+
+  def get_batch_status(batch) do
+    cond do
+      not batch.is_valid -> :invalid
+      batch.is_verified -> :verified
+      true -> :pending
+    end
+  end
 end
 
 # Backend utils

--- a/explorer/priv/repo/migrations/20241010133259_add_is_valid_field.exs
+++ b/explorer/priv/repo/migrations/20241010133259_add_is_valid_field.exs
@@ -3,7 +3,7 @@ defmodule Explorer.Repo.Migrations.AddIsValidField do
 
   def change do
     alter table("batches") do
-      add :is_valid, :boolean
+      add :is_valid, :boolean, default: true
     end
   end
 end

--- a/explorer/priv/repo/migrations/20241010133259_add_is_valid_field.exs
+++ b/explorer/priv/repo/migrations/20241010133259_add_is_valid_field.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddIsValidField do
+  use Ecto.Migration
+
+  def change do
+    alter table("batches") do
+      add :is_valid, :boolean
+    end
+  end
+end


### PR DESCRIPTION
**Motivation**

This PR adds a new status, `Invalid`, to the batcher in the explorer.

**Description**

- Adds `is_valid` field to the `%Batcher{}` and `%BatchDB{}` structs.
- Updates their respective schemas to include this field.
- Creates a migration to add the field to the db.
- Adds the new status to the frontend.