### PR TITLE
hotfix(operator): send only rpc host to telemetry service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OS := $(shell uname -s)
 CONFIG_FILE?=config-files/config.yaml
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
-OPERATOR_VERSION=v0.10.0
+OPERATOR_VERSION=v0.10.1
 
 ifeq ($(OS),Linux)
 	BUILD_ALL_FFI = $(MAKE) build_all_ffi_linux

--- a/batcher/Cargo.lock
+++ b/batcher/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "aligned"
-version = "0.9.2"
+version = "0.10.1"
 dependencies = [
  "aligned-sdk",
  "clap",

--- a/batcher/aligned/Cargo.toml
+++ b/batcher/aligned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aligned"
-version = "0.9.2"
+version = "0.10.1"
 edition = "2021"
 
 [dependencies]

--- a/docs/3_guides/1_SDK_how_to.md
+++ b/docs/3_guides/1_SDK_how_to.md
@@ -12,7 +12,7 @@ To use this SDK in your Rust project, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.10.0" }
+aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.10.1" }
 ```
 
 To find the latest release tag go to [releases](https://github.com/yetanotherco/aligned_layer/releases) and copy the

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -40,7 +40,7 @@
 * [Operator FAQ](operator_guides/1_operator_FAQ.md)
 * [Troubleshooting](operator_guides/2_troubleshooting.md)
 * Upgrading Guides
-    * [Upgrading to v0.10.0](operator_guides/upgrading_guides/v0_10_0.md)
+    * [Upgrading to v0.10.1](operator_guides/upgrading_guides/v0_10_1.md)
     * [Upgrading to v0.9.2](operator_guides/upgrading_guides/v0_9_2.md)
 
 ## Useful links

--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -1,7 +1,7 @@
 # Register as an Aligned operator in testnet
 
 > **CURRENT VERSION:**
-> Aligned Operator [v0.10.0](https://github.com/yetanotherco/aligned_layer/releases/tag/v0.10.0)
+> Aligned Operator [v0.10.1](https://github.com/yetanotherco/aligned_layer/releases/tag/v0.10.1)
 
 > **IMPORTANT:** 
 > You must be [whitelisted](https://docs.google.com/forms/d/e/1FAIpQLSdH9sgfTz4v33lAvwj6BvYJGAeIshQia3FXz36PFfF-WQAWEQ/viewform) to become an Aligned operator.
@@ -26,7 +26,7 @@ Minimum hardware requirements:
 To start with, clone the Aligned repository and move inside it
 
 ```bash
-git clone https://github.com/yetanotherco/aligned_layer.git --branch v0.10.0
+git clone https://github.com/yetanotherco/aligned_layer.git --branch v0.10.1
 cd aligned_layer
 ```
 

--- a/docs/operator_guides/upgrading_guides/v0_10_1.md
+++ b/docs/operator_guides/upgrading_guides/v0_10_1.md
@@ -1,6 +1,6 @@
-# Upgrading to v0.10.0
+# Upgrading to v0.10.1
 
-This guide will walk you through the process of upgrading your Aligned Operator to v0.10.0.
+This guide will walk you through the process of upgrading your Aligned Operator to v0.10.1.
 
 ## Changes
 
@@ -49,7 +49,7 @@ To see the operator version, run:
 This will display the current version of the operator binary.
 
 ```
-Aligned Layer Node Operator version v0.10.0
+Aligned Layer Node Operator version v0.10.1
 ```
 
 ### Step 4 - Restart the Operator

--- a/operator/pkg/utils.go
+++ b/operator/pkg/utils.go
@@ -2,11 +2,9 @@ package operator
 
 import (
 	"fmt"
+	"github.com/yetanotherco/aligned_layer/common"
 	"math/big"
 	"regexp"
-	"strings"
-
-	"github.com/yetanotherco/aligned_layer/common"
 )
 
 func IsVerifierDisabled(disabledVerifiersBitmap *big.Int, verifierId common.ProvingSystemId) bool {
@@ -31,15 +29,6 @@ func BaseUrlOnly(input string) (string, error) {
 	}
 
 	host := matches[2]
-	path := matches[3]
-
-	// If the path is not empty, append the path without the last segment (api_key)
-	if path != "" {
-		pathSegments := strings.Split(path, "/")
-		if len(pathSegments) > 1 {
-			return host + strings.Join(pathSegments[:len(pathSegments)-1], "/"), nil
-		}
-	}
 
 	return host, nil
 }

--- a/operator/pkg/utils_test.go
+++ b/operator/pkg/utils_test.go
@@ -57,7 +57,13 @@ func TestBaseUrlOnlyHappyPath(t *testing.T) {
 		{"http://localhost:8545/asdfoij2a7831has89%342jddav98j2748", "localhost:8545"},
 		{"ws://test.com/23r2f98hkjva0udhvi1j%342jddav98j2748", "test.com"},
 		{"http://localhost:8545", "localhost:8545"},
-		{"https://myservice.com/holesky/ApiKey", "myservice.com/holesky"},
+		{"https://myservice.com/holesky/ApiKey", "myservice.com"},
+		{"https://holesky.myservice.com/holesky", "holesky.myservice.com"},
+		{"https://eth-mainnet.blastapi.io/12345678-abcd-1234-abcd-123456789012", "eth-mainnet.blastapi.io"},
+		{"https://eth-holesky.g.alchemy.com/v2/1234567890_abcdefghijklmnopqrstuv/", "eth-holesky.g.alchemy.com"},
+		{"https://a.b.c.d/1234", "a.b.c.d"},
+		{"https://a.b.c.d/1234/5678", "a.b.c.d"},
+		{"https://a.b.c.d.e/1234/", "a.b.c.d.e"},
 	}
 
 	for _, pair := range urls {


### PR DESCRIPTION
# Description

We missed to catch a case where the url is `https://rpc/apikey/ `.
It was sending the `apiKey` because it only was cutting the latest `/`

- fix(operator): send only rpc host to telemetry service
- chore: update operator and client version to v0.10.1
- docs: update to v0.10.1

# How to Test

1. `cd operator/pkg`
2. `go test`

## Type of change

-  Bug fix

## Checklist

- Unit tests added
 - Documentation has been added/updated.
