### PR TITLE
feat(operator): `SendSignedTaskResponse` Retries

### DIFF
--- a/config-files/config-operator-test.yaml
+++ b/config-files/config-operator-test.yaml
@@ -1,0 +1,41 @@
+# Common variables for all the services
+# 'production' only prints info and above. 'development' also prints debug
+environment: 'development'
+aligned_layer_deployment_config_file_path: '../contracts/script/output/devnet/alignedlayer_deployment_output.json'
+eigen_layer_deployment_config_file_path: '../contracts/script/output/devnet/eigenlayer_deployment_output.json'
+eth_rpc_url: 'http://localhost:8545'
+eth_rpc_url_fallback: 'http://localhost:8545'
+eth_ws_url: 'ws://localhost:8545'
+eth_ws_url_fallback: 'ws://localhost:8545'
+eigen_metrics_ip_port_address: 'localhost:9090'
+
+## ECDSA Configurations
+ecdsa:
+  private_key_store_path: '../config-files/devnet/keys/operator-1.ecdsa.key.json'
+  private_key_store_password: ''
+
+## BLS Configurations
+bls:
+  private_key_store_path: '../config-files/devnet/keys/operator-1.bls.key.json'
+  private_key_store_password: ''
+
+## Operator Configurations
+operator:
+  aggregator_rpc_server_ip_port_address: localhost:8090
+  operator_tracker_ip_port_address: http://localhost:4001
+  address: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+  earnings_receiver_address: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+  delegation_approver_address: '0x0000000000000000000000000000000000000000'
+  staker_opt_out_window_blocks: 0
+  metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'
+  enable_metrics: true
+  metrics_ip_port_address: localhost:9092
+  max_batch_size: 268435456 # 256 MiB
+  last_processed_batch_filepath: '../config-files/operator-1.last_processed_batch.json'
+
+# Operators variables needed for register it in EigenLayer
+el_delegation_manager_address: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9'
+private_key_store_path: config-files/devnet/keys/operator-1.ecdsa.key.json
+bls_private_key_store_path: config-files/devnet/keys/operator-1.bls.key.json
+signer_type: local_keystore
+chain_id: 31337

--- a/core/retry.go
+++ b/core/retry.go
@@ -159,6 +159,7 @@ request     retry_interval (12 sec)    randomized_interval (0.5)		randomized_int
 Reference: https://github.com/cenkalti/backoff/blob/v4/exponential.go#L9
 */
 
+// TODO: Make config optional by using default but passing nil.
 // Same as Retry only that the functionToRetry can return a value upon correct execution
 func RetryWithData[T any](functionToRetry func() (T, error), config *RetryParams) (T, error) {
 	f := func() (T, error) {

--- a/core/retry.go
+++ b/core/retry.go
@@ -159,7 +159,6 @@ request     retry_interval (12 sec)    randomized_interval (0.5)		randomized_int
 Reference: https://github.com/cenkalti/backoff/blob/v4/exponential.go#L9
 */
 
-// TODO: Make config optional by using default but passing nil.
 // Same as Retry only that the functionToRetry can return a value upon correct execution
 func RetryWithData[T any](functionToRetry func() (T, error), config *RetryParams) (T, error) {
 	f := func() (T, error) {

--- a/core/utils/eth_client_utils.go
+++ b/core/utils/eth_client_utils.go
@@ -86,6 +86,7 @@ func CalculateGasPriceBumpBasedOnRetry(currentGasPrice *big.Int, baseBumpPercent
 	return bumpedGasPrice
 }
 
+//TODO: move to retryable function file
 /*
 GetGasPriceRetryable
 Get the gas price from the client with retry logic.

--- a/core/utils/eth_client_utils.go
+++ b/core/utils/eth_client_utils.go
@@ -31,7 +31,19 @@ func WaitForTransactionReceiptRetryable(client eth.InstrumentedClient, fallbackC
 		}
 		return receipt, nil
 	}
-	return retry.RetryWithData(receipt_func, config)
+	return receipt_func
+}
+
+// WaitForTransactionReceiptRetryable repeatedly attempts to fetch the transaction receipt for a given transaction hash.
+// If the receipt is not found, the function will retry with exponential backoff until the specified `waitTimeout` duration is reached.
+// If the receipt is still unavailable after `waitTimeout`, it will return an error.
+//
+// Note: The `time.Second * 2` is set as the max interval in the retry mechanism because we can't reliably measure the specific time the tx will be included in a block.
+// Setting a higher value will imply doing less retries across the waitTimeout, and so we might lose the receipt
+// All errors are considered Transient Errors
+// - Retry times: 0.5s, 1s, 2s, 2s, 2s, ... until it reaches waitTimeout
+func WaitForTransactionReceiptRetryable(client eth.InstrumentedClient, fallbackClient eth.InstrumentedClient, txHash gethcommon.Hash, config *retry.RetryConfig) (*types.Receipt, error) {
+	return retry.RetryWithData(WaitForTransactionReceipt(client, fallbackClient, txHash, config), config)
 }
 
 func BytesToQuorumNumbers(quorumNumbersBytes []byte) eigentypes.QuorumNums {

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -334,7 +334,10 @@ func (o *Operator) handleNewBatchLogV2(newBatchLog *servicemanager.ContractAlign
 		hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 	)
 
-	o.aggRpcClient.SendSignedTaskResponseToAggregatorRetryable(&signedTaskResponse)
+	_, err = o.aggRpcClient.SendSignedTaskResponseToAggregatorRetryable(&signedTaskResponse)
+	if err != nil {
+		o.Logger.Infof("Failed to send signed task response %x to Aggregator. Err: %v", signedTaskResponse.BatchMerkleRoot, err)
+	}
 }
 func (o *Operator) ProcessNewBatchLogV2(newBatchLog *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2) error {
 
@@ -415,7 +418,10 @@ func (o *Operator) handleNewBatchLogV3(newBatchLog *servicemanager.ContractAlign
 		hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 	)
 
-	o.aggRpcClient.SendSignedTaskResponseToAggregatorRetryable(&signedTaskResponse)
+	_, err = o.aggRpcClient.SendSignedTaskResponseToAggregatorRetryable(&signedTaskResponse)
+	if err != nil {
+		o.Logger.Infof("Failed to send signed task response %x to Aggregator. Err: %v", signedTaskResponse.BatchMerkleRoot, err)
+	}
 }
 func (o *Operator) ProcessNewBatchLogV3(newBatchLog *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3) error {
 

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -334,7 +334,7 @@ func (o *Operator) handleNewBatchLogV2(newBatchLog *servicemanager.ContractAlign
 		hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 	)
 
-	o.aggRpcClient.SendSignedTaskResponseToAggregator(&signedTaskResponse)
+	o.aggRpcClient.SendSignedTaskResponseToAggregatorRetryable(&signedTaskResponse)
 }
 func (o *Operator) ProcessNewBatchLogV2(newBatchLog *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2) error {
 
@@ -415,7 +415,7 @@ func (o *Operator) handleNewBatchLogV3(newBatchLog *servicemanager.ContractAlign
 		hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 	)
 
-	o.aggRpcClient.SendSignedTaskResponseToAggregator(&signedTaskResponse)
+	o.aggRpcClient.SendSignedTaskResponseToAggregatorRetryable(&signedTaskResponse)
 }
 func (o *Operator) ProcessNewBatchLogV3(newBatchLog *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3) error {
 


### PR DESCRIPTION
# Add Retry Logic to `SendSignedTaskResponse`
## Description

#closes 1415

Note: I tested this running a local devnet and had no issues. However, I encountered issues stopping the aggregator while writing a unit test and found the rpc client function panic'd when the connection was cut. I discussed this with @Oppen but will take time to investigate it further.

## How to test

### In devnet

1. `make anvil_start_with_block_time`
2. `make aggregator_start`
3. `make operator_full_registration CONFIG_FILE=config-files/config-operator-1.yaml` 
4. `make operator_start CONFIG_FILE=config-files/config-operator-1.yaml`
5. `make batcher_start_local`
6. `make telemetry_full_start`

Once you have the system running, send proofs

7. `make batcher_send_burst_groth16`
8. Go to jaeger `http://localhost:16686/search`
9. You should see the traces correctly created and task verified
<img width="939" alt="image" src="https://github.com/user-attachments/assets/e600fa00-5c11-4fdc-b028-5641890d86a8">

## Type of change

- [x] New feature

## Checklist

- [https://github.com/yetanotherco/aligned_layer/issues/1415] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [x] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
