### PR TITLE
feat(explorer): highlight current page

### DIFF
--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -126,19 +126,12 @@ defmodule NavComponent do
   defp active_view_class(ExplorerWeb.Home.Index, ExplorerWeb.Home.Index), do: "text-4xl"
   defp active_view_class(_other, ExplorerWeb.Home.Index), do: "text-3xl"
 
-  defp active_view_class(current_view, ExplorerWeb.Batches.Index = target_view) do
-    if current_view == target_view || current_view == ExplorerWeb.Batch.Index do
-      "text-green-500 font-bold"
-    else
-      "text-foreground/80 hover:text-foreground font-semibold"
-    end
-  end
+  defp active_view_class(ExplorerWeb.Batches.Index, ExplorerWeb.Batches.Index ), do: "text-green-500 font-bold"
+  defp active_view_class(ExplorerWeb.Batch.Index, ExplorerWeb.Batches.Index ), do: "text-green-500 font-bold"
+  defp active_view_class(_other, ExplorerWeb.Batches.Index ), do: "text-foreground/80 hover:text-foreground font-semibold"
 
-  defp active_view_class(current_view, ExplorerWeb.Operators.Index = target_view) do
-    if current_view == target_view || current_view == ExplorerWeb.Operator.Index do
-      "text-green-500 font-bold"
-    else
-      "text-foreground/80 hover:text-foreground font-semibold"
-    end
-  end
+  defp active_view_class(ExplorerWeb.Operators.Index, ExplorerWeb.Operators.Index ), do: "text-green-500 font-bold"
+  defp active_view_class(ExplorerWeb.Operator.Index, ExplorerWeb.Operators.Index ), do: "text-green-500 font-bold"
+  defp active_view_class(_other, ExplorerWeb.Operators.Index ), do: "text-foreground/80 hover:text-foreground font-semibold"
+
 end

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -18,20 +18,28 @@ defmodule NavComponent do
     }>
       <div class="gap-x-6 inline-flex">
         <.link
-          class="text-3xl hover:scale-105 transform duration-150 active:scale-95"
+          class={
+            classes([
+              "hover:scale-105",
+              "transform",
+              "duration-150",
+              "active:scale-95",
+              active_class(assigns.socket.view, ExplorerWeb.Home.Index)
+            ])
+          }
           navigate={~p"/"}
         >
           🟩 <span class="sr-only">Aligned Explorer Home</span>
         </.link>
         <div class={["items-center gap-8 [&>a]:drop-shadow-md", "hidden md:inline-flex"]}>
           <.link
-            class="text-foreground/80 hover:text-foreground font-semibold"
+            class={active_class(assigns.socket.view, ExplorerWeb.Batches.Index)}
             navigate={~p"/batches"}
           >
             Batches
           </.link>
           <.link
-            class="text-foreground/80 hover:text-foreground font-semibold"
+            class={active_class(assigns.socket.view, ExplorerWeb.Operators.Index)}
             navigate={~p"/operators"}
           >
             Operators
@@ -76,13 +84,18 @@ defmodule NavComponent do
               <%= @latest_release %>
             </.badge>
             <.link
-              class="text-foreground/80 hover:text-foreground font-semibold"
+              class={
+                classes([
+                  active_class(assigns.socket.view, ExplorerWeb.Batches.Index),
+                  "text-foreground/80 hover:text-foreground font-semibold"
+                ])
+              }
               navigate={~p"/batches"}
             >
               Batches
             </.link>
             <.link
-              class="text-foreground/80 hover:text-foreground font-semibold"
+              class={active_class(assigns.socket.view, ExplorerWeb.Operators.Index)}
               navigate={~p"/operators"}
             >
               Operators
@@ -108,5 +121,24 @@ defmodule NavComponent do
     JS.toggle(to: "#menu-overlay")
     |> JS.toggle(to: ".toggle-open")
     |> JS.toggle(to: ".toggle-close")
+  end
+
+  defp active_class(ExplorerWeb.Home.Index, ExplorerWeb.Home.Index), do: "text-4xl"
+  defp active_class(_other, ExplorerWeb.Home.Index), do: "text-3xl"
+
+  defp active_class(current_view, ExplorerWeb.Batches.Index = target_view) do
+    if current_view == target_view || current_view == ExplorerWeb.Batch.Index do
+      "text-green-500 font-bold"
+    else
+      "text-foreground/80 hover:text-foreground font-semibold"
+    end
+  end
+
+  defp active_class(current_view, ExplorerWeb.Operators.Index = target_view) do
+    if current_view == target_view || current_view == ExplorerWeb.Operator.Index do
+      "text-green-500 font-bold"
+    else
+      "text-foreground/80 hover:text-foreground font-semibold"
+    end
   end
 end

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -18,28 +18,30 @@ defmodule NavComponent do
     }>
       <div class="gap-x-6 inline-flex">
         <.link
-          class={
-            classes([
-              "hover:scale-105",
-              "transform",
-              "duration-150",
-              "active:scale-95",
-              active_view_class(assigns.socket.view, ExplorerWeb.Home.Index)
-            ])
-          }
+          class="hover:scale-105 transform duration-150 active:scale-95 text-3xl"
           navigate={~p"/"}
         >
           🟩 <span class="sr-only">Aligned Explorer Home</span>
         </.link>
         <div class={["items-center gap-8 [&>a]:drop-shadow-md", "hidden md:inline-flex"]}>
           <.link
-            class={active_view_class(assigns.socket.view, ExplorerWeb.Batches.Index)}
+            class={
+              active_view_class(assigns.socket.view, [
+                ExplorerWeb.Batches.Index,
+                ExplorerWeb.Batch.Index
+              ])
+            }
             navigate={~p"/batches"}
           >
             Batches
           </.link>
           <.link
-            class={active_view_class(assigns.socket.view, ExplorerWeb.Operators.Index)}
+            class={
+              active_view_class(assigns.socket.view, [
+                ExplorerWeb.Operators.Index,
+                ExplorerWeb.Operator.Index
+              ])
+            }
             navigate={~p"/operators"}
           >
             Operators
@@ -86,7 +88,10 @@ defmodule NavComponent do
             <.link
               class={
                 classes([
-                  active_view_class(assigns.socket.view, ExplorerWeb.Batches.Index),
+                  active_view_class(assigns.socket.view, [
+                    ExplorerWeb.Batches.Index,
+                    ExplorerWeb.Batch.Index
+                  ]),
                   "text-foreground/80 hover:text-foreground font-semibold"
                 ])
               }
@@ -95,7 +100,12 @@ defmodule NavComponent do
               Batches
             </.link>
             <.link
-              class={active_view_class(assigns.socket.view, ExplorerWeb.Operators.Index)}
+              class={
+                active_view_class(assigns.socket.view, [
+                  ExplorerWeb.Operators.Index,
+                  ExplorerWeb.Operator.Index
+                ])
+              }
               navigate={~p"/operators"}
             >
               Operators
@@ -123,15 +133,9 @@ defmodule NavComponent do
     |> JS.toggle(to: ".toggle-close")
   end
 
-  defp active_view_class(ExplorerWeb.Home.Index, ExplorerWeb.Home.Index), do: "text-4xl"
-  defp active_view_class(_other, ExplorerWeb.Home.Index), do: "text-3xl"
-
-  defp active_view_class(ExplorerWeb.Batches.Index, ExplorerWeb.Batches.Index ), do: "text-green-500 font-bold"
-  defp active_view_class(ExplorerWeb.Batch.Index, ExplorerWeb.Batches.Index ), do: "text-green-500 font-bold"
-  defp active_view_class(_other, ExplorerWeb.Batches.Index ), do: "text-foreground/80 hover:text-foreground font-semibold"
-
-  defp active_view_class(ExplorerWeb.Operators.Index, ExplorerWeb.Operators.Index ), do: "text-green-500 font-bold"
-  defp active_view_class(ExplorerWeb.Operator.Index, ExplorerWeb.Operators.Index ), do: "text-green-500 font-bold"
-  defp active_view_class(_other, ExplorerWeb.Operators.Index ), do: "text-foreground/80 hover:text-foreground font-semibold"
-
+  defp active_view_class(current_view, target_views) do
+    if current_view in target_views,
+      do: "text-green-500 font-bold",
+      else: "text-foreground/80 hover:text-foreground font-semibold"
+  end
 end

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -24,7 +24,7 @@ defmodule NavComponent do
               "transform",
               "duration-150",
               "active:scale-95",
-              active_class(assigns.socket.view, ExplorerWeb.Home.Index)
+              active_view_class(assigns.socket.view, ExplorerWeb.Home.Index)
             ])
           }
           navigate={~p"/"}
@@ -33,13 +33,13 @@ defmodule NavComponent do
         </.link>
         <div class={["items-center gap-8 [&>a]:drop-shadow-md", "hidden md:inline-flex"]}>
           <.link
-            class={active_class(assigns.socket.view, ExplorerWeb.Batches.Index)}
+            class={active_view_class(assigns.socket.view, ExplorerWeb.Batches.Index)}
             navigate={~p"/batches"}
           >
             Batches
           </.link>
           <.link
-            class={active_class(assigns.socket.view, ExplorerWeb.Operators.Index)}
+            class={active_view_class(assigns.socket.view, ExplorerWeb.Operators.Index)}
             navigate={~p"/operators"}
           >
             Operators
@@ -86,7 +86,7 @@ defmodule NavComponent do
             <.link
               class={
                 classes([
-                  active_class(assigns.socket.view, ExplorerWeb.Batches.Index),
+                  active_view_class(assigns.socket.view, ExplorerWeb.Batches.Index),
                   "text-foreground/80 hover:text-foreground font-semibold"
                 ])
               }
@@ -95,7 +95,7 @@ defmodule NavComponent do
               Batches
             </.link>
             <.link
-              class={active_class(assigns.socket.view, ExplorerWeb.Operators.Index)}
+              class={active_view_class(assigns.socket.view, ExplorerWeb.Operators.Index)}
               navigate={~p"/operators"}
             >
               Operators
@@ -123,10 +123,10 @@ defmodule NavComponent do
     |> JS.toggle(to: ".toggle-close")
   end
 
-  defp active_class(ExplorerWeb.Home.Index, ExplorerWeb.Home.Index), do: "text-4xl"
-  defp active_class(_other, ExplorerWeb.Home.Index), do: "text-3xl"
+  defp active_view_class(ExplorerWeb.Home.Index, ExplorerWeb.Home.Index), do: "text-4xl"
+  defp active_view_class(_other, ExplorerWeb.Home.Index), do: "text-3xl"
 
-  defp active_class(current_view, ExplorerWeb.Batches.Index = target_view) do
+  defp active_view_class(current_view, ExplorerWeb.Batches.Index = target_view) do
     if current_view == target_view || current_view == ExplorerWeb.Batch.Index do
       "text-green-500 font-bold"
     else
@@ -134,7 +134,7 @@ defmodule NavComponent do
     end
   end
 
-  defp active_class(current_view, ExplorerWeb.Operators.Index = target_view) do
+  defp active_view_class(current_view, ExplorerWeb.Operators.Index = target_view) do
     if current_view == target_view || current_view == ExplorerWeb.Operator.Index do
       "text-green-500 font-bold"
     else

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -67,7 +67,12 @@ defmodule NavComponent do
             Operators
           </.link>
           <.link
-            class="text-foreground/80 hover:text-foreground font-semibold"
+            class={
+                active_view_class(assigns.socket.view, [
+                  ExplorerWeb.Restakes.Index,
+                  ExplorerWeb.Restake.Index
+                ])
+              }
             navigate={~p"/restakes"}
           >
             Restakes
@@ -143,7 +148,12 @@ defmodule NavComponent do
               Operators
             </.link>
             <.link
-              class="text-foreground/80 hover:text-foreground font-semibold"
+              class={
+                active_view_class(assigns.socket.view, [
+                  ExplorerWeb.Restakes.Index,
+                  ExplorerWeb.Restake.Index
+                ])
+              }
               navigate={~p"/restakes"}
             >
               Restakes


### PR DESCRIPTION
# Highlight Current Page

## Description

Highlights the current page in the nav bar in the explorer.

![image](https://github.com/user-attachments/assets/631ddfcf-d13c-4eae-b6fa-44469f44cd91)
![image](https://github.com/user-attachments/assets/7befa14b-e27e-41de-b378-59e559009f51)


## Type of change


- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
