### PR TITLE
fix: parse error codes from createNewTask ethereum contract function

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1274,17 +1274,6 @@ impl Batcher {
             {
                 error!("Failed to send task status to telemetry: {:?}", e);
             }
-
-            // TODO: Here we have to match and handle the errors and flush the queue if necessary
-            // NoProofSubmitters
-            // NoFeePerProof
-            // InsufficientFeeForAggregator
-            // SubmissionInsufficientBalance
-            // BatchAlreadySubmitted
-            // InsufficientFunds
-            // OnlyBatcherAllowed
-            // Generic
-
             for entry in finalized_batch.into_iter() {
                 if let Some(ws_sink) = entry.messaging_sink {
                     let merkle_root = hex::encode(batch_merkle_tree.root);

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1274,6 +1274,17 @@ impl Batcher {
             {
                 error!("Failed to send task status to telemetry: {:?}", e);
             }
+
+            // TODO: Here we have to match and handle the errors and flush the queue if necessary
+            // NoProofSubmitters
+            // NoFeePerProof
+            // InsufficientFeeForAggregator
+            // SubmissionInsufficientBalance
+            // BatchAlreadySubmitted
+            // InsufficientFunds
+            // OnlyBatcherAllowed
+            // Generic
+
             for entry in finalized_batch.into_iter() {
                 if let Some(ws_sink) = entry.messaging_sink {
                     let merkle_root = hex::encode(batch_merkle_tree.root);

--- a/batcher/aligned-batcher/src/retry/batcher_retryables.rs
+++ b/batcher/aligned-batcher/src/retry/batcher_retryables.rs
@@ -10,7 +10,7 @@ use crate::{
         utils::get_current_nonce,
     },
     retry::RetryError,
-    types::errors::BatcherError,
+    types::errors::{BatcherError, TransactionSendError},
 };
 
 pub async fn get_user_balance_retryable(
@@ -130,7 +130,7 @@ pub async fn create_new_task_retryable(
             // Since transaction was reverted, we don't want to retry with fallback.
             warn!("Transaction reverted {:?}", err);
             return Err(RetryError::Permanent(BatcherError::TransactionSendError(
-                err.to_string(),
+                TransactionSendError::from(err),
             )));
         }
         _ => {
@@ -149,12 +149,12 @@ pub async fn create_new_task_retryable(
                 Err(ContractError::Revert(err)) => {
                     warn!("Transaction reverted {:?}", err);
                     return Err(RetryError::Permanent(BatcherError::TransactionSendError(
-                        err.to_string(),
+                        TransactionSendError::from(err),
                     )));
                 }
                 Err(err) => {
                     return Err(RetryError::Transient(BatcherError::TransactionSendError(
-                        err.to_string(),
+                        TransactionSendError::Generic(err.to_string()),
                     )))
                 }
             }

--- a/batcher/aligned-batcher/src/types/errors.rs
+++ b/batcher/aligned-batcher/src/types/errors.rs
@@ -1,7 +1,47 @@
 use std::fmt;
 
-use ethers::types::{Address, SignatureError};
+use ethers::types::{Address, Bytes, SignatureError};
 use tokio_tungstenite::tungstenite;
+
+pub enum TransactionSendError {
+    NoProofSubmitters,
+    NoFeePerProof,
+    InsufficientFeeForAggregator,
+    SubmissionInsufficientBalance,
+    BatchAlreadySubmitted,
+    InsufficientFunds,
+    OnlyBatcherAllowed,
+    Generic(String),
+}
+
+// TODO: Here we are missing the modifiers: onlyWhenNotPaused
+// TODO: Parse parameters from error responses
+
+impl From<Bytes> for TransactionSendError {
+    fn from(e: Bytes) -> Self {
+        let byte_string = e.to_string();
+        let str_code = if byte_string.len() >= 10 {
+            &byte_string[..10] // Extract the error code only
+        } else {
+            "" // Not gonna match
+        };
+        match str_code {
+            "0xc43ac290" => TransactionSendError::NoProofSubmitters, // can't happen
+            "0xa3a8658a" => TransactionSendError::NoFeePerProof,     // can't happen
+            "0x7899ec71" => TransactionSendError::InsufficientFeeForAggregator, // shouldn't happen,
+            // returning the proofs and retrying later may help
+            "0x4f779ceb" => TransactionSendError::SubmissionInsufficientBalance, // shouldn't happen,
+            // flush can help if something went wrong
+            "0x3102f10c" => TransactionSendError::BatchAlreadySubmitted,
+            "0x5c54305e" => TransactionSendError::InsufficientFunds,
+            "0x152bc288" => TransactionSendError::OnlyBatcherAllowed,
+            // flush can help if something went wrong
+            _ => {
+                TransactionSendError::Generic(format!("Unknown bytestring error: {}", byte_string))
+            }
+        }
+    }
+}
 
 pub enum BatcherError {
     TcpListenerError(String),
@@ -12,7 +52,7 @@ pub enum BatcherError {
     BatchUploadError(String),
     TaskCreationError(String),
     ReceiptNotFoundError,
-    TransactionSendError(String),
+    TransactionSendError(TransactionSendError),
     MaxRetriesReachedError,
     SerializationError(String),
     GasPriceError,
@@ -97,6 +137,37 @@ impl fmt::Debug for BatcherError {
                     "Error while trying to get disabled verifiers: {}",
                     reason
                 )
+            }
+        }
+    }
+}
+
+impl fmt::Display for TransactionSendError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TransactionSendError::NoProofSubmitters => {
+                write!(f, "No proof submitter error")
+            }
+            TransactionSendError::NoFeePerProof => {
+                write!(f, "No fee per proof")
+            }
+            TransactionSendError::InsufficientFeeForAggregator => {
+                write!(f, "Insufficient fee for aggregator")
+            }
+            TransactionSendError::SubmissionInsufficientBalance => {
+                write!(f, "Submission insufficient balance")
+            }
+            TransactionSendError::BatchAlreadySubmitted => {
+                write!(f, "Batch already submitted")
+            }
+            TransactionSendError::InsufficientFunds => {
+                write!(f, "Insufficient funds")
+            }
+            TransactionSendError::OnlyBatcherAllowed => {
+                write!(f, "Only batcher allowed")
+            }
+            TransactionSendError::Generic(e) => {
+                write!(f, "Generic error: {}", e)
             }
         }
     }

--- a/batcher/aligned-batcher/src/types/errors.rs
+++ b/batcher/aligned-batcher/src/types/errors.rs
@@ -35,7 +35,6 @@ impl From<Bytes> for TransactionSendError {
             "0x3102f10c" => TransactionSendError::BatchAlreadySubmitted,
             "0x5c54305e" => TransactionSendError::InsufficientFunds,
             "0x152bc288" => TransactionSendError::OnlyBatcherAllowed,
-            // flush can help if something went wrong
             _ => {
                 TransactionSendError::Generic(format!("Unknown bytestring error: {}", byte_string))
             }

--- a/batcher/aligned-batcher/src/types/errors.rs
+++ b/batcher/aligned-batcher/src/types/errors.rs
@@ -14,9 +14,6 @@ pub enum TransactionSendError {
     Generic(String),
 }
 
-// TODO: Here we are missing the modifiers: onlyWhenNotPaused
-// TODO: Parse parameters from error responses
-
 impl From<Bytes> for TransactionSendError {
     fn from(e: Bytes) -> Self {
         let byte_string = e.to_string();

--- a/batcher/aligned-batcher/src/types/errors.rs
+++ b/batcher/aligned-batcher/src/types/errors.rs
@@ -23,15 +23,15 @@ impl From<Bytes> for TransactionSendError {
             "" // Not gonna match
         };
         match str_code {
-            "0xc43ac290" => TransactionSendError::NoProofSubmitters, // can't happen
-            "0xa3a8658a" => TransactionSendError::NoFeePerProof,     // can't happen
-            "0x7899ec71" => TransactionSendError::InsufficientFeeForAggregator, // shouldn't happen,
+            "0xc43ac290" => TransactionSendError::NoProofSubmitters, // can't happen, don't flush
+            "0xa3a8658a" => TransactionSendError::NoFeePerProof,     // can't happen, don't flush
+            "0x7899ec71" => TransactionSendError::InsufficientFeeForAggregator, // shouldn't happen, don't flush
             // returning the proofs and retrying later may help
             "0x4f779ceb" => TransactionSendError::SubmissionInsufficientBalance, // shouldn't happen,
             // flush can help if something went wrong
-            "0x3102f10c" => TransactionSendError::BatchAlreadySubmitted,
-            "0x5c54305e" => TransactionSendError::InsufficientFunds,
-            "0x152bc288" => TransactionSendError::OnlyBatcherAllowed,
+            "0x3102f10c" => TransactionSendError::BatchAlreadySubmitted, // can happen, don't flush
+            "0x5c54305e" => TransactionSendError::InsufficientFunds, // shouldn't happen, don't flush
+            "0x152bc288" => TransactionSendError::OnlyBatcherAllowed, // won't happen, don't flush
             _ => {
                 TransactionSendError::Generic(format!("Unknown bytestring error: {}", byte_string))
             }


### PR DESCRIPTION
# Parse error codes from `createNewTask`

## Description

This PR adds parsing errors on batcher from the `createNewTask` function on ethereum `BatcherPaymentService` contract
Another PR will be made to add handling of modifiers `onlyWhenNotPaused` `whenNotPaused`, as well as improve the parsing of some revert errors by parsing the returned args.

## How to test

You will have to repeat this for each error:

1. Modify functions `createNewTask` from `BatcherPaymentService` or `AlignedServiceManager` to revert with an error handled in this PR
2. Build contracts into anvil state with `make anvil_deploy_aligned_contracts`
3. Run anvil
4. Start batcher
5. Send a burst of proofs
6. Watch it failing on the batcher logs
7. Repeat with another error

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
