### PR TITLE
build contracts before running deployment scripts

### DIFF
--- a/claim_contracts/Makefile
+++ b/claim_contracts/Makefile
@@ -9,11 +9,14 @@ help: ## 📚 Show help for each of the Makefile recipes
 RPC_URL?=http://localhost:8545
 PRIVATE_KEY?=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 
-deploy-all: ## 🚀 Deploy all contracts
+build:
+	forge build
+
+deploy-all: build ## 🚀 Deploy all contracts
 	cd script && forge script DeployAll.s.sol --private-key $(PRIVATE_KEY) --rpc-url $(RPC_URL) --broadcast
 
 CONFIG?=example
-deploy-token: ## 🚀 Deploy the token contract
+deploy-token: build ## 🚀 Deploy the token contract
 	cd script && \
 	forge script DeployAlignedToken.s.sol \
 	--sig "run(string)" \
@@ -32,7 +35,7 @@ CLAIM_TIME_LIMIT?=1632960000
 MERKLE_ROOT?=0x90076b5fb9a6c81d9fce83dfd51760987b8c49e7c861ea25b328e6e63d2cd3df
 TOKEN_OWNER?=$(OWNER)
 
-deploy-proxy-admin: ## 🚀 Deploy the ProxyAdmin contract
+deploy-proxy-admin: build ## 🚀 Deploy the ProxyAdmin contract
 	cd script/proxy_admin && \
 	forge script DeployProxyAdmin.s.sol \
 	--sig "run(address)" \
@@ -41,14 +44,14 @@ deploy-proxy-admin: ## 🚀 Deploy the ProxyAdmin contract
 	--private-key $(PRIVATE_KEY) \
 	--broadcast
 
-deploy-aligned-token-implementation: ## 🚀 Deploy the AlignedToken implementation contract
+deploy-aligned-token-implementation: build ## 🚀 Deploy the AlignedToken implementation contract
 	cd script/aligned_token && \
 	forge script DeployAlignedTokenImplementation.s.sol \
 	--rpc-url $(RPC_URL) \
 	--private-key $(PRIVATE_KEY) \
 	--broadcast
 
-deploy-aligned-token-proxy: ## 🚀 Deploy the AlignedToken proxy contract
+deploy-aligned-token-proxy: build ## 🚀 Deploy the AlignedToken proxy contract
 	cd script/aligned_token && \
 	forge script DeployAlignedTokenProxy.s.sol \
 	--sig "run(address,address,address,address,address,address,uint256)" \
@@ -57,14 +60,14 @@ deploy-aligned-token-proxy: ## 🚀 Deploy the AlignedToken proxy contract
 	--private-key $(PRIVATE_KEY) \
 	--broadcast
 
-deploy-claimable-airdrop-implementation: ## 🚀 Deploy the ClaimableAirdrop implementation contract
+deploy-claimable-airdrop-implementation: build ## 🚀 Deploy the ClaimableAirdrop implementation contract
 	cd script/claimable_airdrop && \
 	forge script DeployClaimableAirdropImplementation.s.sol \
 	--rpc-url $(RPC_URL) \
 	--private-key $(PRIVATE_KEY) \
 	--broadcast
 
-deploy-claimable-airdrop-proxy: ## 🚀 Deploy the ClaimableAirdrop proxy contract
+deploy-claimable-airdrop-proxy: build ## 🚀 Deploy the ClaimableAirdrop proxy contract
 	cd script/claimable_airdrop && \
 	forge script DeployClaimableAirdropProxy.s.sol \
 	--sig "run(address,address,address,address,address,uint256,bytes32)" \
@@ -75,7 +78,7 @@ deploy-claimable-airdrop-proxy: ## 🚀 Deploy the ClaimableAirdrop proxy contra
 
 # Upgrades
 
-upgrade-aligned-token-implementation: ## 🚀 Upgrade the AlignedToken implementation contract
+upgrade-aligned-token-implementation: build ## 🚀 Upgrade the AlignedToken implementation contract
 	cd script/aligned_token && \
 	forge script UpgradeAlignedTokenImplementation.s.sol \
 	--sig "function run(address,address,uint256,address,address,address,address,uint256)" \

--- a/claim_contracts/README.md
+++ b/claim_contracts/README.md
@@ -4,6 +4,14 @@
 
 - Foundry
 
+## Build
+
+Install dependencies and compile the project running:
+
+```bash
+$ make build
+```
+
 ## Local deploying
 
 To deploy the contracts, set the following environment variables:


### PR DESCRIPTION
# Build before running the deployment scripts

## Description

Adds a target for building the contracts and add it as dependence to the rest of the targets that deploy contracts.


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
