### PR TITLE
fix: export operator address in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := /bin/bash
 OS := $(shell uname -s)
 
 CONFIG_FILE?=config-files/config.yaml
+export OPERATOR_ADDRESS ?= $(shell yq -r '.operator.address' $(CONFIG_FILE))
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
 OPERATOR_VERSION=v0.12.1


### PR DESCRIPTION
# How to test

To start an [Operator](https://docs.alignedlayer.com/architecture/1_fast_mode/4_operator) (note it also registers it):

```shell
make operator_register_and_start
```

If you need to start again the operator, and it's already registered, you can use:

```
make operator_start
```

Also, test it using other config files

```shell
make operator_register_and_start CONFIG_FILE=./config-files/config-operator-2.yaml
```