### PR TITLE
nit(retries): Add description and suffix to GetTaskIndex

### DIFF
--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -110,8 +110,8 @@ func (agg *Aggregator) ServerRunning(_ *struct{}, reply *int64) error {
 	return nil
 }
 
-// Checks Internal mapping for Signed Task Response, returns its TaskIndex.
 /*
+Checks Internal mapping for Signed Task Response, returns its TaskIndex.
 - All errors are considered Transient Errors
 - Retry times (3 retries): 1 sec, 2 sec, 4 sec
 

--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -50,10 +50,10 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 		"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
 	taskIndex := uint32(0)
 
-	// Aggregator may receive the Task Identifier after the operators.
+	// The Aggregator may receive the Task Identifier after the operators.
 	// If that's the case, we won't know about the task at this point
-	// so we make the GetTask retryabl, waiting for some seconds,
-	// before trying to fetch it again
+	// so we make GetTaskIndex retryable, waiting for some seconds,
+	// before trying to fetch the task again from the map.
 	taskIndex, err := agg.GetTaskIndexRetryable(signedTaskResponse.BatchIdentifierHash)
 
 	if err != nil {

--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -114,6 +114,8 @@ func (agg *Aggregator) ServerRunning(_ *struct{}, reply *int64) error {
 /*
 - All errors are considered Transient Errors
 - Retry times (3 retries): 1 sec, 2 sec, 4 sec
+
+TODO: This should retry a bit more, at least somewhere between 1 and 2 blocks
 */
 func (agg *Aggregator) GetTaskIndexRetryable(batchIdentifierHash [32]byte) (uint32, error) {
 	getTaskIndex_func := func() (uint32, error) {

--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -115,7 +115,7 @@ func (agg *Aggregator) ServerRunning(_ *struct{}, reply *int64) error {
 - All errors are considered Transient Errors
 - Retry times (3 retries): 1 sec, 2 sec, 4 sec
 
-TODO: This should retry a bit more, at least somewhere between 1 and 2 blocks
+TODO: We should refactor the retry duration considering extending it to a larger time or number of retries, at least somewhere between 1 and 2 blocks
 */
 func (agg *Aggregator) GetTaskIndexRetryable(batchIdentifierHash [32]byte) (uint32, error) {
 	getTaskIndex_func := func() (uint32, error) {


### PR DESCRIPTION
# Add Description and suffix to GetTaskIndex

## Description

Add Description and suffix to GetTaskIndex

## Type of change

Please delete options that are not relevant.

- [x] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
