### PR TITLE
refactor(aggregator): move `timeToExpiry` task to config file

### DIFF
--- a/aggregator/internal/pkg/aggregator.go
+++ b/aggregator/internal/pkg/aggregator.go
@@ -215,8 +215,6 @@ func (agg *Aggregator) Start(ctx context.Context) error {
 
 const MaxSentTxRetries = 5
 
-const BLS_AGG_SERVICE_TIMEOUT = 100 * time.Second
-
 func (agg *Aggregator) handleBlsAggServiceResponse(blsAggServiceResp blsagg.BlsAggregationServiceResponse) {
 	agg.taskMutex.Lock()
 	agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Fetching task data")
@@ -375,7 +373,7 @@ func (agg *Aggregator) AddNewTask(batchMerkleRoot [32]byte, senderAddress [20]by
 	quorumNums := eigentypes.QuorumNums{eigentypes.QuorumNum(QUORUM_NUMBER)}
 	quorumThresholdPercentages := eigentypes.QuorumThresholdPercentages{eigentypes.QuorumThresholdPercentage(QUORUM_THRESHOLD)}
 
-	err := agg.blsAggregationService.InitializeNewTask(batchIndex, taskCreatedBlock, quorumNums, quorumThresholdPercentages, BLS_AGG_SERVICE_TIMEOUT)
+	err := agg.blsAggregationService.InitializeNewTask(batchIndex, taskCreatedBlock, quorumNums, quorumThresholdPercentages, agg.AggregatorConfig.Aggregator.BlsServiceTaskTimeout)
 	// FIXME(marian): When this errors, should we retry initializing new task? Logging fatal for now.
 	if err != nil {
 		agg.logger.Fatalf("BLS aggregation service error when initializing new task: %s", err)

--- a/config-files/config-aggregator-docker.yaml
+++ b/config-files/config-aggregator-docker.yaml
@@ -30,3 +30,4 @@ aggregator:
   garbage_collector_period: 2m #The period of the GC process. Suggested value for Prod: '168h' (7 days)
   garbage_collector_tasks_age: 20 #The age of tasks that will be removed by the GC, in blocks. Suggested value for prod: '216000' (30 days)
   garbage_collector_tasks_interval: 10 #The interval of queried blocks to get an old batch. Suggested value for prod: '900' (3 hours)
+  bls_service_task_timeout: 168h # The timeout of bls aggregation service tasks. Suggested value for prod '168h' (7 days)

--- a/config-files/config-aggregator.yaml
+++ b/config-files/config-aggregator.yaml
@@ -37,6 +37,7 @@ aggregator:
   garbage_collector_period: 2m #The period of the GC process. Suggested value for Prod: '168h' (7 days)
   garbage_collector_tasks_age: 20 #The age of tasks that will be removed by the GC, in blocks. Suggested value for prod: '216000' (30 days)
   garbage_collector_tasks_interval: 10 #The interval of queried blocks to get an old batch. Suggested value for prod: '900' (3 hours)
+  bls_service_task_timeout: 168h # The timeout of bls aggregation service tasks. Suggested value for prod '168h' (7 days)
 
 ## Operator Configurations
 # operator:

--- a/config-files/config.yaml
+++ b/config-files/config.yaml
@@ -35,6 +35,7 @@ aggregator:
   avs_service_manager_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
   enable_metrics: true
   metrics_ip_port_address: localhost:9091
+  bls_service_task_timeout: 168h # The timeout of bls aggregation service tasks. Suggested value for prod '168h' (7 days)
 
 ## Operator Configurations
 operator:

--- a/core/config/aggregator.go
+++ b/core/config/aggregator.go
@@ -24,6 +24,7 @@ type AggregatorConfig struct {
 		GarbageCollectorPeriod        time.Duration
 		GarbageCollectorTasksAge      uint64
 		GarbageCollectorTasksInterval uint64
+		BlsServiceTaskTimeout         time.Duration
 	}
 }
 
@@ -38,6 +39,7 @@ type AggregatorConfigFromYaml struct {
 		GarbageCollectorPeriod        time.Duration  `yaml:"garbage_collector_period"`
 		GarbageCollectorTasksAge      uint64         `yaml:"garbage_collector_tasks_age"`
 		GarbageCollectorTasksInterval uint64         `yaml:"garbage_collector_tasks_interval"`
+		BlsServiceTaskTimeout         time.Duration  `yaml:"bls_service_task_timeout"`
 	} `yaml:"aggregator"`
 }
 
@@ -82,6 +84,7 @@ func NewAggregatorConfig(configFilePath string) *AggregatorConfig {
 			GarbageCollectorPeriod        time.Duration
 			GarbageCollectorTasksAge      uint64
 			GarbageCollectorTasksInterval uint64
+			BlsServiceTaskTimeout         time.Duration
 		}(aggregatorConfigFromYaml.Aggregator),
 	}
 }


### PR DESCRIPTION
## Description

This pr moves the `timeToExpiry` time set when Initializing a new task in the aggregator to the config file and sets it to a week by default.

## Testing

1. Setup a localtestnet with 1 operator.
2. Kill the operator
3. Sends proofs
5. Restart the operator after some time and you should expect the right behavior based on the value you provided in the config file.

## Type of change

- [x] Refactor

## Checklist

- [x] “Hotfix” to testnet, everything else to staging
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [x] Has a known issue
  - Closes #1207 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible