### PR TITLE
fix(ci): foundryup install flag

### DIFF
--- a/docker/foundry.Dockerfile
+++ b/docker/foundry.Dockerfile
@@ -9,4 +9,4 @@ RUN apt install -y curl git
 # Install foundry
 RUN curl -L https://foundry.paradigm.xyz | bash
 ENV PATH="/root/.foundry/bin:${PATH}"
-RUN foundryup -v ${FOUNDRY_VERSION}
+RUN foundryup -i ${FOUNDRY_VERSION}

--- a/docs/0_internal/2_deploy_contracts.md
+++ b/docs/0_internal/2_deploy_contracts.md
@@ -18,7 +18,7 @@ Also, you will be able to deploy the Batcher Payment Service contract.
 
     ```shell
     make install_foundry
-    foundryup -v nightly-a428ba6ad8856611339a6319290aade3347d25d9
+    foundryup -i nightly-a428ba6ad8856611339a6319290aade3347d25d9
     ```
   
 ## AlignedServiceManager Contracts

--- a/docs/0_internal/3_a_upgrade_contracts.md
+++ b/docs/0_internal/3_a_upgrade_contracts.md
@@ -20,7 +20,7 @@ If you deployed the contract using a Multisig wallet, you can follow the [Upgrad
 
     ```sh
     make install_foundry
-    foundryup -v nightly-a428ba6ad8856611339a6319290aade3347d25d9
+    foundryup -i nightly-a428ba6ad8856611339a6319290aade3347d25d9
     ```
 
 - Add the following variables to the `.env` file:

--- a/docs/0_internal/3_b_upgrade_contracts_with_multisig.md
+++ b/docs/0_internal/3_b_upgrade_contracts_with_multisig.md
@@ -32,7 +32,7 @@ In this guide we make an upgrade of Aligned Layer Service Manager contract using
 
     ```shell
     make install_foundry
-    foundryup -v nightly-a428ba6ad8856611339a6319290aade3347d25d9
+    foundryup -i nightly-a428ba6ad8856611339a6319290aade3347d25d9
     ```
 
 ## Steps

--- a/docs/0_internal/4_b_pause_contracts_with_multisig.md
+++ b/docs/0_internal/4_b_pause_contracts_with_multisig.md
@@ -31,7 +31,7 @@ In this guide we pause and unpause the AlignedLayerServiceManager and BatcherPay
 
     ```shell
     make install_foundry
-    foundryup -v nightly-a428ba6ad8856611339a6319290aade3347d25d9
+    foundryup -i nightly-a428ba6ad8856611339a6319290aade3347d25d9
     ```
 
 ## Steps for Pausing

--- a/docs/3_guides/6_setup_aligned.md
+++ b/docs/3_guides/6_setup_aligned.md
@@ -29,7 +29,7 @@ Install [Foundry](https://book.getfoundry.sh/getting-started/installation):
 
 ```bash
 make install_foundry
-foundryup -v nightly-a428ba6ad8856611339a6319290aade3347d25d9
+foundryup -i nightly-a428ba6ad8856611339a6319290aade3347d25d9
 ```
 
 Install the necessary submodules and build all the FFIs for your OS:


### PR DESCRIPTION
# Update foundryup flag to install specific version

## Description

This PR in the foundry repo changed the `-v, --version` flag to `-i` to install a specific version: https://github.com/foundry-rs/foundry/pull/9551

## Type of change

- [X] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
