### PR TITLE
refactor(operator): use url.Parse instead of regex for sending rpc information to telemetry service

### DIFF
--- a/operator/pkg/utils.go
+++ b/operator/pkg/utils.go
@@ -1,10 +1,9 @@
 package operator
 
 import (
-	"fmt"
 	"github.com/yetanotherco/aligned_layer/common"
 	"math/big"
-	"regexp"
+	"net/url"
 )
 
 func IsVerifierDisabled(disabledVerifiersBitmap *big.Int, verifierId common.ProvingSystemId) bool {
@@ -17,18 +16,11 @@ func IsVerifierDisabled(disabledVerifiersBitmap *big.Int, verifierId common.Prov
 }
 
 func BaseUrlOnly(input string) (string, error) {
-	// Define a regex pattern to match the URL format
-	// The pattern captures the scheme, host, and path
-	pattern := `^(?P<scheme>[^:]+)://(?P<host>[^/]+)(?P<path>/.*)?$`
-	re := regexp.MustCompile(pattern)
-
-	matches := re.FindStringSubmatch(input)
-
-	if matches == nil {
-		return "", fmt.Errorf("invalid URL: %s", input)
+	// https://gobyexample.com/url-parsing
+	u, err := url.Parse(input)
+	if err != nil {
+		return "", err
 	}
 
-	host := matches[2]
-
-	return host, nil
+	return u.Host, nil
 }

--- a/operator/pkg/utils_test.go
+++ b/operator/pkg/utils_test.go
@@ -64,6 +64,13 @@ func TestBaseUrlOnlyHappyPath(t *testing.T) {
 		{"https://a.b.c.d/1234", "a.b.c.d"},
 		{"https://a.b.c.d/1234/5678", "a.b.c.d"},
 		{"https://a.b.c.d.e/1234/", "a.b.c.d.e"},
+		{"https://a.b.c.d?e=1234", "a.b.c.d"},
+		{"https://a.b.c.d/rpc?e=1234", "a.b.c.d"},
+		{"wss://a.b.c.d/1234", "a.b.c.d"},
+		{"wss://a.b.c.d/1234/5678", "a.b.c.d"},
+		{"wss://a.b.c.d.e/1234/", "a.b.c.d.e"},
+		{"wss://a.b.c.d?e=1234", "a.b.c.d"},
+		{"wss://a.b.c.d/rpc?e=1234", "a.b.c.d"},
 	}
 
 	for _, pair := range urls {
@@ -78,22 +85,6 @@ func TestBaseUrlOnlyHappyPath(t *testing.T) {
 
 		if baseUrl != expectedBaseUrl {
 			t.Errorf("Expected base URL %s, got %s for URL %s", expectedBaseUrl, baseUrl, url)
-		}
-	}
-}
-
-func TestBaseUrlOnlyFailureCases(t *testing.T) {
-
-	urls := [...]string{
-		"localhost:8545/asdfoij2a7831has89%342jddav98j2748",
-		"this-is-all-wrong",
-	}
-
-	for _, url := range urls {
-		baseUrl, err := BaseUrlOnly(url)
-
-		if err == nil {
-			t.Errorf("An error was expected, but received %s", baseUrl)
 		}
 	}
 }


### PR DESCRIPTION
# Use url.Parse instead of regex for sending rpc information to telemetry service

## Description

The previous version was using a regex to get the host of the RPC provider. This makes difficult to be sure it covers al cases and if the process fails, regexp.MustCompile panics

The new version uses the url.Parse from the Go net library (https://gobyexample.com/url-parsing). This way the process of parse urls is more robust and safe.

## Type of change

- [x] Refactor

## How to Test

1. `cd operator/pkg`
2. `go test`

## Checklist

- Unit tests added
