### PR TITLE
ci: address clippy warnings

### DIFF
--- a/batcher/aligned-batcher/src/zk_utils/mod.rs
+++ b/batcher/aligned-batcher/src/zk_utils/mod.rs
@@ -34,11 +34,7 @@ fn verify_internal(verification_data: &VerificationData) -> bool {
 
             let mut image_id = [0u8; 32];
             image_id.copy_from_slice(image_id_slice.as_slice());
-            return verify_risc_zero_proof(
-                verification_data.proof.as_slice(),
-                &image_id,
-                &pub_input,
-            );
+            verify_risc_zero_proof(verification_data.proof.as_slice(), &image_id, &pub_input)
         }
         ProvingSystemId::GnarkPlonkBls12_381
         | ProvingSystemId::GnarkPlonkBn254


### PR DESCRIPTION
## Description

Address clippy warnings on ci.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
