### PR TITLE
fix: commands linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ ifeq ($(OS),Darwin)
 endif
 
 ifeq ($(OS),Linux)
-	LD_LIBRARY_PATH+=$(CURDIR)/operator/risc_zero_old/lib:$(CURDIR)/operator/risc_zero/lib
+	export LD_LIBRARY_PATH+=$(CURDIR)/operator/risc_zero_old/lib:$(CURDIR)/operator/risc_zero/lib
+	OPERATOR_FFIS=$(CURDIR)/operator/risc_zero_old/lib:$(CURDIR)/operator/risc_zero/lib
 endif
 
 ifeq ($(OS),Linux)
@@ -141,7 +142,7 @@ build_operator_macos:
 
 build_operator_linux:
 	@echo "Building Operator..."
-	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION) -r $(LD_LIBRARY_PATH)" -o ./operator/build/aligned-operator ./operator/cmd/main.go
+	@go build -ldflags "-X main.Version=$(OPERATOR_VERSION) -r $(OPERATOR_FFIS)" -o ./operator/build/aligned-operator ./operator/cmd/main.go
 	@echo "Operator built into /operator/build/aligned-operator"
 
 update_operator:


### PR DESCRIPTION
# Fix commands on linux (for real)

## Description
This pr #1254 fixed Linux commands but broke the `build_operator_linux`, this other pr #1299 fixed `build_operator_linux` but broke all the other Linux commands. This pr (hopefully) fixes it once and for all.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix

## Test
Go to a Linux machine and verify that `build_operator_linux` and `operator_register_and_start` work. When doing `build_operator_linux` make sure you run the command as well.

## Checklist
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
