### PR TITLE
fix: telemetry spans

### DIFF
--- a/telemetry_api/lib/telemetry_api/periodically.ex
+++ b/telemetry_api/lib/telemetry_api/periodically.ex
@@ -48,14 +48,14 @@ defmodule TelemetryApi.Periodically do
         EthereumMetrics.new_gas_price(gas_price)
 
       {:error, error} ->
-        IO.inspect("Error fetching gas price: #{error}")
+        Logger.error("Error fetching gas price: #{inspect(error)}")
     end
         {:noreply, %{}}
   end
   defp fetch_operators_info() do
     case Operators.fetch_all_operators() do
       :ok -> :ok
-      {:error, message} -> IO.inspect("Couldn't fetch operators: #{IO.inspect(message)}")
+      {:error, message} -> Logger.error("Couldn't fetch operators: #{inspect(message)}")
     end
   end
 
@@ -67,7 +67,7 @@ defmodule TelemetryApi.Periodically do
           Operators.update_operator(op, %{status: string_status(status)})
 
         error ->
-          Logger.error("Error when updating status: #{error}")
+          Logger.error("Error when updating status: #{inspect(error)}")
       end
     end)
     :ok

--- a/telemetry_api/lib/telemetry_api/traces.ex
+++ b/telemetry_api/lib/telemetry_api/traces.ex
@@ -91,7 +91,7 @@ defmodule TelemetryApi.Traces do
       })
 
       IO.inspect(
-        "Operator response included. merkle_root: #{IO.inspect(merkle_root)} operator_id: #{IO.inspect(operator_id)}"
+        "Operator response included. merkle_root: #{inspect(merkle_root)} operator_id: #{inspect(operator_id)}"
       )
 
       :ok
@@ -123,11 +123,6 @@ defmodule TelemetryApi.Traces do
         trace
         | subspans: Map.delete(trace.subspans, :batcher)
       })
-
-      with {:ok, _trace} <- set_current_trace(merkle_root) do
-        Tracer.end_span()
-        TraceStore.delete_trace(merkle_root)
-      end
 
       :ok
     end
@@ -208,7 +203,6 @@ defmodule TelemetryApi.Traces do
       :ok
     end
   end
-  
 
   @doc """
   Registers the sending of a batcher task to Ethereum in the task trace.
@@ -298,7 +292,7 @@ defmodule TelemetryApi.Traces do
       :ok
     end
   end
-  
+
   @doc """
   Registers a bump in the gas price when the aggregator tries to respond to a task in the task trace.
 


### PR DESCRIPTION
# Fix Telemetry Spans

## Motivation

We found that sometimes our Batcher tries to cancel batches that were actually included in the net, calling the `batcherTaskCreationFailed` endpoint, which finalizes the trace and prevents the Aggregator from registering its spans in the trace.

## Description

- Stops finalizing the trace when a `batcherTaskCreationFailed` occurs.

## Observations

On a real `batcherTaskCreationFailed`, the Aggregator won't receive the new task, and the trace will remain unfinished. Furthermore, the trace metadata won't be removed from the Telemetry server store. Despite that, we will be able to visualize the orphans spans with a warning that their parent ID is invalid.

#1477 was created to address this issue.

## How To Test

1. Check that everything is working normally:

Run anvil, all Aligned components with one or more operators and start telemetry:
```bash
make telemetry_full_start
```
Go to [jaeger](http:localhost:16686) and explore the generated traces:

![image](https://github.com/user-attachments/assets/e9bef5cd-2273-4e48-b029-46cfc09ea5c6)

2. Test the scenario addressed in this PR:

Change the Batcher `create_new_task_retryable` function in `batcher/aligned-batcher/src/retry/batcher_retryables.rs:165` to return an error after receiving the receipt:

```Rust
 // timeout to prevent a deadlock while waiting for the transaction to be included in a block.
    let _result = timeout(Duration::from_millis(transaction_wait_timeout), pending_tx)
        .await
        .map_err(|e| {
            warn!("Error while waiting for batch inclusion: {e}");
            RetryError::Permanent(BatcherError::ReceiptNotFoundError)
        })?
        .map_err(|e| {
            warn!("Error while waiting for batch inclusion: {e}");
            RetryError::Permanent(BatcherError::ReceiptNotFoundError)
        })?
        .ok_or(RetryError::Permanent(BatcherError::ReceiptNotFoundError));
    Err(RetryError::Permanent(BatcherError::ReceiptNotFoundError))
```
Then, start all components again and you should be able to see the Aggregator spans even when the Batcher sends `Batcher - Task Creation Failed`

![image](https://github.com/user-attachments/assets/a41fc604-2f4a-4470-92ae-86a18638ad20)

3. Test a real cancel scenario:

Remove the hole content of the Batcher `create_new_task_retryable` function in `batcher/aligned-batcher/src/retry/batcher_retryables.rs:105` and return an error without creating any task:

```Rust
pub async fn create_new_task_retryable(
    batch_merkle_root: [u8; 32],
    batch_data_pointer: String,
    proofs_submitters: Vec<Address>,
    fee_params: CreateNewTaskFeeParams,
    transaction_wait_timeout: u64,
    payment_service: &BatcherPaymentService,
    payment_service_fallback: &BatcherPaymentService,
) -> Result<TransactionReceipt, RetryError<BatcherError>> {
    Err(RetryError::Permanent(BatcherError::ReceiptNotFoundError))
}
```
You should only be able to see the Batcher spans:

![image](https://github.com/user-attachments/assets/5d3ec52b-ab00-415f-8e38-73e2ad50fe38)


## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
