### PR TITLE
feat: add simulate_create_new_task

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1481,7 +1481,7 @@ impl Batcher {
         fee_params: CreateNewTaskFeeParams,
     ) -> Result<TransactionReceipt, BatcherError> {
         // First, we simulate the tx
-        let result = retry_function(
+        retry_function(
             || {
                 simulate_create_new_task_retryable(
                     batch_merkle_root,
@@ -1497,11 +1497,8 @@ impl Batcher {
             ETHEREUM_CALL_MAX_RETRIES,
             ETHEREUM_CALL_MAX_RETRY_DELAY,
         )
-        .await;
-
-        if let Err(e) = result {
-            return Err(e.inner());
-        }
+        .await
+        .map_err(|e| e.inner())?;
 
         // Then, we send the real tx
         let result = retry_function(

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -8,7 +8,8 @@ use ethers::contract::ContractError;
 use ethers::signers::Signer;
 use retry::batcher_retryables::{
     cancel_create_new_task_retryable, create_new_task_retryable, get_user_balance_retryable,
-    get_user_nonce_from_ethereum_retryable, user_balance_is_unlocked_retryable,
+    get_user_nonce_from_ethereum_retryable, simulate_create_new_task_retryable,
+    user_balance_is_unlocked_retryable,
 };
 use retry::{retry_function, RetryError};
 use tokio::time::timeout;
@@ -1479,6 +1480,30 @@ impl Batcher {
         proof_submitters: Vec<Address>,
         fee_params: CreateNewTaskFeeParams,
     ) -> Result<TransactionReceipt, BatcherError> {
+        // First, we simulate the tx
+        let result = retry_function(
+            || {
+                simulate_create_new_task_retryable(
+                    batch_merkle_root,
+                    batch_data_pointer.clone(),
+                    proof_submitters.clone(),
+                    fee_params.clone(),
+                    &self.payment_service,
+                    &self.payment_service_fallback,
+                )
+            },
+            ETHEREUM_CALL_MIN_RETRY_DELAY,
+            ETHEREUM_CALL_BACKOFF_FACTOR,
+            ETHEREUM_CALL_MAX_RETRIES,
+            ETHEREUM_CALL_MAX_RETRY_DELAY,
+        )
+        .await;
+
+        if let Err(e) = result {
+            return Err(e.inner());
+        }
+
+        // Then, we send the real tx
         let result = retry_function(
             || {
                 create_new_task_retryable(

--- a/batcher/aligned-batcher/src/retry/batcher_retryables.rs
+++ b/batcher/aligned-batcher/src/retry/batcher_retryables.rs
@@ -202,7 +202,7 @@ pub async fn simulate_create_new_task_retryable(
             // Since transaction was reverted, we don't want to retry with fallback.
             warn!("Simulated transaction reverted {:?}", err);
             Err(RetryError::Permanent(BatcherError::TransactionSendError(
-                err.to_string(),
+                TransactionSendError::from(err),
             )))
         }
         _ => {
@@ -221,11 +221,11 @@ pub async fn simulate_create_new_task_retryable(
                 Err(ContractError::Revert(err)) => {
                     warn!("Simulated transaction reverted {:?}", err);
                     Err(RetryError::Permanent(BatcherError::TransactionSendError(
-                        err.to_string(),
+                        TransactionSendError::from(err),
                     )))
                 }
                 Err(err) => Err(RetryError::Transient(BatcherError::TransactionSendError(
-                    err.to_string(),
+                    TransactionSendError::Generic(err.to_string()),
                 ))),
             }
         }

--- a/batcher/aligned-batcher/src/retry/batcher_retryables.rs
+++ b/batcher/aligned-batcher/src/retry/batcher_retryables.rs
@@ -195,7 +195,7 @@ pub async fn simulate_create_new_task_retryable(
             fee_params.respond_to_task_fee_limit,
         )
         .gas_price(fee_params.gas_price);
-// sends an `eth_call` request to the node
+    // sends an `eth_call` request to the node
     match simulation.call().await {
         Ok(_) => Ok(()),
         Err(ContractError::Revert(err)) => {

--- a/batcher/aligned-batcher/src/retry/batcher_retryables.rs
+++ b/batcher/aligned-batcher/src/retry/batcher_retryables.rs
@@ -201,9 +201,9 @@ pub async fn simulate_create_new_task_retryable(
         Err(ContractError::Revert(err)) => {
             // Since transaction was reverted, we don't want to retry with fallback.
             warn!("Simulated transaction reverted {:?}", err);
-            return Err(RetryError::Permanent(BatcherError::TransactionSendError(
+            Err(RetryError::Permanent(BatcherError::TransactionSendError(
                 err.to_string(),
-            )));
+            )))
         }
         _ => {
             simulation_fallback = payment_service_fallback
@@ -220,15 +220,13 @@ pub async fn simulate_create_new_task_retryable(
                 Ok(_) => Ok(()),
                 Err(ContractError::Revert(err)) => {
                     warn!("Simulated transaction reverted {:?}", err);
-                    return Err(RetryError::Permanent(BatcherError::TransactionSendError(
-                        err.to_string(),
-                    )));
-                }
-                Err(err) => {
-                    return Err(RetryError::Transient(BatcherError::TransactionSendError(
+                    Err(RetryError::Permanent(BatcherError::TransactionSendError(
                         err.to_string(),
                     )))
                 }
+                Err(err) => Err(RetryError::Transient(BatcherError::TransactionSendError(
+                    err.to_string(),
+                ))),
             }
         }
     }

--- a/batcher/aligned-batcher/src/retry/batcher_retryables.rs
+++ b/batcher/aligned-batcher/src/retry/batcher_retryables.rs
@@ -175,6 +175,65 @@ pub async fn create_new_task_retryable(
         .ok_or(RetryError::Permanent(BatcherError::ReceiptNotFoundError))
 }
 
+pub async fn simulate_create_new_task_retryable(
+    batch_merkle_root: [u8; 32],
+    batch_data_pointer: String,
+    proofs_submitters: Vec<Address>,
+    fee_params: CreateNewTaskFeeParams,
+    payment_service: &BatcherPaymentService,
+    payment_service_fallback: &BatcherPaymentService,
+) -> Result<(), RetryError<BatcherError>> {
+    info!("Simulating task for: 0x{}", hex::encode(batch_merkle_root));
+    let simulation_fallback;
+    let simulation = payment_service
+        .create_new_task(
+            batch_merkle_root,
+            batch_data_pointer.clone(),
+            proofs_submitters.clone(),
+            fee_params.fee_for_aggregator,
+            fee_params.fee_per_proof,
+            fee_params.respond_to_task_fee_limit,
+        )
+        .gas_price(fee_params.gas_price);
+
+    match simulation.call().await {
+        Ok(_) => Ok(()),
+        Err(ContractError::Revert(err)) => {
+            // Since transaction was reverted, we don't want to retry with fallback.
+            warn!("Simulated transaction reverted {:?}", err);
+            return Err(RetryError::Permanent(BatcherError::TransactionSendError(
+                err.to_string(),
+            )));
+        }
+        _ => {
+            simulation_fallback = payment_service_fallback
+                .create_new_task(
+                    batch_merkle_root,
+                    batch_data_pointer,
+                    proofs_submitters,
+                    fee_params.fee_for_aggregator,
+                    fee_params.fee_per_proof,
+                    fee_params.respond_to_task_fee_limit,
+                )
+                .gas_price(fee_params.gas_price);
+            match simulation_fallback.call().await {
+                Ok(_) => Ok(()),
+                Err(ContractError::Revert(err)) => {
+                    warn!("Simulated transaction reverted {:?}", err);
+                    return Err(RetryError::Permanent(BatcherError::TransactionSendError(
+                        err.to_string(),
+                    )));
+                }
+                Err(err) => {
+                    return Err(RetryError::Transient(BatcherError::TransactionSendError(
+                        err.to_string(),
+                    )))
+                }
+            }
+        }
+    }
+}
+
 pub async fn cancel_create_new_task_retryable(
     batcher_signer: &SignerMiddlewareT,
     batcher_signer_fallback: &SignerMiddlewareT,

--- a/batcher/aligned-batcher/src/retry/batcher_retryables.rs
+++ b/batcher/aligned-batcher/src/retry/batcher_retryables.rs
@@ -195,7 +195,7 @@ pub async fn simulate_create_new_task_retryable(
             fee_params.respond_to_task_fee_limit,
         )
         .gas_price(fee_params.gas_price);
-
+// sends an `eth_call` request to the node
     match simulation.call().await {
         Ok(_) => Ok(()),
         Err(ContractError::Revert(err)) => {


### PR DESCRIPTION
# Add simulation to create new task

## Description

This PR adds a simulation to create a new task from the batcher.

## How to test

### Test the happy path

1. Get all services up
2. Send transactions
3. See the batches being processed sucesfully and the batcher logging "Simulating task for: "

### Test the error case

1. Add the following line to the `createNewTask` function inside the `BatcherPaymentService.sol` contract

```solidity
96         revert NoProofSubmitters();
```
2. Compile the contracts for anvil with `make anvil_deploy_aligned_contracts`
3. Run anvil
4. Run the batcher
5. Start sending proofs
6. You should see the simulation being run and failing because of the revert

## Type of change

Please delete options that are not relevant.

- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
