### PR TITLE
feat(explorer): footer component

### DIFF
--- a/explorer/lib/explorer_web/components/footer.ex
+++ b/explorer/lib/explorer_web/components/footer.ex
@@ -59,7 +59,11 @@ defmodule FooterComponent do
               <div class="flex flex-col items-start gap-2">
                 <h3 class="text-foreground font-bold text-lg"><%= title %></h3>
                 <%= for {value, link} <- links do %>
-                  <.link class="text-md text-foreground/80 hover:underline" navigate={link}>
+                  <.link
+                    class="text-md text-foreground/80 hover:underline"
+                    href={link}
+                    _target="blank"
+                  >
                     <%= value %>
                   </.link>
                 <% end %>

--- a/explorer/lib/explorer_web/components/footer.ex
+++ b/explorer/lib/explorer_web/components/footer.ex
@@ -21,9 +21,11 @@ defmodule FooterComponent do
           ]},
          {"Developers",
           [
+            {"Docs", "https://docs.alignedlayer.com/"},
+            {"Supported verifiers",
+             "https://docs.alignedlayer.com/architecture/0_supported_verifiers"},
             {"Whitepaper", "https://alignedlayer.com/whitepaper/"},
-            {"Github", "https://github.com/yetanotherco/aligned_layer"},
-            {"Docs", "https://docs.alignedlayer.com/"}
+            {"Github", "https://github.com/yetanotherco/aligned_layer"}
           ]},
          {"Resources",
           [

--- a/explorer/lib/explorer_web/components/footer.ex
+++ b/explorer/lib/explorer_web/components/footer.ex
@@ -1,0 +1,72 @@
+defmodule FooterComponent do
+  use ExplorerWeb, :live_component
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     assign(socket,
+       headers: [
+         {"General",
+          [
+            {"Batches", "/batches"},
+            {"Operators", "/operators"},
+            {"Restake", "/restake"}
+          ]},
+         {"Social",
+          [
+            {"Twitter", "https://x.com/alignedlayer"},
+            {"Telegram", "https://t.me/aligned_layer"},
+            {"Discord", "https://discord.gg/alignedlayer"},
+            {"Youtube", "https://youtube.com/@alignedlayer"}
+          ]},
+         {"Developers",
+          [
+            {"Whitepaper", "https://alignedlayer.com/whitepaper/"},
+            {"Github", "https://github.com/yetanotherco/aligned_layer"},
+            {"Docs", "https://docs.alignedlayer.com/"}
+          ]},
+         {"Resources",
+          [
+            {"Contact", "https://alignedlayer.com/contact/"},
+            {"Blog", "https://blog.alignedlayer.com/"}
+          ]}
+       ]
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="w-full border-t border-foreground/10 backdrop-blur-lg backdrop-saturate-200">
+      <div
+        class="w-full flex justify-center flex-wrap p-5 pb-10 gap-5 m-auto"
+        style="max-width: 75rem;"
+      >
+        <div class="hidden sm:inline-block flex-1">
+          <.link
+            class="text-md font-bold hover:scale-105 transform duration-150 active:scale-95"
+            navigate={~p"/"}
+          >
+            🟩 <span class="text-foreground">Aligned Layer</span>
+          </.link>
+        </div>
+
+        <div>
+          <div class="flex-1 flex flex-wrap gap-10 md:gap-32">
+            <%= for {title, links} <- @headers do %>
+              <div class="flex flex-col items-start gap-2">
+                <h3 class="text-foreground font-bold text-lg"><%= title %></h3>
+                <%= for {value, link} <- links do %>
+                  <.link class="text-md text-foreground/80 hover:underline" navigate={link}>
+                    <%= value %>
+                  </.link>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/explorer/lib/explorer_web/components/footer.ex
+++ b/explorer/lib/explorer_web/components/footer.ex
@@ -27,8 +27,8 @@ defmodule FooterComponent do
           ]},
          {"Resources",
           [
-            {"Contact", "https://alignedlayer.com/contact/"},
-            {"Blog", "https://blog.alignedlayer.com/"}
+            {"Blog", "https://blog.alignedlayer.com/"},
+            {"Contact", "https://alignedlayer.com/contact/"}
           ]}
        ]
      )}

--- a/explorer/lib/explorer_web/components/layouts/app.html.heex
+++ b/explorer/lib/explorer_web/components/layouts/app.html.heex
@@ -3,3 +3,4 @@
   <.flash_group flash={@flash} />
   <%= @inner_content %>
 </.root_background>
+<.live_component module={FooterComponent} id="footer" />


### PR DESCRIPTION
## Description

Adds footer component to the explorer.

**Testing**
Run the explorer locally and you should see:

![image](https://github.com/user-attachments/assets/85b13387-06b2-4381-9390-f031331db990)


Check that the links go to the right locations.

## Type of change
- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
