### PR TITLE
fix: remove check for batch len

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1124,8 +1124,9 @@ impl Batcher {
         let mut batch_state_lock = self.batch_state.lock().await;
         let current_batch_len = batch_state_lock.batch_queue.len();
         let last_uploaded_batch_block_lock = self.last_uploaded_batch_block.lock().await;
+        let min_len = 1;
 
-        if current_batch_len < 2 {
+        if current_batch_len < min_len {
             info!(
                 "Current batch has {} proofs. Waiting for more proofs...",
                 current_batch_len

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1125,7 +1125,7 @@ impl Batcher {
         let current_batch_len = batch_state_lock.batch_queue.len();
         let last_uploaded_batch_block_lock = self.last_uploaded_batch_block.lock().await;
 
-        if current_batch_len < 2 {
+        if current_batch_len < 1 {
             info!(
                 "Current batch has {} proofs. Waiting for more proofs...",
                 current_batch_len

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1124,9 +1124,8 @@ impl Batcher {
         let mut batch_state_lock = self.batch_state.lock().await;
         let current_batch_len = batch_state_lock.batch_queue.len();
         let last_uploaded_batch_block_lock = self.last_uploaded_batch_block.lock().await;
-        let min_len = 2;
 
-        if current_batch_len < min_len {
+        if current_batch_len < 1 {
             info!(
                 "Current batch has {} proofs. Waiting for more proofs...",
                 current_batch_len

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1125,11 +1125,8 @@ impl Batcher {
         let current_batch_len = batch_state_lock.batch_queue.len();
         let last_uploaded_batch_block_lock = self.last_uploaded_batch_block.lock().await;
 
-        if current_batch_len < 1 {
-            info!(
-                "Current batch has {} proofs. Waiting for more proofs...",
-                current_batch_len
-            );
+        if current_batch_len == 0 {
+            info!("Batch queue is empty. Waiting for more proofs...",);
             return None;
         }
 

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1125,7 +1125,7 @@ impl Batcher {
         let current_batch_len = batch_state_lock.batch_queue.len();
         let last_uploaded_batch_block_lock = self.last_uploaded_batch_block.lock().await;
 
-        if current_batch_len < 1 {
+        if current_batch_len < 2 {
             info!(
                 "Current batch has {} proofs. Waiting for more proofs...",
                 current_batch_len

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1124,7 +1124,7 @@ impl Batcher {
         let mut batch_state_lock = self.batch_state.lock().await;
         let current_batch_len = batch_state_lock.batch_queue.len();
         let last_uploaded_batch_block_lock = self.last_uploaded_batch_block.lock().await;
-        let min_len = 1;
+        let min_len = 2;
 
         if current_batch_len < min_len {
             info!(

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -1125,8 +1125,11 @@ impl Batcher {
         let current_batch_len = batch_state_lock.batch_queue.len();
         let last_uploaded_batch_block_lock = self.last_uploaded_batch_block.lock().await;
 
-        if current_batch_len == 0 {
-            info!("Batch queue is empty. Waiting for more proofs...",);
+        if current_batch_len < 1 {
+            info!(
+                "Current batch has {} proofs. Waiting for more proofs...",
+                current_batch_len
+            );
             return None;
         }
 


### PR DESCRIPTION
# Remove check for batch len

## Description

Remove the `< 2` check for batch len. Now we only check that the batch is not empty.

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
