### PR TITLE
feat(explorer): take batch ttl from env

### DIFF
--- a/explorer/.env.dev
+++ b/explorer/.env.dev
@@ -22,3 +22,6 @@ DEBUG_ERRORS=true
 TRACKER_API_URL=http://localhost:3030
 
 MAX_BATCH_SIZE=268435456 # 256 MiB
+
+# Time we wait for a batch to be verified before marking it stale
+BATCH_TTL_MINUTES=5

--- a/explorer/.env.example
+++ b/explorer/.env.example
@@ -20,3 +20,6 @@ DEBUG_ERRORS=<true|false>
 
 # Tracker API
 TRACKER_API_URL=<tracker_api_url>
+
+# Time we wait for a batch to be verified before marking it stale
+BATCH_TTL_MINUTES=5

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -148,7 +148,8 @@ defmodule ExplorerWeb.Helpers do
   end
 
   def is_stale?(batch) do
-    DateTime.add(batch.submission_timestamp, 5, :minute)
+    ttl = Utils.batch_ttl_minutes()
+    DateTime.add(batch.submission_timestamp, ttl, :minute)
     |> DateTime.before?(DateTime.utc_now())
   end
 
@@ -295,6 +296,11 @@ defmodule Utils do
       _other ->
         false
     end
+  end
+
+  def batch_ttl_minutes() do
+    System.get_env("BATCH_TTL_MINUTES")
+    |> String.to_integer()
   end
 
   def process_batch(%BatchDB{} = batch) do

--- a/explorer/start.sh
+++ b/explorer/start.sh
@@ -15,6 +15,7 @@ env_vars=(
   "DEBUG_ERRORS"
   "TRACKER_API_URL"
   "MAX_BATCH_SIZE"
+  "BATCH_TTL_MINUTES"
 )
 
 for var in "${env_vars[@]}"; do


### PR DESCRIPTION
Add a new `BATCH_TTL_MINUTES` environment variable for the explorer.
This variable stores the expected time in minutes we'll wait before
marking a `Pending` batch as `Unverified` in the UI.

## Type of change

Please delete options that are not relevant.

- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Testing

1. Bring up a devnet
2. Bring up the explorer with different settings in your `.env` for `BATCH_TTL_MINUTES`
3. Check that the `Age` at which batches get marked match the values you use in the different screens

Relevant pages: home, batches, individual batch.

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
