### PR TITLE
fix(operator): build operator for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ifeq ($(OS),Darwin)
 endif
 
 ifeq ($(OS),Linux)
-	export LD_LIBRARY_PATH += $(CURDIR)/operator/risc_zero/lib
+	LD_LIBRARY_PATH += $(CURDIR)/operator/risc_zero/lib
 endif
 
 ifeq ($(OS),Linux)


### PR DESCRIPTION
# Build operator for linux not working

## Description

There is a crash when building the operator due to how is exported the LD_LIBRARY_PATH

## Type of change

- [x] Bug fix

## How to test

1. Build the operator on a linux server

```
make build_operator
```

2. Check the version of the operator

```
./operator/build/aligned-operator --version
```

This is just to check the build is correct