### PR TITLE
fix: set path in gnark generator script correctly

### DIFF
--- a/scripts/test_files/gnark_groth16_bn254_infinite_script/cmd/main.go
+++ b/scripts/test_files/gnark_groth16_bn254_infinite_script/cmd/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	x, err := strconv.Atoi(os.Args[1])
-	outputDir := "../../scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/"
+	outputDir := "scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/"
 
 	if len(os.Args) > 2 {
 		outputDir = os.Args[2]


### PR DESCRIPTION
# set path in gnark generator script correctly

## Description

set path in gnark generator script correctly

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
