### PR TITLE
hotfix(batcher): rm MIN_FEE_PER_PROOF check in batcher

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -469,12 +469,6 @@ impl Batcher {
 
         // Nonce and max fee verification
         let max_fee = nonced_verification_data.max_fee;
-        if max_fee < U256::from(MIN_FEE_PER_PROOF) {
-            error!("The max fee signed in the message is less than the accepted minimum fee to be included in the batch.");
-            send_message(ws_conn_sink.clone(), ValidityResponseMessage::InvalidMaxFee).await;
-            return Ok(());
-        }
-
         // Check that we had a user state entry for this user and insert it if not.
 
         // We aquire the lock first only to query if the user is already present and the lock is dropped.

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -467,10 +467,6 @@ impl Batcher {
             return Ok(());
         }
 
-        // Nonce and max fee verification
-        let max_fee = nonced_verification_data.max_fee;
-        // Check that we had a user state entry for this user and insert it if not.
-
         // We aquire the lock first only to query if the user is already present and the lock is dropped.
         // If it was not present, then the user nonce is queried to the Aligned contract.
         // Lastly, we get a lock of the batch state again and insert the user state if it was still missing.


### PR DESCRIPTION
# Hotfix Removes MIN_FEE_PER_PROOF check from Batcher

closes #1268 

## Description

Removes a check that the` max_fee` of proof submitted to the batcher is greater than `MIN_FEE_PER_PROOF` https://github.com/yetanotherco/aligned_layer/blob/testnet/batcher/aligned-batcher/src/lib.rs#L472 .

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
