### PR TITLE
feat: add mainnet values to sdk

### DIFF
--- a/batcher/aligned-sdk/src/core/types.rs
+++ b/batcher/aligned-sdk/src/core/types.rs
@@ -401,6 +401,7 @@ pub enum Network {
     Devnet,
     Holesky,
     HoleskyStage,
+    Mainnet,
 }
 
 impl FromStr for Network {
@@ -411,8 +412,9 @@ impl FromStr for Network {
             "holesky" => Ok(Network::Holesky),
             "holesky-stage" => Ok(Network::HoleskyStage),
             "devnet" => Ok(Network::Devnet),
+            "mainnet" => Ok(Network::Mainnet),
             _ => Err(
-                "Invalid network, possible values are: \"holesky\", \"holesky-stage\", \"devnet\""
+                "Invalid network, possible values are: \"holesky\", \"holesky-stage\", \"devnet\", \"mainnet\""
                     .to_string(),
             ),
         }

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -278,6 +278,7 @@ pub fn get_payment_service_address(network: Network) -> ethers::types::H160 {
         Network::HoleskyStage => {
             H160::from_str("0x7577Ec4ccC1E6C529162ec8019A49C13F6DAd98b").unwrap()
         }
+        Network::Mainnet => H160::from_str("0xb0567184A52cB40956df6333510d6eF35B89C8de").unwrap(),
     }
 }
 
@@ -288,6 +289,7 @@ pub fn get_aligned_service_manager_address(network: Network) -> ethers::types::H
         Network::HoleskyStage => {
             H160::from_str("0x9C5231FC88059C086Ea95712d105A2026048c39B").unwrap()
         }
+        Network::Mainnet => H160::from_str("0xeF2A435e5EE44B2041100EF8cbC8ae035166606c").unwrap(),
     }
 }
 

--- a/batcher/aligned-task-sender/src/structs.rs
+++ b/batcher/aligned-task-sender/src/structs.rs
@@ -155,6 +155,7 @@ pub enum NetworkArg {
     Devnet,
     Holesky,
     HoleskyStage,
+    Mainnet,
 }
 
 impl From<NetworkArg> for Network {
@@ -163,6 +164,7 @@ impl From<NetworkArg> for Network {
             NetworkArg::Devnet => Network::Devnet,
             NetworkArg::Holesky => Network::Holesky,
             NetworkArg::HoleskyStage => Network::HoleskyStage,
+            NetworkArg::Mainnet => Network::Mainnet,
         }
     }
 }

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -223,6 +223,7 @@ enum NetworkArg {
     Devnet,
     Holesky,
     HoleskyStage,
+    Mainnet,
 }
 
 impl From<NetworkArg> for Network {
@@ -231,6 +232,7 @@ impl From<NetworkArg> for Network {
             NetworkArg::Devnet => Network::Devnet,
             NetworkArg::Holesky => Network::Holesky,
             NetworkArg::HoleskyStage => Network::HoleskyStage,
+            NetworkArg::Mainnet => Network::Mainnet,
         }
     }
 }


### PR DESCRIPTION
# Add mainnet values to sdk

## Description

this pr adds mainnet to network and networkArg, and also their addresses in the respective `get addresses`

## Type of change

Please delete options that are not relevant.

- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
