### PR TITLE
fix: use fallbackclient in waitForTransactionReceipt

### DIFF
--- a/core/utils/eth_client_utils.go
+++ b/core/utils/eth_client_utils.go
@@ -24,7 +24,7 @@ func WaitForTransactionReceiptRetryable(client eth.InstrumentedClient, fallbackC
 	receipt_func := func() (*types.Receipt, error) {
 		receipt, err := client.TransactionReceipt(context.Background(), txHash)
 		if err != nil {
-			receipt, err = client.TransactionReceipt(context.Background(), txHash)
+			receipt, err = fallbackClient.TransactionReceipt(context.Background(), txHash)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Description

Uses the fallbackClient in `waitForTransactionReceipt`, we were getting it from the params but not using it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it](#1418 ) 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
