### PR TITLE
feat: remove disconnected sockets from batch

### DIFF
--- a/batcher/aligned-batcher/src/connection.rs
+++ b/batcher/aligned-batcher/src/connection.rs
@@ -79,10 +79,10 @@ pub(crate) async fn send_message<T: Serialize>(ws_conn_sink: WsMessageSink, mess
     }
 }
 
-pub(crate) async fn drop_connection(ws_conn_sink: WsMessageSink, reason: Option<&str>) {
+pub(crate) async fn drop_connection(ws_conn_sink: WsMessageSink, reason: String) {
     let close_frame = CloseFrame {
         code: CloseCode::Normal,
-        reason: "Closing connection".into(),
+        reason: reason.into(),
     };
 
     ws_conn_sink

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -947,7 +947,9 @@ impl Batcher {
                     })
                     .collect();
 
-                batch_state_lock.user_states.remove(&addr);
+                if !self.is_nonpaying(&addr) {
+                    batch_state_lock.user_states.remove(&addr);
+                }
             };
 
         self.metrics.dismissed_sockets_latest_batch.set(0);

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -923,6 +923,7 @@ impl Batcher {
         &self,
         finalized_batch: Vec<BatchQueueEntry>,
     ) -> Vec<BatchQueueEntry> {
+        info!("Finalized batch: verifying that clients are still connected");
         let mut filtered_finalized_batch = vec![];
         let mut closed_clients = HashSet::new();
         let mut conns_to_drop = vec![];
@@ -974,6 +975,7 @@ impl Batcher {
             };
 
             // we make sure its still alive by sending a ping message
+            debug!("Sending pig message");
             let ping_msg = Message::Ping(vec![]);
             if let Err(e) = ws_conn.clone().write().await.send(ping_msg).await {
                 error!("Failed to send ping, WebSocket may be closed: {:?}", e);
@@ -987,6 +989,7 @@ impl Batcher {
         }
 
         for ws_conn in conns_to_drop {
+            debug!("Connection dropped");
             drop_connection(
                 ws_conn,
                 "Another connection of yours has disconnected".into(),
@@ -994,6 +997,7 @@ impl Batcher {
             .await;
         }
 
+        info!("Finalized batch: clients connection verification ended");
         filtered_finalized_batch
     }
 

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -4,7 +4,6 @@ use connection::{drop_connection, send_message, WsMessageSink};
 use dotenvy::dotenv;
 use ethers::contract::ContractError;
 use ethers::signers::Signer;
-use sha3::digest::generic_array::iter;
 use types::batch_state::BatchState;
 use types::user_state::UserState;
 
@@ -22,7 +21,7 @@ use eth::{try_create_new_task, BatcherPaymentService, CreateNewTaskFeeParams, Si
 use ethers::prelude::{Middleware, Provider};
 use ethers::providers::Ws;
 use ethers::types::{Address, Signature, TransactionReceipt, U256};
-use futures_util::{future, stream, SinkExt, StreamExt, TryStreamExt};
+use futures_util::{future, SinkExt, StreamExt, TryStreamExt};
 use lambdaworks_crypto::merkle_tree::merkle::MerkleTree;
 use lambdaworks_crypto::merkle_tree::traits::IsMerkleTreeBackend;
 use log::{debug, error, info, warn};

--- a/batcher/aligned-batcher/src/metrics.rs
+++ b/batcher/aligned-batcher/src/metrics.rs
@@ -14,6 +14,7 @@ pub struct BatcherMetrics {
     pub batcher_started: IntCounter,
     pub gas_price_used_on_latest_batch: IntGauge,
     pub broken_sockets_latest_batch: IntGauge,
+    pub dismissed_sockets_latest_batch: IntGauge,
 }
 
 impl BatcherMetrics {
@@ -30,6 +31,10 @@ impl BatcherMetrics {
             register_int_gauge!(opts!("gas_price_used_on_latest_batch", "Gas Price"))?;
         let broken_sockets_latest_batch =
             register_int_gauge!(opts!("broken_sockets_latest_batch", "Broken sockets"))?;
+        let dismissed_sockets_latest_batch = register_int_gauge!(opts!(
+            "dismissed_sockets_latest_batch",
+            "Dismissed sockets latest batch"
+        ))?;
 
         registry.register(Box::new(open_connections.clone()))?;
         registry.register(Box::new(received_proofs.clone()))?;
@@ -37,6 +42,7 @@ impl BatcherMetrics {
         registry.register(Box::new(reverted_batches.clone()))?;
         registry.register(Box::new(batcher_started.clone()))?;
         registry.register(Box::new(broken_sockets_latest_batch.clone()))?;
+        registry.register(Box::new(dismissed_sockets_latest_batch.clone()))?;
 
         let metrics_route = warp::path!("metrics")
             .and(warp::any().map(move || registry.clone()))
@@ -56,6 +62,7 @@ impl BatcherMetrics {
             batcher_started,
             gas_price_used_on_latest_batch,
             broken_sockets_latest_batch,
+            dismissed_sockets_latest_batch,
         })
     }
 

--- a/batcher/aligned-batcher/src/types/batch_queue.rs
+++ b/batcher/aligned-batcher/src/types/batch_queue.rs
@@ -12,7 +12,7 @@ use std::{
 use super::errors::BatcherError;
 use crate::connection::WsMessageSink;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct BatchQueueEntry {
     pub(crate) nonced_verification_data: NoncedVerificationData,
     pub(crate) verification_data_commitment: VerificationDataCommitment,

--- a/batcher/aligned-sdk/src/communication/messaging.rs
+++ b/batcher/aligned-sdk/src/communication/messaging.rs
@@ -175,6 +175,9 @@ pub async fn receive(
                     .to_string(),
             ));
         }
+        if msg.is_ping() {
+            continue;
+        }
         process_batch_inclusion_data(
             msg,
             &mut aligned_verification_data,

--- a/batcher/aligned-sdk/src/communication/messaging.rs
+++ b/batcher/aligned-sdk/src/communication/messaging.rs
@@ -75,6 +75,16 @@ pub async fn send_messages(
             }
         };
 
+        if msg.is_close() {
+            if let Message::Close(Some(frame)) = msg {
+                return Err(SubmitError::ConnectionClose(frame.reason.to_string()));
+            } else {
+                return Err(SubmitError::ConnectionClose(
+                    "Connection was closed".to_string(),
+                ));
+            }
+        };
+
         let response_msg: ValidityResponseMessage = cbor_deserialize(msg.into_data().as_slice())
             .map_err(SubmitError::SerializationError)?;
 

--- a/batcher/aligned-sdk/src/core/errors.rs
+++ b/batcher/aligned-sdk/src/core/errors.rs
@@ -91,6 +91,7 @@ pub enum SubmitError {
     InvalidPaymentServiceAddress(H160, H160),
     BatchSubmissionFailed(String),
     AddToBatchError,
+    ConnectionClose(String),
     GenericError(String),
 }
 
@@ -200,6 +201,7 @@ impl fmt::Display for SubmitError {
             }
             SubmitError::ProofQueueFlushed => write!(f, "Batch reset"),
             SubmitError::AddToBatchError => write!(f, "Error while adding entry to batch"),
+            SubmitError::ConnectionClose(reason) => write!(f, "Connection closed: {}", reason),
         }
     }
 }

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -554,6 +554,7 @@ async fn handle_submit_err(err: SubmitError, nonce_file: &str) {
         SubmitError::InsufficientBalance => {
             error!("Insufficient balance to pay for the transaction")
         }
+        SubmitError::ConnectionClose(reason) => error!("Connection closed: {}", reason),
         _ => {}
     }
 

--- a/grafana/provisioning/dashboards/aligned/aggregator_batcher.json
+++ b/grafana/provisioning/dashboards/aligned/aggregator_batcher.json
@@ -715,7 +715,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Socket connections that were disconnected when sending a batch response.",
+      "description": "Socket connections that were disconnected when sending a batch response. These proofs were included in the bath but the socket connection failed when sending the batch response to the client",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -811,6 +811,106 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "The clients whose proofs have been removed from the batch because their socket was disconnected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 21,
+      "interval": "1m",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "dismissed_sockets_latest_batch",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Dismissed sockets",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
@@ -858,7 +958,7 @@
             "h": 7,
             "w": 10,
             "x": 0,
-            "y": 42
+            "y": 50
           },
           "id": 9,
           "options": {
@@ -1010,7 +1110,7 @@
             "h": 7,
             "w": 10,
             "x": 10,
-            "y": 42
+            "y": 50
           },
           "id": 1,
           "options": {
@@ -1074,7 +1174,7 @@
             "h": 7,
             "w": 5,
             "x": 0,
-            "y": 49
+            "y": 57
           },
           "id": 8,
           "options": {
@@ -1144,7 +1244,7 @@
             "h": 7,
             "w": 5,
             "x": 5,
-            "y": 49
+            "y": 57
           },
           "id": 7,
           "options": {
@@ -1209,7 +1309,7 @@
             "h": 7,
             "w": 5,
             "x": 0,
-            "y": 56
+            "y": 64
           },
           "id": 2,
           "options": {
@@ -1279,7 +1379,7 @@
             "h": 7,
             "w": 5,
             "x": 5,
-            "y": 56
+            "y": 64
           },
           "id": 5,
           "options": {
@@ -1326,7 +1426,7 @@
       "type": "row"
     }
   ],
-  "refresh": "5s",
+  "refresh": false,
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -1334,8 +1434,8 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
-    "to": "now"
+    "from": "2024-10-15T20:24:27.682Z",
+    "to": "2024-10-15T20:25:15.664Z"
   },
   "timepicker": {},
   "timezone": "browser",


### PR DESCRIPTION
**Changes**
Following pr #1255, this pr removes from the finalized batch the proofs whose clients connections is down. It also adds metrics for the number of dropped proofs per finalized batch. 

**Test**
First, run a local testnet as usual, then:
- Run metrics: `make run_metrics`
- Send a bunch of proofs and cancel some of them quickly
- Go to `localhost:300` and check the `Dismissed sockets` metric.
- Check that the proofs that you have canceled have not been included in the batch: ``

You can also test that effectively all proofs from the batch queue have been removed by sending proofs with `make batcher_send_burst_groth16` and in parallel sending other proofs and canceling them. You should see that newer proofs fail because of the nonce, as the cached user is removed.

Closes #1242