### PR TITLE
feat(explorer): (WIP - Halted) Search for wallet sent proofs and balance

### DIFF
--- a/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
@@ -68,4 +68,24 @@ defmodule BatcherPaymentServiceManager do
         raise("Unexpected response on fee per proof events.")
     end
   end
+
+  def get_user_balance(user_address) do
+    case BatcherPaymentServiceManager.user_balances(user_address)
+      |> Ethers.call() do
+        {:ok, data} ->
+          data
+        error ->
+          {:error, error}
+      end
+  end
+
+  def get_user_nonce(user_address) do
+    case BatcherPaymentServiceManager.user_nonces(user_address)
+      |> Ethers.call() do
+        {:ok, data} ->
+          data
+        error ->
+          {:error, error}
+      end
+  end
 end


### PR DESCRIPTION
# Explorer: Search for wallet sent proofs and balances

## Description

This PR adds a new component so any user can search for their address and get the number of proofs sent, as well as their current balance.

## How to test

1. Start all services
2. Open explorer and search for any address on the search bar, it should show information of a wallet zero balance and proofs
3. Fund a wallet on the payment service
4. Search that wallet on the explorer and check that the balance is right
5. Send a proof with that wallet.
6. Search that wallet and check that the balance has reduced and the number of proofs increased.

## Type of change

Please delete options that are not relevant.

- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
