### PR TITLE
fix: zkquiz proof submitions

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -417,7 +417,7 @@ impl Batcher {
         info!("4");
         info!("44");
         
-        let mut incoming_filter = incoming.try_filter(|msg| future::ready(!msg.is_binary()));
+        let mut incoming_filter = incoming.try_filter(|msg| future::ready(msg.is_binary()));
 
         info!("5");
         let future_msg = incoming_filter.try_next();

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -416,7 +416,11 @@ impl Batcher {
 
         info!("4");
         
-        let mut incoming_filter = incoming.try_filter(|msg| future::ready(msg.is_binary()));
+        let mut incoming_filter = incoming.try_filter(|msg| {
+            let res = future::ready(msg.is_binary());
+            println!("is_binary: {:?}", res);
+            res
+        });
 
         info!("5");
         let future_msg = incoming_filter.try_next();

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -418,7 +418,7 @@ impl Batcher {
         
         let mut incoming_filter = incoming.try_filter(|msg| {
             let res = future::ready(msg.is_binary());
-            println!("is_binary: {:?}", res);
+            info!("is_binary: {:?}", res);
             res
         });
 
@@ -426,7 +426,6 @@ impl Batcher {
         let future_msg = incoming_filter.try_next();
 
         info!("6");
-        info!("future: {:?}", future_msg);
 
         // timeout to prevent a DOS attack
         match timeout(Duration::from_secs(CONNECTION_TIMEOUT), future_msg).await {

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -417,12 +417,7 @@ impl Batcher {
         info!("4");
         info!("44");
         
-        let mut incoming_filter = incoming.try_filter(|msg| {
-            // let res = future::ready(msg.is_binary());
-            let res = future::ready(msg.is_text());
-            info!("is_binary: {:?}", res);
-            res
-        });
+        let mut incoming_filter = incoming.try_filter(|msg| future::ready(!msg.is_binary()));
 
         info!("5");
         let future_msg = incoming_filter.try_next();
@@ -431,7 +426,7 @@ impl Batcher {
         info!("future: {:?}", future_msg);
 
         // timeout to prevent a DOS attack
-        match timeout(Duration::from_secs(CONNECTION_TIMEOUT), future_msg).await {
+        match timeout(Duration::from_secs(CONNECTION_TIMEOUT*10), future_msg).await {
             Ok(Ok(Some(msg))) => {
                 self.clone().handle_message(msg, outgoing.clone()).await?;
             }

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -415,9 +415,11 @@ impl Batcher {
             .await?;
 
         info!("4");
+        info!("44");
         
         let mut incoming_filter = incoming.try_filter(|msg| {
-            let res = future::ready(msg.is_binary());
+            // let res = future::ready(msg.is_binary());
+            let res = future::ready(msg.is_text());
             info!("is_binary: {:?}", res);
             res
         });
@@ -426,6 +428,7 @@ impl Batcher {
         let future_msg = incoming_filter.try_next();
 
         info!("6");
+        info!("future: {:?}", future_msg);
 
         // timeout to prevent a DOS attack
         match timeout(Duration::from_secs(CONNECTION_TIMEOUT), future_msg).await {
@@ -433,7 +436,7 @@ impl Batcher {
                 self.clone().handle_message(msg, outgoing.clone()).await?;
             }
             Err(elapsed) => {
-                info!("probably here");
+                info!("timeout here");
                 warn!("[{}] {}", &addr, elapsed);
                 self.metrics.user_error(&["user_timeout", ""]);
                 self.metrics.open_connections.dec();

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -426,7 +426,7 @@ impl Batcher {
         info!("future: {:?}", future_msg);
 
         // timeout to prevent a DOS attack
-        match timeout(Duration::from_secs(CONNECTION_TIMEOUT*10), future_msg).await {
+        match timeout(Duration::from_secs(CONNECTION_TIMEOUT), future_msg).await {
             Ok(Ok(Some(msg))) => {
                 self.clone().handle_message(msg, outgoing.clone()).await?;
             }

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -426,7 +426,7 @@ impl Batcher {
         info!("future: {:?}", future_msg);
 
         // timeout to prevent a DOS attack
-        match timeout(Duration::from_secs(CONNECTION_TIMEOUT), future_msg).await {
+        match timeout(Duration::from_secs(CONNECTION_TIMEOUT*10), future_msg).await {
             Ok(Ok(Some(msg))) => {
                 self.clone().handle_message(msg, outgoing.clone()).await?;
             }

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -372,7 +372,6 @@ impl Batcher {
         self.metrics.open_connections.inc();
 
         let ws_stream_future = tokio_tungstenite::accept_async(raw_stream);
-
         let ws_stream =
             match timeout(Duration::from_secs(CONNECTION_TIMEOUT), ws_stream_future).await {
                 Ok(Ok(stream)) => stream,

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -369,9 +369,13 @@ impl Batcher {
         addr: SocketAddr,
     ) -> Result<(), BatcherError> {
         info!("Incoming TCP connection from: {}", addr);
+        info!("HELLO");
         self.metrics.open_connections.inc();
+        info!("HIII");
 
         let ws_stream_future = tokio_tungstenite::accept_async(raw_stream);
+
+        info!("Establishing WebSocket connection...");
         let ws_stream =
             match timeout(Duration::from_secs(CONNECTION_TIMEOUT), ws_stream_future).await {
                 Ok(Ok(stream)) => stream,
@@ -388,7 +392,7 @@ impl Batcher {
                 }
             };
 
-        debug!("WebSocket connection established: {}", addr);
+        info!("WebSocket connection established: {}", addr);
         let (outgoing, incoming) = ws_stream.split();
         let outgoing = Arc::new(RwLock::new(outgoing));
 

--- a/batcher/aligned-sdk/src/core/constants.rs
+++ b/batcher/aligned-sdk/src/core/constants.rs
@@ -8,7 +8,7 @@ pub const CONSTANT_GAS_COST: u128 =
         + BATCHER_SUBMISSION_BASE_GAS_COST;
 pub const DEFAULT_MAX_FEE_PER_PROOF: u128 =
     ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF * 100_000_000_000; // gas_price = 100 Gwei = 0.0000001 ether (high gas price)
-pub const CONNECTION_TIMEOUT: u64 = 5; // 5 secs
+pub const CONNECTION_TIMEOUT: u64 = 30; // 30 secs
 
 // % modifiers: (100% is x1, 10% is x0.1, 1000% is x10)
 pub const RESPOND_TO_TASK_FEE_LIMIT_PERCENTAGE_MULTIPLIER: u128 = 250; // fee_for_aggregator -> respondToTaskFeeLimit modifier


### PR DESCRIPTION
# Fix ZKQuiz proof submitions

## Description

ZKQuiz seemed broken because it was failing to receive messages from the Batcher. It was discovered this was because Batcher was cutting the connection with the timeout, because it was taking longer than 5 seconds to receive the proof. This makes sense because the ZKQuiz proof is 5 times bigger than the fibonnacci proof.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
