### PR TITLE
feat(explorer): show batcher_payments lastest movements

### DIFF
--- a/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
@@ -68,4 +68,34 @@ defmodule BatcherPaymentServiceManager do
         raise("Unexpected response on fee per proof events.")
     end
   end
+
+  def get_latest_activity() do
+    # event PaymentReceived(address indexed sender, uint256 amount);
+    # event FundsWithdrawn(address indexed recipient, uint256 amount);
+    # event BalanceLocked(address indexed user);
+    # event BalanceUnlocked(address indexed user, uint256 unlockBlockTime);
+    BatcherPaymentServiceManager.EventFilters.payment_received(nil)
+    |> Ethers.get_logs(fromBlock: @first_block)
+    |> case do
+      {:ok, []} ->
+        Logger.warning("No latest activity found.")
+        []
+
+      {:ok, events} -> dbg events
+        # events
+        # |> Enum.map(fn event ->
+        #   merkle_root = event.topics[1]
+        #   fee_per_proof = event.data |> hd()
+        #   {merkle_root, fee_per_proof}
+        # end)
+
+      {:error, reason} ->
+        Logger.error("Error getting latest activity: #{inspect(reason)}.")
+        raise("Error getting latest activity events.")
+
+      other ->
+        Logger.error("Unexpected response on latest activity events: #{inspect(other)}")
+        raise("Unexpected response on latest activity events.")
+    end
+  end
 end

--- a/explorer/lib/explorer_web/live/pages/home/index.ex
+++ b/explorer/lib/explorer_web/live/pages/home/index.ex
@@ -46,6 +46,8 @@ defmodule ExplorerWeb.Home.Index do
     restaked_amount_eth = Restakings.get_restaked_amount_eth()
     restaked_amount_usd = Restakings.get_restaked_amount_usd()
 
+    latest_batcher_payment_movements = BatcherPaymentServiceManager.get_latest_activity()
+
     if connected?(socket), do: Phoenix.PubSub.subscribe(Explorer.PubSub, "update_views")
 
     {:ok,


### PR DESCRIPTION
# Show latest batcher_payment_service movements in explorer

> [!NOTE]
> This PR is still WIP

## Description

We want to show the latest movements of the payment service in the explorer

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
