### PR TITLE
fix: makefile build_operator on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,15 +127,15 @@ operator_full_registration: operator_get_eth operator_register_with_eigen_layer 
 
 operator_register_and_start: operator_full_registration operator_start
 
-build_operator:
+build_operator: deps
 	$(BUILD_OPERATOR)
 
-build_operator_macos: deps
+build_operator_macos:
 	@echo "Building Operator..."
 	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION)" -o ./operator/build/aligned-operator ./operator/cmd/main.go
 	@echo "Operator built into /operator/build/aligned-operator"
 
-build_operator_linux: deps
+build_operator_linux:
 	@echo "Building Operator..."
 	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION) -r $(LD_LIBRARY_PATH)" -o ./operator/build/aligned-operator ./operator/cmd/main.go
 	@echo "Operator built into /operator/build/aligned-operator"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,15 @@ ifeq ($(OS),Darwin)
 endif
 
 ifeq ($(OS),Linux)
-	export LD_LIBRARY_PATH := $(CURDIR)/operator/risc_zero/lib
+	export LD_LIBRARY_PATH += $(CURDIR)/operator/risc_zero/lib
+endif
+
+ifeq ($(OS),Linux)
+	BUILD_OPERATOR = $(MAKE) build_operator_linux 
+endif
+
+ifeq ($(OS),Darwin)
+	BUILD_OPERATOR = $(MAKE) build_operator_macos
 endif
 
 
@@ -119,7 +127,15 @@ operator_full_registration: operator_get_eth operator_register_with_eigen_layer 
 
 operator_register_and_start: operator_full_registration operator_start
 
-build_operator: deps
+build_operator:
+	$(BUILD_OPERATOR)
+
+build_operator_macos: deps
+	@echo "Building Operator..."
+	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION)" -o ./operator/build/aligned-operator ./operator/cmd/main.go
+	@echo "Operator built into /operator/build/aligned-operator"
+
+build_operator_linux: deps
 	@echo "Building Operator..."
 	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION) -r $(LD_LIBRARY_PATH)" -o ./operator/build/aligned-operator ./operator/cmd/main.go
 	@echo "Operator built into /operator/build/aligned-operator"


### PR DESCRIPTION
**Changes**
Creates new targets to build the operator for Linux and macos separately. This fixes `ld: warning: -rpath missing <path>` err in macOS. The err because `LD_LIBRARY_PATH` was set only for Linux systems, as mac does not need it.

**Test**
Run `make build_operator` and check that it works alright.