### PR TITLE
docs: add list of supported strategies and contracts addresses on mainnet

### DIFF
--- a/contracts/script/deploy/config/mainnet/aligned.mainnet.config.json
+++ b/contracts/script/deploy/config/mainnet/aligned.mainnet.config.json
@@ -1,6 +1,6 @@
 {
     "chainInfo": {
-      "chainId": 17000
+      "chainId": 1
     },
     "permissions" : {
       "aggregator": "<aggregator_address>", 
@@ -18,8 +18,56 @@
     "strategyWeights": [
       [
         {
-          "0_strategy": "TBD",
-          "1_multiplier": 1e+18
+          "0_strategy": "0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0",
+          "1_multiplier": 1000000000000000000
+        },
+        {
+          "0_strategy": "0x93c4b944D05dfe6df7645A86cd2206016c51564D",
+          "1_multiplier": 1030077629425962827
+        },
+        {
+          "0_strategy": "0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2",
+          "1_multiplier": 1102456657360376283
+        },
+        {
+          "0_strategy": "0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc",
+          "1_multiplier": 1067949170243902475
+        },
+        {
+          "0_strategy": "0x9d7eD45EE2E8FC5482fa2428f15C971e6369011d",
+          "1_multiplier": 1026158078493781538
+        },
+        {
+          "0_strategy": "0x13760F50a9d7377e4F20CB8CF9e4c26586c658ff",
+          "1_multiplier": 1152393415227598758
+        },
+        {
+          "0_strategy": "0xa4C637e0F704745D182e4D38cAb7E7485321d059",
+          "1_multiplier": 1011855761455017859
+        },
+        {
+          "0_strategy": "0x57ba429517c3473B6d34CA9aCd56c0e735b94c02",
+          "1_multiplier": 1012495275290785447
+        },
+        {
+          "0_strategy": "0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6",
+          "1_multiplier": 1055446649335815388
+        },
+        {
+          "0_strategy": "0x7CA911E83dabf90C90dD3De5411a10F1A6112184",
+          "1_multiplier": 1035345726488000000
+        },
+        {
+          "0_strategy": "0x8CA7A5d6f3acd3A7A8bC468a8CD0FB14B6BD28b6",
+          "1_multiplier": 1081259809521793439
+        },
+        {
+          "0_strategy": "0xAe60d8180437b5C34bB956822ac2710972584473",
+          "1_multiplier": 1044315639811926396
+        },
+        {
+          "0_strategy": "0x298aFB19A105D59E74658C4C334Ff360BadE6dd2",
+          "1_multiplier": 1028802524926876401
         }
       ]
     ],

--- a/docs/3_guides/7_contract_addresses.md
+++ b/docs/3_guides/7_contract_addresses.md
@@ -32,7 +32,7 @@ Below is the list of supported strategies available on Aligned Mainnet:
 | [lsETH](https://app.eigenlayer.xyz/restake/lsETH)          | [0xAe60d8180437b5C34bB956822ac2710972584473](https://etherscan.io/address/0xAe60d8180437b5C34bB956822ac2710972584473) |
 | [mETH](https://app.eigenlayer.xyz/restake/mETH)            | [0x298aFB19A105D59E74658C4C334Ff360BadE6dd2](https://etherscan.io/address/0x298aFB19A105D59E74658C4C334Ff360BadE6dd2) |
 
-For additional details, refer to the [official EigenLayer documentation](https://github.com/Layr-Labs/eigenlayer-contracts/tree/testnet-holesky?tab=readme-ov-file#strategies).
+For additional details, refer to the [official EigenLayer documentation](https://github.com/Layr-Labs/eigenlayer-contracts/tree/mainnet?tab=readme-ov-file#strategies).
 
 
 ## Holesky Deployments

--- a/docs/3_guides/7_contract_addresses.md
+++ b/docs/3_guides/7_contract_addresses.md
@@ -1,6 +1,36 @@
 # Aligned contract addresses
 
-## Holesky deployments
+## Mainnet Deployments
+
+| Contract                   | Address                                                                                                               |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| AlignedLayerServiceManager | [0xeF2A435e5EE44B2041100EF8cbC8ae035166606c](https://etherscan.io/address/0xeF2A435e5EE44B2041100EF8cbC8ae035166606c) |
+| BlsApkRegistry             | [0x3CcfB7e6e8fe2A8d941a8Ce4C69A944a770E8228](https://etherscan.io/address/0x3CcfB7e6e8fe2A8d941a8Ce4C69A944a770E8228) |
+| IndexRegistry              | [0x9Bf1275e18eC8FA3cA7f9bffF1b0DF3e14C6E134](https://etherscan.io/address/0x9Bf1275e18eC8FA3cA7f9bffF1b0DF3e14C6E134) |
+| OperatorStateRetriever     | [0x6e0046205cAfA503F6b7465195A6C63C47d214f1](https://etherscan.io/address/0x6e0046205cAfA503F6b7465195A6C63C47d214f1) |
+| RegistryCoordinator        | [0xA8CC0749b4409c3c47012323E625aEcBA92f64b9](https://etherscan.io/address/0xA8CC0749b4409c3c47012323E625aEcBA92f64b9) |
+| StakeRegistry              | [0x45F5290a3630Cd6dc277B6f92227526121ca7c22](https://etherscan.io/address/0x45F5290a3630Cd6dc277B6f92227526121ca7c22) |
+| BatcherPaymentService      | [0xb0567184A52cB40956df6333510d6eF35B89C8de](https://etherscan.io/address/0xb0567184A52cB40956df6333510d6eF35B89C8de) |
+
+### Strategies
+
+| Name                                                       | Address                                                                                                               |
+|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| [Beacon Chain ETH](https://app.eigenlayer.xyz/restake/ETH) | [0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0](https://etherscan.io/address/0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0) |  
+| [stETH](https://app.eigenlayer.xyz/restake/stETH)          | [0x93c4b944D05dfe6df7645A86cd2206016c51564D](https://etherscan.io/address/0x93c4b944D05dfe6df7645A86cd2206016c51564D) |
+| [rETH](https://app.eigenlayer.xyz/restake/rETH)            | [0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2](https://etherscan.io/address/0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2) |
+| [cbETH](https://app.eigenlayer.xyz/restake/cbETH)          | [0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc](https://etherscan.io/address/0x54945180dB7943c0ed0FEE7EdaB2Bd24620256bc) |
+| [ETHx](https://app.eigenlayer.xyz/restake/ETHx)            | [0x9d7eD45EE2E8FC5482fa2428f15C971e6369011d](https://etherscan.io/address/0x9d7eD45EE2E8FC5482fa2428f15C971e6369011d) |
+| [ankrETH](https://app.eigenlayer.xyz/restake/ankrETH)      | [0x13760F50a9d7377e4F20CB8CF9e4c26586c658ff](https://etherscan.io/address/0x13760F50a9d7377e4F20CB8CF9e4c26586c658ff) |
+| [oETH](https://app.eigenlayer.xyz/restake/oETH)            | [0xa4C637e0F704745D182e4D38cAb7E7485321d059](https://etherscan.io/address/0xa4C637e0F704745D182e4D38cAb7E7485321d059) |
+| [osETH](https://app.eigenlayer.xyz/restake/osETH)          | [0x57ba429517c3473B6d34CA9aCd56c0e735b94c02](https://etherscan.io/address/0x57ba429517c3473B6d34CA9aCd56c0e735b94c02) |
+| [swETH](https://app.eigenlayer.xyz/restake/swETH)          | [0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6](https://etherscan.io/address/0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6) |
+| [wBETH](https://app.eigenlayer.xyz/restake/wBETH)          | [0x7CA911E83dabf90C90dD3De5411a10F1A6112184](https://etherscan.io/address/0x7CA911E83dabf90C90dD3De5411a10F1A6112184) |
+| [sfrxETH](https://app.eigenlayer.xyz/restake/sfrxETH)      | [0x8CA7A5d6f3acd3A7A8bC468a8CD0FB14B6BD28b6](https://etherscan.io/address/0x8CA7A5d6f3acd3A7A8bC468a8CD0FB14B6BD28b6) |
+| [lsETH](https://app.eigenlayer.xyz/restake/lsETH)          | [0xAe60d8180437b5C34bB956822ac2710972584473](https://etherscan.io/address/0xAe60d8180437b5C34bB956822ac2710972584473) |
+| [mETH](https://app.eigenlayer.xyz/restake/mETH)            | [0x298aFB19A105D59E74658C4C334Ff360BadE6dd2](https://etherscan.io/address/0x298aFB19A105D59E74658C4C334Ff360BadE6dd2) |
+
+## Holesky Deployments
 
 | Contract                   | Address                                                                                                                       |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/3_guides/7_contract_addresses.md
+++ b/docs/3_guides/7_contract_addresses.md
@@ -14,6 +14,8 @@
 
 ### Strategies
 
+Below is the list of supported strategies available on Aligned Mainnet:
+
 | Name                                                       | Address                                                                                                               |
 |------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | [Beacon Chain ETH](https://app.eigenlayer.xyz/restake/ETH) | [0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0](https://etherscan.io/address/0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0) |  
@@ -29,6 +31,9 @@
 | [sfrxETH](https://app.eigenlayer.xyz/restake/sfrxETH)      | [0x8CA7A5d6f3acd3A7A8bC468a8CD0FB14B6BD28b6](https://etherscan.io/address/0x8CA7A5d6f3acd3A7A8bC468a8CD0FB14B6BD28b6) |
 | [lsETH](https://app.eigenlayer.xyz/restake/lsETH)          | [0xAe60d8180437b5C34bB956822ac2710972584473](https://etherscan.io/address/0xAe60d8180437b5C34bB956822ac2710972584473) |
 | [mETH](https://app.eigenlayer.xyz/restake/mETH)            | [0x298aFB19A105D59E74658C4C334Ff360BadE6dd2](https://etherscan.io/address/0x298aFB19A105D59E74658C4C334Ff360BadE6dd2) |
+
+For additional details, refer to the [official EigenLayer documentation](https://github.com/Layr-Labs/eigenlayer-contracts/tree/testnet-holesky?tab=readme-ov-file#strategies)
+
 
 ## Holesky Deployments
 

--- a/docs/3_guides/7_contract_addresses.md
+++ b/docs/3_guides/7_contract_addresses.md
@@ -32,7 +32,7 @@ Below is the list of supported strategies available on Aligned Mainnet:
 | [lsETH](https://app.eigenlayer.xyz/restake/lsETH)          | [0xAe60d8180437b5C34bB956822ac2710972584473](https://etherscan.io/address/0xAe60d8180437b5C34bB956822ac2710972584473) |
 | [mETH](https://app.eigenlayer.xyz/restake/mETH)            | [0x298aFB19A105D59E74658C4C334Ff360BadE6dd2](https://etherscan.io/address/0x298aFB19A105D59E74658C4C334Ff360BadE6dd2) |
 
-For additional details, refer to the [official EigenLayer documentation](https://github.com/Layr-Labs/eigenlayer-contracts/tree/testnet-holesky?tab=readme-ov-file#strategies)
+For additional details, refer to the [official EigenLayer documentation](https://github.com/Layr-Labs/eigenlayer-contracts/tree/testnet-holesky?tab=readme-ov-file#strategies).
 
 
 ## Holesky Deployments

--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -21,6 +21,10 @@ Minimum hardware requirements:
 | **Bandwidth** | 1 Gbps            |
 | **Storage**   | 256 GB disk space |
 
+## Supported Strategies
+
+The list of supported strategies can be found [here](../3_guides/7_contract_addresses.md).
+
 ## Step 1 - Clone the repo
 
 To start with, clone the Aligned repository and move inside it

--- a/docs/operator_guides/1_operator_FAQ.md
+++ b/docs/operator_guides/1_operator_FAQ.md
@@ -8,6 +8,10 @@ To get whitelisted,
 you need to fill out the form available [here](https://docs.google.com/forms/d/e/1FAIpQLSdH9sgfTz4v33lAvwj6BvYJGAeIshQia3FXz36PFfF-WQAWEQ/viewform)
 and wait for the Aligned team to approve your request.
 
+### What Strategies Tokens are supported in Mainnet?
+
+The list of supported strategies can be found [here](../3_guides/7_contract_addresses.md).
+
 ### What RPC should I use?
 
 We suggest you use your own nodes for better performance and reliability. Note that the node must support HTTP and WebSockets.


### PR DESCRIPTION


# Add list of supported strategies and contracts addresses on mainnet

## Description

This PR adds the list of supported strategies and the contract addresses deployed on mainnet.

## Type of change

Please delete options that are not relevant.

- [x] Documentation

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
