### PR TITLE
feat(explorer): Add Restaking tab to nav bar

### DIFF
--- a/explorer/lib/explorer_web/components/assets_cta.ex
+++ b/explorer/lib/explorer_web/components/assets_cta.ex
@@ -25,7 +25,7 @@ defmodule AssetsCTAComponent do
             View all active operators
           </.tooltip>
         </.link>
-        <.link navigate={~p"/restake"} class="flex-1 flex flex-col justify-start gap-0.5 group">
+        <.link navigate={~p"/restakes"} class="flex-1 flex flex-col justify-start gap-0.5 group">
           <div class="text-muted-foreground font-semibold flex gap-2 items-center">
             <h2>
               Total Restaked

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -93,6 +93,12 @@ defmodule NavComponent do
             >
               Operators
             </.link>
+            <.link
+              class="text-foreground/80 hover:text-foreground font-semibold"
+              navigate={~p"/restake"}
+            >
+              Assets
+            </.link>
             <.link class="hover:text-foreground" target="_blank" href="https://docs.alignedlayer.com">
               Docs
             </.link>

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -40,7 +40,7 @@ defmodule NavComponent do
             class="text-foreground/80 hover:text-foreground font-semibold"
             navigate={~p"/restake"}
           >
-            Assets
+            Restakings
           </.link>
         </div>
         <.live_component module={SearchComponent} id="nav_search" />
@@ -97,7 +97,7 @@ defmodule NavComponent do
               class="text-foreground/80 hover:text-foreground font-semibold"
               navigate={~p"/restake"}
             >
-              Assets
+              Restakings
             </.link>
             <.link class="hover:text-foreground" target="_blank" href="https://docs.alignedlayer.com">
               Docs

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -38,9 +38,9 @@ defmodule NavComponent do
           </.link>
           <.link
             class="text-foreground/80 hover:text-foreground font-semibold"
-            navigate={~p"/restake"}
+            navigate={~p"/restakes"}
           >
-            Restakings
+            Restakes
           </.link>
         </div>
         <.live_component module={SearchComponent} id="nav_search" />
@@ -95,9 +95,9 @@ defmodule NavComponent do
             </.link>
             <.link
               class="text-foreground/80 hover:text-foreground font-semibold"
-              navigate={~p"/restake"}
+              navigate={~p"/restakes"}
             >
-              Restakings
+              Restakes
             </.link>
             <.link class="hover:text-foreground" target="_blank" href="https://docs.alignedlayer.com">
               Docs

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -40,7 +40,7 @@ defmodule NavComponent do
             class="text-foreground/80 hover:text-foreground font-semibold"
             navigate={~p"/restake"}
           >
-            Restaking
+            Assets
           </.link>
         </div>
         <.live_component module={SearchComponent} id="nav_search" />

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -36,6 +36,12 @@ defmodule NavComponent do
           >
             Operators
           </.link>
+          <.link
+            class="text-foreground/80 hover:text-foreground font-semibold"
+            navigate={~p"/restake"}
+          >
+            Restaking
+          </.link>
         </div>
         <.live_component module={SearchComponent} id="nav_search" />
       </div>

--- a/explorer/lib/explorer_web/live/pages/home/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/home/index.html.heex
@@ -16,7 +16,7 @@
     </.card_link>
     <.card_link 
       icon="hero-arrow-right-solid" 
-      navigate={~p"/restake"} 
+      navigate={~p"/restakes"} 
       title="Total Restaked" 
       subtitle={"(#{@restaked_amount_eth |> Helpers.format_number()} ETH)"}>
       <%= if @restaked_amount_eth != :nil do %>

--- a/explorer/lib/explorer_web/live/pages/restakes/index.ex
+++ b/explorer/lib/explorer_web/live/pages/restakes/index.ex
@@ -68,7 +68,7 @@ defmodule ExplorerWeb.Restakes.Index do
         <.table id="assets" rows={@assets}>
           <:col :let={asset} label="Token" class="text-left">
             <.link
-              navigate={~p"/restake/#{asset.strategy_address}"}
+              navigate={~p"/restakes/#{asset.strategy_address}"}
               class="flex gap-x-2 items-center group-hover:text-foreground/80"
             >
               <img

--- a/explorer/lib/explorer_web/router.ex
+++ b/explorer/lib/explorer_web/router.ex
@@ -37,8 +37,8 @@ defmodule ExplorerWeb.Router do
       live "/", Home.Index
       live "/batches/:merkle_root", Batch.Index
       live "/batches", Batches.Index
-      live "/restake", Restakes.Index
-      live "/restake/:address", Restake.Index
+      live "/restakes", Restakes.Index
+      live "/restakes/:address", Restake.Index
       live "/operators", Operators.Index
       live "/operators/:address", Operator.Index
       live "/search", Search.Index


### PR DESCRIPTION
# Add Restaking tab to nav bar

## Description

Adds a restaking tab to the explorer navigation bar that links to the restaking page.

## Testing

Start a local devnet.
Run the explorer.
Ensure clicking on `Restaking` links to the correct page.

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
