### PR TITLE
hotfix: batcher queue ord

### DIFF
--- a/batcher/aligned-batcher/src/connection.rs
+++ b/batcher/aligned-batcher/src/connection.rs
@@ -22,7 +22,7 @@ pub(crate) async fn send_batch_inclusion_data_responses(
     batch_merkle_tree: &MerkleTree<VerificationCommitmentBatch>,
 ) -> Result<(), BatcherError> {
     // iter in reverse because each sender wants to receive responses in ascending nonce order
-    // and finalized_batch is ordered as the PriorityQueue , low max_nonce first && high nonce first.
+    // and finalized_batch is ordered as the PriorityQueue , low max_fee first && high nonce first.
     for (vd_batch_idx, entry) in finalized_batch.iter().enumerate().rev() {
         let batch_inclusion_data = BatchInclusionData::new(
             vd_batch_idx,

--- a/batcher/aligned-batcher/src/connection.rs
+++ b/batcher/aligned-batcher/src/connection.rs
@@ -21,8 +21,8 @@ pub(crate) async fn send_batch_inclusion_data_responses(
     finalized_batch: Vec<BatchQueueEntry>,
     batch_merkle_tree: &MerkleTree<VerificationCommitmentBatch>,
 ) -> Result<(), BatcherError> {
-    // iter in reverse because each sender wants to receive responses in ascending nonce order
-    // and finalized_batch is ordered as the PriorityQueue , low max_fee first && high nonce first.
+    // Finalized_batch is ordered as the PriorityQueue, ordered by: ascending max_fee && if max_fee is equal, by descending nonce.
+    // We iter it in reverse because each sender wants to receive responses in ascending nonce order
     for (vd_batch_idx, entry) in finalized_batch.iter().enumerate().rev() {
         let batch_inclusion_data = BatchInclusionData::new(
             vd_batch_idx,

--- a/batcher/aligned-batcher/src/connection.rs
+++ b/batcher/aligned-batcher/src/connection.rs
@@ -21,7 +21,9 @@ pub(crate) async fn send_batch_inclusion_data_responses(
     finalized_batch: Vec<BatchQueueEntry>,
     batch_merkle_tree: &MerkleTree<VerificationCommitmentBatch>,
 ) -> Result<(), BatcherError> {
-    for (vd_batch_idx, entry) in finalized_batch.iter().enumerate() {
+    // iter in reverse because each sender wants to receive responses in ascending nonce order
+    // and finalized_batch is ordered as the PriorityQueue , low max_nonce first && high nonce first.
+    for (vd_batch_idx, entry) in finalized_batch.iter().enumerate().rev() {
         let batch_inclusion_data = BatchInclusionData::new(
             vd_batch_idx,
             batch_merkle_tree,

--- a/batcher/aligned-batcher/src/types/batch_queue.rs
+++ b/batcher/aligned-batcher/src/types/batch_queue.rs
@@ -339,7 +339,7 @@ mod test {
         // All with the same fee
 
         let max_fee = U256::from(130000000000000u128);
-        
+
         // Entry 1
         let nonce_1 = U256::from(1);
         let nonced_verification_data_1 = NoncedVerificationData::new(
@@ -441,7 +441,7 @@ mod test {
         // All with the same fee
 
         let max_fee = U256::from(130000000000000u128);
-        
+
         // Entry 1
         let nonce_1 = U256::from(1);
         let nonced_verification_data_1 = NoncedVerificationData::new(

--- a/batcher/aligned-batcher/src/types/batch_queue.rs
+++ b/batcher/aligned-batcher/src/types/batch_queue.rs
@@ -499,13 +499,14 @@ mod test {
         let mut batch_queue = BatchQueue::new();
         batch_queue.push(entry_1, batch_priority_1);
         batch_queue.push(entry_2, batch_priority_2);
-        batch_queue.push(entry_3, batch_priority_3);
+        batch_queue.push(entry_3.clone(), batch_priority_3.clone());
 
         let gas_price = U256::from(1);
         let (resulting_batch_queue, batch) =
             try_build_batch(batch_queue, gas_price, 5000000, 2).unwrap();
 
         assert!(resulting_batch_queue.len() == 1); //nonce_3
+        assert!(resulting_batch_queue.clone().pop() == Some((entry_3.clone(), batch_priority_3.clone()))); //nonce_3
 
         assert_eq!(batch[0].nonced_verification_data.nonce, nonce_2);
         assert_eq!(batch[1].nonced_verification_data.nonce, nonce_1);

--- a/batcher/aligned-batcher/src/types/batch_queue.rs
+++ b/batcher/aligned-batcher/src/types/batch_queue.rs
@@ -312,6 +312,206 @@ mod test {
     }
 
     #[test]
+    fn batch_finalization_algorithm_works_from_same_sender_same_fee() {
+        // The following information will be the same for each entry, it is just some dummy data to see
+        // algorithm working.
+
+        let proof_generator_addr = Address::random();
+        let payment_service_addr = Address::random();
+        let sender_addr = Address::random();
+        let bytes_for_verification_data = vec![42_u8; 10];
+        let dummy_signature = Signature {
+            r: U256::from(1),
+            s: U256::from(2),
+            v: 3,
+        };
+        let verification_data = VerificationData {
+            proving_system: ProvingSystemId::Risc0,
+            proof: bytes_for_verification_data.clone(),
+            pub_input: Some(bytes_for_verification_data.clone()),
+            verification_key: Some(bytes_for_verification_data.clone()),
+            vm_program_code: Some(bytes_for_verification_data),
+            proof_generator_addr,
+        };
+        let chain_id = U256::from(42);
+
+        // Here we create different entries for the batch queue.
+        // All with the same fee
+
+        let max_fee = U256::from(130000000000000u128);
+        
+        // Entry 1
+        let nonce_1 = U256::from(1);
+        let nonced_verification_data_1 = NoncedVerificationData::new(
+            verification_data.clone(),
+            nonce_1,
+            max_fee,
+            chain_id,
+            payment_service_addr,
+        );
+        let vd_commitment_1: VerificationDataCommitment = nonced_verification_data_1.clone().into();
+        let entry_1 = BatchQueueEntry::new_for_testing(
+            nonced_verification_data_1,
+            vd_commitment_1,
+            dummy_signature,
+            sender_addr,
+        );
+        let batch_priority_1 = BatchQueueEntryPriority::new(max_fee, nonce_1);
+
+        // Entry 2
+        let nonce_2 = U256::from(2);
+        let nonced_verification_data_2 = NoncedVerificationData::new(
+            verification_data.clone(),
+            nonce_2,
+            max_fee,
+            chain_id,
+            payment_service_addr,
+        );
+        let vd_commitment_2: VerificationDataCommitment = nonced_verification_data_2.clone().into();
+        let entry_2 = BatchQueueEntry::new_for_testing(
+            nonced_verification_data_2,
+            vd_commitment_2,
+            dummy_signature,
+            sender_addr,
+        );
+        let batch_priority_2 = BatchQueueEntryPriority::new(max_fee, nonce_2);
+
+        // Entry 3
+        let nonce_3 = U256::from(3);
+        let nonced_verification_data_3 = NoncedVerificationData::new(
+            verification_data.clone(),
+            nonce_3,
+            max_fee,
+            chain_id,
+            payment_service_addr,
+        );
+        let vd_commitment_3: VerificationDataCommitment = nonced_verification_data_3.clone().into();
+        let entry_3 = BatchQueueEntry::new_for_testing(
+            nonced_verification_data_3,
+            vd_commitment_3,
+            dummy_signature,
+            sender_addr,
+        );
+        let batch_priority_3 = BatchQueueEntryPriority::new(max_fee, nonce_3);
+
+        let mut batch_queue = BatchQueue::new();
+        batch_queue.push(entry_1, batch_priority_1);
+        batch_queue.push(entry_2, batch_priority_2);
+        batch_queue.push(entry_3, batch_priority_3);
+
+        let gas_price = U256::from(1);
+        let (resulting_batch_queue, batch) =
+            try_build_batch(batch_queue, gas_price, 5000000, 50).unwrap();
+
+        assert!(resulting_batch_queue.is_empty());
+
+        assert_eq!(batch[0].nonced_verification_data.nonce, nonce_3);
+        assert_eq!(batch[1].nonced_verification_data.nonce, nonce_2);
+        assert_eq!(batch[2].nonced_verification_data.nonce, nonce_1);
+
+        // sanity check
+        assert_eq!(batch[2].nonced_verification_data.max_fee, max_fee);
+    }
+
+    #[test]
+    fn batch_finalization_algorithm_works_from_same_sender_same_fee_nonempty_resulting_queue() {
+        // The following information will be the same for each entry, it is just some dummy data to see
+        // algorithm working.
+
+        let proof_generator_addr = Address::random();
+        let payment_service_addr = Address::random();
+        let sender_addr = Address::random();
+        let bytes_for_verification_data = vec![42_u8; 10];
+        let dummy_signature = Signature {
+            r: U256::from(1),
+            s: U256::from(2),
+            v: 3,
+        };
+        let verification_data = VerificationData {
+            proving_system: ProvingSystemId::Risc0,
+            proof: bytes_for_verification_data.clone(),
+            pub_input: Some(bytes_for_verification_data.clone()),
+            verification_key: Some(bytes_for_verification_data.clone()),
+            vm_program_code: Some(bytes_for_verification_data),
+            proof_generator_addr,
+        };
+        let chain_id = U256::from(42);
+
+        // Here we create different entries for the batch queue.
+        // All with the same fee
+
+        let max_fee = U256::from(130000000000000u128);
+        
+        // Entry 1
+        let nonce_1 = U256::from(1);
+        let nonced_verification_data_1 = NoncedVerificationData::new(
+            verification_data.clone(),
+            nonce_1,
+            max_fee,
+            chain_id,
+            payment_service_addr,
+        );
+        let vd_commitment_1: VerificationDataCommitment = nonced_verification_data_1.clone().into();
+        let entry_1 = BatchQueueEntry::new_for_testing(
+            nonced_verification_data_1,
+            vd_commitment_1,
+            dummy_signature,
+            sender_addr,
+        );
+        let batch_priority_1 = BatchQueueEntryPriority::new(max_fee, nonce_1);
+
+        // Entry 2
+        let nonce_2 = U256::from(2);
+        let nonced_verification_data_2 = NoncedVerificationData::new(
+            verification_data.clone(),
+            nonce_2,
+            max_fee,
+            chain_id,
+            payment_service_addr,
+        );
+        let vd_commitment_2: VerificationDataCommitment = nonced_verification_data_2.clone().into();
+        let entry_2 = BatchQueueEntry::new_for_testing(
+            nonced_verification_data_2,
+            vd_commitment_2,
+            dummy_signature,
+            sender_addr,
+        );
+        let batch_priority_2 = BatchQueueEntryPriority::new(max_fee, nonce_2);
+
+        // Entry 3
+        let nonce_3 = U256::from(3);
+        let nonced_verification_data_3 = NoncedVerificationData::new(
+            verification_data.clone(),
+            nonce_3,
+            max_fee,
+            chain_id,
+            payment_service_addr,
+        );
+        let vd_commitment_3: VerificationDataCommitment = nonced_verification_data_3.clone().into();
+        let entry_3 = BatchQueueEntry::new_for_testing(
+            nonced_verification_data_3,
+            vd_commitment_3,
+            dummy_signature,
+            sender_addr,
+        );
+        let batch_priority_3 = BatchQueueEntryPriority::new(max_fee, nonce_3);
+
+        let mut batch_queue = BatchQueue::new();
+        batch_queue.push(entry_1, batch_priority_1);
+        batch_queue.push(entry_2, batch_priority_2);
+        batch_queue.push(entry_3, batch_priority_3);
+
+        let gas_price = U256::from(1);
+        let (resulting_batch_queue, batch) =
+            try_build_batch(batch_queue, gas_price, 5000000, 2).unwrap();
+
+        assert!(resulting_batch_queue.len() == 1); //nonce_3
+
+        assert_eq!(batch[0].nonced_verification_data.nonce, nonce_2);
+        assert_eq!(batch[1].nonced_verification_data.nonce, nonce_1);
+    }
+
+    #[test]
     fn batch_finalization_algorithm_works_from_different_senders() {
         // The following information will be the same for each entry, it is just some dummy data to see
         // algorithm working.

--- a/batcher/aligned-batcher/src/types/batch_queue.rs
+++ b/batcher/aligned-batcher/src/types/batch_queue.rs
@@ -514,7 +514,10 @@ mod test {
             try_build_batch(batch_queue, gas_price, 5000000, 2).unwrap();
 
         assert!(resulting_batch_queue.len() == 1); //nonce_3
-        assert!(resulting_batch_queue.clone().pop() == Some((entry_3.clone(), batch_priority_3.clone()))); //nonce_3
+        assert!(
+            resulting_batch_queue.clone().pop()
+                == Some((entry_3.clone(), batch_priority_3.clone()))
+        ); //nonce_3
 
         assert_eq!(batch[0].nonced_verification_data.nonce, nonce_2);
         assert_eq!(batch[1].nonced_verification_data.nonce, nonce_1);

--- a/batcher/aligned-batcher/src/types/batch_queue.rs
+++ b/batcher/aligned-batcher/src/types/batch_queue.rs
@@ -102,7 +102,7 @@ impl Ord for BatchQueueEntryPriority {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         let ord = other.max_fee.cmp(&self.max_fee);
         if ord == std::cmp::Ordering::Equal {
-            self.nonce.cmp(&other.nonce).reverse()
+            self.nonce.cmp(&other.nonce)
         } else {
             ord
         }


### PR DESCRIPTION
> [!important]
> This PR was rebased here: #1664
# Fix batcher queue ord

## Description

There was a bug in the batcher queue ordering of elements, which led to a wrong placement of proofs when a same sender sent proofs with same max_fee.
The consecuence of this bug was seen when the batcher queue is filled, the proofs sent to chain will be not from lowest to highest nonce, but the other way around.

## To Test

You can view the unit tests.

Also you can add the following print statements (and can do before this PR so you can verify the bug indeed existed).

in `batcher/aligned-batcher/src/lib.rs`, line 1175:
```
        info!("resulting:");
        for (entry, _priority) in resulting_batch_queue.iter() {
            info!(
                "nonce: {:?}, max fee: {:?}",
                entry.nonced_verification_data.nonce, entry.nonced_verification_data.max_fee
            );
        }

        info!("finalized:");
        for entry in finalized_batch.iter() {
            info!(
                "nonce: {:?}, max fee: {:?}",
                entry.nonced_verification_data.nonce, entry.nonced_verification_data.max_fee
            );
        }
```


in `messaging.rs`, line 161:
```
        info!("Last proof nonce: {:?}", last_proof_nonce);
        info!("Current proof nonce: {:?}", batch_inclusion_data_message.user_nonce);
```

This will help to view the resulting state of the batcher queue. 

To execute the bug you should send a burst bigger than the batch_qty limit. For this it is recommended to lower this value, `config-batcher.yaml`:
```
  max_batch_proof_qty: 5 # 5 proofs in a batch, for testing
```

Then send a burst of size 8, so that the first batch is of size 5 and the second of size 3. (this ensures you don't get the `batch already submitted` contract revert).

For this you can set `BURST_SIZE ?= 8` in the Makefile.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [x] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
