### PR TITLE
fix(aggregator): add garbage collector mutex

### DIFF
--- a/aggregator/pkg/aggregator.go
+++ b/aggregator/pkg/aggregator.go
@@ -74,7 +74,12 @@ type Aggregator struct {
 	// Note: In case of a reboot it can start from 0 again
 	nextBatchIndex uint32
 
-	// Mutex to protect batchesIdentifierHashByIdx, batchesIdxByIdentifierHash and nextBatchIndex
+	// Mutex to protect:
+	// - batchesIdentifierHashByIdx
+	// - batchesIdxByIdentifierHash
+	// - batchCreatedBlockByIdx
+	// - batchDataByIdentifierHash
+	// - nextBatchIndex
 	taskMutex *sync.Mutex
 
 	// Mutex to protect ethereum wallet
@@ -443,6 +448,8 @@ func (agg *Aggregator) ClearTasksFromMaps() {
 			agg.logger.Warn("No old tasks found")
 			continue // Retry in the next iteration
 		}
+		agg.taskMutex.Lock()
+		agg.AggregatorConfig.BaseConfig.Logger.Info("- Locked Resources: Cleaning finalized tasks")
 
 		taskIdxToDelete := agg.batchesIdxByIdentifierHash[*oldTaskIdHash]
 		agg.logger.Info("Old task found", "taskIndex", taskIdxToDelete)
@@ -460,6 +467,8 @@ func (agg *Aggregator) ClearTasksFromMaps() {
 			}
 		}
 		lastIdxDeleted = taskIdxToDelete
+		agg.taskMutex.Unlock()
+		agg.AggregatorConfig.BaseConfig.Logger.Info("- Unlocked Resources: Cleaning finalized tasks")
 		agg.AggregatorConfig.BaseConfig.Logger.Info("Done cleaning finalized tasks from maps")
 	}
 }


### PR DESCRIPTION
# Add mutex to garbage collector go routine

## Description

This PR adds `taskMutex` protection to the `ClearTasksFromMaps` go routine that its used to clear old finalized tasks on the aggregator. Currently, we are deleting entries on the internal map, which is accessed by multiple go routines concurrently, without first locking the mutex.

## Type of change

- [X] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [X] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [X] Has a known issue
  - #1416 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
  
## How to test

Just start all te services and start sending proofs with `make batcher_send_infinite_sp1`. Wait a few minutes until you see the garbage collector running:

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/824cfdc2-28de-41cf-90b6-e6b2694538bf">

You should also see the batches being verified in the explorer, as normal  
  
Closes #1416 