### PR TITLE
feat: show staging networks if we are on a staging network only

### DIFF
--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -15,7 +15,7 @@ defmodule NavComponent do
       Helpers.get_aligned_networks()
       |> Enum.filter(fn {name, _link} ->
         case current_network do
-          # Filter staging networks if we are in mainnet or holesky
+          # Filter dev networks if we are in mainnet or holesky
           "Mainnet" -> name in ["Mainnet", "Holesky"]
           "Holesky" -> name in ["Mainnet", "Holesky"]
           _ -> true

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -109,21 +109,14 @@ defmodule ExplorerWeb.Helpers do
   end
 
   @doc """
-    Returns the current network based on the configured environment.
-  """
-  def get_current_network() do
-    prefix = System.get_env("ENVIRONMENT")
-    String.capitalize(prefix)
-  end
-
-  @doc """
     Returns a list of available AlignedLayer networks with their names and explorer URLs.
   """
   def get_aligned_networks() do
     [
       {"Mainnet", "https://explorer.alignedlayer.com"},
       {"Holesky", "https://holesky.explorer.alignedlayer.com"},
-      {"Stage", "https://stage.explorer.alignedlayer.com"}
+      {"Stage", "https://stage.explorer.alignedlayer.com"},
+      {"Devnet", "http://localhost:4000/"}
     ]
   end
 


### PR DESCRIPTION
## Description

Shows `Stage` and `Devnet` optinos in the network selector only when the user is in `stage.explorer.alignedlayer.com` or `localhost`. Otherwise, shows `Mainnet` and `Holesky` networks.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
