### PR TITLE
fix(audit): timeouts for metrics server to avoid DoS attacks

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,12 +49,23 @@ func NewMetrics(ipPortAddress string, reg prometheus.Registerer, logger logging.
 func (m *Metrics) Start(ctx context.Context, reg prometheus.Gatherer) <-chan error {
 	m.logger.Infof("Starting metrics server at port %v", m.ipPortAddress)
 	errC := make(chan error, 1)
+
+	server := http.Server{
+		Addr:           m.ipPortAddress,
+		Handler:        http.NewServeMux(),
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		IdleTimeout:    120 * time.Second,
+		MaxHeaderBytes: 1 << 20, // This is 1MB
+	}
+
+	server.Handler.(*http.ServeMux).Handle("/metrics", promhttp.HandlerFor(
+		reg,
+		promhttp.HandlerOpts{},
+	))
+
 	go func() {
-		http.Handle("/metrics", promhttp.HandlerFor(
-			reg,
-			promhttp.HandlerOpts{},
-		))
-		err := http.ListenAndServe(m.ipPortAddress, nil)
+		err := server.ListenAndServe()
 		if err != nil {
 			errC <- errors.New("prometheus server failed")
 		} else {


### PR DESCRIPTION
The metrics server used for the operator and the aggregator is now initialize with custom timeout parameters to avoid attacks that could bring the server down.