### PR TITLE
fix: batcher flush queue

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1299,6 +1299,7 @@ impl Batcher {
                             );
                         }
                     }
+                    self.flush_queue_and_clear_nonce_cache();
                 }
             }
 

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1299,7 +1299,7 @@ impl Batcher {
                             );
                         }
                     }
-                    self.flush_queue_and_clear_nonce_cache();
+                    self.flush_queue_and_clear_nonce_cache().await;
                 }
             }
 
@@ -1311,7 +1311,7 @@ impl Batcher {
 
     async fn push_batch_proofs_back_to_queue(&self, batch: Vec<BatchQueueEntry>) {
         let mut batch_state = self.batch_state.lock().await;
-
+        warn!("Pushing batch proofs back to the queue");
         for entry in batch {
             let max_fee = entry.nonced_verification_data.max_fee;
             let nonce = entry.nonced_verification_data.nonce;


### PR DESCRIPTION
## Description

Modifies the batcher queue's behavior when encountering an error during task creation. Instead of flushing the entire queue by default, the logic now checks if the error resulted from a cancellation. If so, the affected batch entries are re-added to the queue. For all other error types, the queue will still be flushed.

Additionally, @JulianVentura is working on a separate PR to improve error handling by distinguishing between various error types during task submission. Once implemented, it will allow us to catch more scenarios where a complete queue flush isn't necessary.


**Testing**

The scenario of a canceled batch is hard to test locally. Instead, you can make the `push_batch_proofs_back_to_queue` logic run on any type of errs when submitting a batch:
```rust
1278:    match e {
1279:              _ => {
1280:                    self.push_batch_proofs_back_to_queue(finalized_batch.clone())
1281:                        .await
1282:                }
1283:    }
```

If you send two similar batches, the second one should fail but the queue should not be flushed and the user connection should remain open:
1. Send proofs: `make batcher_send_risc0_burst BURST_SIZE=2`
2. Wait till they are accepted and send them again: `make batcher_send_risc0_burst BURST_SIZE=2`
3. See that if fails but the connection remains open
4. Send more proofs: `make batcher_send_plonk_bls12_381_burst BURST_SIZE=4`
5. You should see that the task does not fail now.. 

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
