### PR TITLE
fix: replace error type logs to warn type logs on telemetry

### DIFF
--- a/aggregator/pkg/telemetry.go
+++ b/aggregator/pkg/telemetry.go
@@ -68,7 +68,7 @@ func (t *Telemetry) InitNewTrace(batchMerkleRoot [32]byte) {
 		MerkleRoot: fmt.Sprintf("0x%s", hex.EncodeToString(batchMerkleRoot[:])),
 	}
 	if err := t.sendTelemetryMessage("/api/initTaskTrace", body); err != nil {
-		t.logger.Error("[Telemetry] Error in InitNewTrace", "error", err)
+		t.logger.Warn("[Telemetry] Error in InitNewTrace", "error", err)
 	}
 }
 
@@ -78,7 +78,7 @@ func (t *Telemetry) LogOperatorResponse(batchMerkleRoot [32]byte, operatorId [32
 		OperatorId: fmt.Sprintf("0x%s", hex.EncodeToString(operatorId[:])),
 	}
 	if err := t.sendTelemetryMessage("/api/operatorResponse", body); err != nil {
-		t.logger.Error("[Telemetry] Error in LogOperatorResponse", "error", err)
+		t.logger.Warn("[Telemetry] Error in LogOperatorResponse", "error", err)
 	}
 }
 
@@ -87,7 +87,7 @@ func (t *Telemetry) LogQuorumReached(batchMerkleRoot [32]byte) {
 		MerkleRoot: fmt.Sprintf("0x%s", hex.EncodeToString(batchMerkleRoot[:])),
 	}
 	if err := t.sendTelemetryMessage("/api/quorumReached", body); err != nil {
-		t.logger.Error("[Telemetry] Error in LogQuorumReached", "error", err)
+		t.logger.Warn("[Telemetry] Error in LogQuorumReached", "error", err)
 	}
 }
 
@@ -97,7 +97,7 @@ func (t *Telemetry) LogTaskError(batchMerkleRoot [32]byte, taskError error) {
 		TaskError:  taskError.Error(),
 	}
 	if err := t.sendTelemetryMessage("/api/taskError", body); err != nil {
-		t.logger.Error("[Telemetry] Error in LogTaskError", "error", err)
+		t.logger.Warn("[Telemetry] Error in LogTaskError", "error", err)
 	}
 }
 
@@ -107,7 +107,7 @@ func (t *Telemetry) BumpedTaskGasPrice(batchMerkleRoot [32]byte, bumpedGasPrice 
 		BumpedGasPrice: bumpedGasPrice,
 	}
 	if err := t.sendTelemetryMessage("/api/aggregatorTaskGasPriceBump", body); err != nil {
-		t.logger.Error("[Telemetry] Error in LogOperatorResponse", "error", err)
+		t.logger.Warn("[Telemetry] Error in LogOperatorResponse", "error", err)
 	}
 }
 
@@ -117,7 +117,7 @@ func (t *Telemetry) TaskSentToEthereum(batchMerkleRoot [32]byte, txHash string) 
 		TxHash:     txHash,
 	}
 	if err := t.sendTelemetryMessage("/api/aggregatorTaskSent", body); err != nil {
-		t.logger.Error("[Telemetry] Error in TaskSentToEthereum", "error", err)
+		t.logger.Warn("[Telemetry] Error in TaskSentToEthereum", "error", err)
 	}
 }
 
@@ -129,7 +129,7 @@ func (t *Telemetry) FinishTrace(batchMerkleRoot [32]byte) {
 			MerkleRoot: fmt.Sprintf("0x%s", hex.EncodeToString(batchMerkleRoot[:])),
 		}
 		if err := t.sendTelemetryMessage("/api/finishTaskTrace", body); err != nil {
-			t.logger.Error("[Telemetry] Error in FinishTrace", "error", err)
+			t.logger.Warn("[Telemetry] Error in FinishTrace", "error", err)
 		}
 	}()
 }
@@ -137,7 +137,7 @@ func (t *Telemetry) FinishTrace(batchMerkleRoot [32]byte) {
 func (t *Telemetry) sendTelemetryMessage(endpoint string, message interface{}) error {
 	encodedBody, err := json.Marshal(message)
 	if err != nil {
-		t.logger.Error("[Telemetry] Error marshalling JSON", "error", err)
+		t.logger.Warn("[Telemetry] Error marshalling JSON", "error", err)
 		return fmt.Errorf("error marshalling JSON: %w", err)
 	}
 
@@ -147,14 +147,14 @@ func (t *Telemetry) sendTelemetryMessage(endpoint string, message interface{}) e
 
 	resp, err := t.client.Post(fullURL.String(), "application/json", bytes.NewBuffer(encodedBody))
 	if err != nil {
-		t.logger.Error("[Telemetry] Error sending POST request", "error", err)
+		t.logger.Warn("[Telemetry] Error sending POST request", "error", err)
 		return fmt.Errorf("error making POST request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.logger.Error("[Telemetry] Error reading response body", "error", err)
+		t.logger.Warn("[Telemetry] Error reading response body", "error", err)
 		return fmt.Errorf("error reading response body: %w", err)
 	}
 

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1253,7 +1253,7 @@ impl Batcher {
             .init_task_trace(&hex::encode(batch_merkle_tree.root))
             .await
         {
-            error!("Failed to initialize task trace on telemetry: {:?}", e);
+            warn!("Failed to initialize task trace on telemetry: {:?}", e);
         }
 
         if let Err(e) = self
@@ -1272,7 +1272,7 @@ impl Batcher {
                 .task_creation_failed(&hex::encode(batch_merkle_tree.root), &reason)
                 .await
             {
-                error!("Failed to send task status to telemetry: {:?}", e);
+                warn!("Failed to send task status to telemetry: {:?}", e);
             }
             for entry in finalized_batch.into_iter() {
                 if let Some(ws_sink) = entry.messaging_sink {
@@ -1396,7 +1396,7 @@ impl Batcher {
             .task_uploaded_to_s3(&batch_merkle_root_hex)
             .await
         {
-            error!("Failed to send task status to telemetry: {:?}", e);
+            warn!("Failed to send task status to telemetry: {:?}", e);
         };
         info!("Batch sent to S3 with name: {}", file_name);
 
@@ -1439,7 +1439,7 @@ impl Batcher {
             )
             .await
         {
-            error!("Failed to send task status to telemetry: {:?}", e);
+            warn!("Failed to send task status to telemetry: {:?}", e);
         };
 
         match self
@@ -1504,7 +1504,7 @@ impl Batcher {
                     .task_sent(&hex::encode(batch_merkle_root), receipt.transaction_hash)
                     .await
                 {
-                    error!("Failed to send task status to telemetry: {:?}", e);
+                    warn!("Failed to send task status to telemetry: {:?}", e);
                 }
                 Ok(receipt)
             }


### PR DESCRIPTION
# Replace error type logs to warn on Telemetry

## Description

This PR modifies the type of log message from `error` to `warn` logged on batcher and aggregator when an error occurs when a telemetry message tries to be sent.

## How to test

1. Start all the following services: batcher, aggregator, operator, telemetry
2. Start sending proofs
3. See in the logs that no error or warn is shown, because telemetry is still on
4. Shut down telemetry
5. Warns should appear in the logs of both the batcher and the aggregator

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [X] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
