### PR TITLE
Hotfix: explorer missing vars throw 500

### DIFF
--- a/explorer/lib/explorer_web/live/numbers.ex
+++ b/explorer/lib/explorer_web/live/numbers.ex
@@ -1,5 +1,5 @@
 defmodule Numbers do
-  def format_number(number) when is_nil(number) do
+  def format_number(number) when is_nil(number) or number == :empty do
     nil
   end
 

--- a/explorer/lib/explorer_web/live/pages/home/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/home/index.html.heex
@@ -10,33 +10,29 @@
     >
       <%= if @operators_registered != :empty do %>
         <%= @operators_registered %>
-      <% else %>
-        0
       <% end %>
     </.card_link>
     <.card_link 
-      icon="hero-arrow-right-solid" 
-      navigate={~p"/restake"} 
-      title="Total Restaked" 
-      subtitle={"(#{@restaked_amount_eth |> Helpers.format_number()} ETH)"}>
-      <%= if @restaked_amount_eth != :nil do %>
-        <%= @restaked_amount_usd |> Helpers.format_number() %> USD
-      <% else %>
-        0
-      <% end %>
+        icon="hero-arrow-right-solid" 
+        navigate={~p"/restake"} 
+        title="Total Restaked" 
+        subtitle={
+          if @restaked_amount_eth |> Helpers.format_number() != nil do
+            "(#{@restaked_amount_eth |> Helpers.format_number()} ETH)"
+          end
+        }>
+        <%= if @restaked_amount_usd |> Helpers.format_number() != nil do %>
+          <%= @restaked_amount_usd |> Helpers.format_number() %> USD
+        <% end %>
     </.card_link>
     <.card title="verified batches">
       <%= if @verified_batches != :empty do %>
         <%= @verified_batches |> Helpers.format_number() %>
-      <% else %>
-        0
       <% end %>
     </.card>
     <.card title="Verified Proofs" class="-mt-0.5 md:mt-0">
       <%= if @verified_proofs != :empty do %>
         <%= @verified_proofs |> Helpers.format_number() %>
-      <% else %>
-        0
       <% end %>
     </.card>
     <.live_component module={ContractsComponent} id="contracts_card" class="sm:col-span-2" />


### PR DESCRIPTION
# hotfix explorer set all vars when catching a panic

## Description

This PR makes the explorer home page to set all corresponding variables to :empty when handling a panic case.
The error was that there were a couple of new variables that were not set in a panic.

This is a hotfix, this same fix should be applied to all explorer pages

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
