### PR TITLE
Enable claimability through calldata

### DIFF
--- a/claim_contracts/Makefile
+++ b/claim_contracts/Makefile
@@ -4,6 +4,23 @@
 help: ## 📚 Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+# Calldata
+
+calldata-update-merkle-root: ## 💾 Calldata for the method `updateMerkleRoot` to use in a transaction
+	cast calldata "updateMerkleRoot(bytes32)" $(MERKLE_ROOT)
+
+calldata-update-limit-timestamp: ## 💾 Calldata for the method `extendClaimPeriod` to use in a transaction
+	cast calldata "extendClaimPeriod(uint256)" $(LIMIT_TIMESTAMP)
+
+calldata-approve-spending: ## 💾 Calldata for the method `approve` to use in a transaction
+	cast calldata "approve(address,uint256)" $(CLAIM_PROXY_ADDRESS) 2600000000000000000000000000
+
+calldata-unpause: ## 💾 Calldata for the method `unpause` to use in a transaction
+	cast calldata "unpause()"
+
+calldata-pause: ## 💾 Calldata for the method `pause` to use in a transaction
+	cast calldata "pause()"
+
 # Deployments
 
 RPC_URL?=http://localhost:8545

--- a/claim_contracts/README.md
+++ b/claim_contracts/README.md
@@ -59,17 +59,20 @@
 > Steps 1, 2, and 4 can be batched into a single transaction in a multisig wallet. This multisig must be the `ClaimableAirdrop` contract owner.
 > Step 3 must be done by the token distributor multisig as it is the one that has the tokens to be claimed.
 
+> [!WARNING]
+> The data below is an example and should be replaced with the actual data.
+
 1. Update the merkle root
    ```
-   cast calldata "updateMerkleRoot(bytes32)" <merkle_root>
+   cast calldata "updateMerkleRoot(bytes32)" 0x97619aea42a289b94acc9fb98f5030576fa7449f1dd6701275815a6e99441927
    ```
 2. Update the claim time limit
    ```
-   cast calldata "extendClaimPeriod(uint256)" <new_timestamp>
+   cast calldata "extendClaimPeriod(uint256)" 2733427550
    ```
 3. Approve the claimable proxy contract to spend the token from the distributor (_2.6B, taking into account the 18 decimals_)
    ```
-   cast calldata "approve(address,uint256)" <claimable_proxy_address> 2600000000000000000000000000
+   cast calldata "approve(address,uint256)" 0x0234947ce63d1a5E731e5700b911FB32ec54C3c3 2600000000000000000000000000
    ```
 4. Unpause the claimable contract (it is paused by default)
    ```

--- a/claim_contracts/README.md
+++ b/claim_contracts/README.md
@@ -104,18 +104,3 @@ or
 ```
 make deploy-example MERKLE_ROOT=<claims-merkle-root> TIMESTAMP=2733427549
 ```
-
-### Testnet (using Safe Wallets)
-
-> [!IMPORTANT]
-> This assumes that the token and claimable contracts have already been deployed.
-
-#### Treasury
-
-- Approve the claimable contract to spend the token from the distributor.
-
-#### Foundation
-
-- Set the Merkle root
-- Set claim time limit
-- Unpause

--- a/claim_contracts/README.md
+++ b/claim_contracts/README.md
@@ -55,6 +55,10 @@
 > [!WARNING]
 > Double-check the data you passing into the commands, any mistake can lead to undesired behavior.
 
+> [!IMPORTANT]
+> Steps 1, 2, and 4 can be batched into a single transaction in a multisig wallet. This multisig must be the `ClaimableAirdrop` contract owner.
+> Step 3 must be done by the token distributor multisig as it is the one that has the tokens to be claimed.
+
 1. Update the merkle root
    ```
    cast calldata "updateMerkleRoot(bytes32)" <merkle_root>

--- a/claim_contracts/README.md
+++ b/claim_contracts/README.md
@@ -46,6 +46,32 @@
 
 ## Enabling Claimability
 
+### By Calldata
+
+> [!IMPORTANT]
+> This method **only** generates the necessary calldata to call the methods through transactions. It does **not** actually call the methods.
+> This method is useful for copy-pasting the calldata into a multisig wallet.
+
+> [!WARNING]
+> Double-check the data you passing into the commands, any mistake can lead to undesired behavior.
+
+1. Update the merkle root
+   ```
+   cast calldata "updateMerkleRoot(bytes32)" <merkle_root>
+   ```
+2. Update the claim time limit
+   ```
+   cast calldata "extendClaimPeriod(uint256)" <new_timestamp>
+   ```
+3. Approve the claimable proxy contract to spend the token from the distributor (_2.6B, taking into account the 18 decimals_)
+   ```
+   cast calldata "approve(address,uint256)" <claimable_proxy_address> 2600000000000000000000000000
+   ```
+4. Unpause the claimable contract (it is paused by default)
+   ```
+   cast calldata "unpause()"
+   ```
+
 ### Local
 
 1. Deploy the claimable contract as explained above.
@@ -71,3 +97,18 @@ or
 ```
 make deploy-example MERKLE_ROOT=<claims-merkle-root> TIMESTAMP=2733427549
 ```
+
+### Testnet (using Safe Wallets)
+
+> [!IMPORTANT]
+> This assumes that the token and claimable contracts have already been deployed.
+
+#### Treasury
+
+- Approve the claimable contract to spend the token from the distributor.
+
+#### Foundation
+
+- Set the Merkle root
+- Set claim time limit
+- Unpause

--- a/claim_contracts/README.md
+++ b/claim_contracts/README.md
@@ -49,23 +49,17 @@
 ### By Calldata
 
 > [!IMPORTANT]
-> This method **only** generates the necessary calldata to call the methods through transactions. It does **not** actually call the methods.
-> This method is useful for copy-pasting the calldata into a multisig wallet.
+>
+> - This step-by-step **assumes** that the claimable proxy contract **is already deployed** and that **is already paused**. If it is not paused, the first transaction should be to pause it using this calldata `cast calldata "pause()"`.
+> - This method **only** generates the necessary calldata to call the methods through transactions. It does **not** actually call the methods. This method is useful for copy-pasting the calldata into a multisig wallet.
+> - Steps 1, 2, and 4 can be batched into a single transaction in a multisig wallet. This multisig must be the `ClaimableAirdrop` contract owner.
+> - Step 3 must be done by the token distributor multisig as it is the one that has the tokens to be claimed.
 
 > [!WARNING]
-> Double-check the data you passing into the commands, any mistake can lead to undesired behavior.
+>
+> - Double-check the data you passing into the commands, any mistake can lead to undesired behavior.
+> - The data below is an example and should be replaced with the actual data.
 
-> [!IMPORTANT]
-> Steps 1, 2, and 4 can be batched into a single transaction in a multisig wallet. This multisig must be the `ClaimableAirdrop` contract owner.
-> Step 3 must be done by the token distributor multisig as it is the one that has the tokens to be claimed.
-
-> [!WARNING]
-> The data below is an example and should be replaced with the actual data.
-
-0. Pause the claimable proxy contract (if it is not already paused)
-   ```
-   cast calldata "pause()"
-   ```
 1. Update the merkle root
    ```
    cast calldata "updateMerkleRoot(bytes32)" 0x97619aea42a289b94acc9fb98f5030576fa7449f1dd6701275815a6e99441927

--- a/claim_contracts/README.md
+++ b/claim_contracts/README.md
@@ -62,6 +62,10 @@
 > [!WARNING]
 > The data below is an example and should be replaced with the actual data.
 
+0. Pause the claimable proxy contract (if it is not already paused)
+   ```
+   cast calldata "pause()"
+   ```
 1. Update the merkle root
    ```
    cast calldata "updateMerkleRoot(bytes32)" 0x97619aea42a289b94acc9fb98f5030576fa7449f1dd6701275815a6e99441927

--- a/claim_contracts/README.md
+++ b/claim_contracts/README.md
@@ -56,21 +56,22 @@
 > - Step 3 must be done by the token distributor multisig as it is the one that has the tokens to be claimed.
 
 > [!WARNING]
->
 > - Double-check the data you passing into the commands, any mistake can lead to undesired behavior.
-> - The data below is an example and should be replaced with the actual data.
 
 1. Update the merkle root
    ```
-   cast calldata "updateMerkleRoot(bytes32)" 0x97619aea42a289b94acc9fb98f5030576fa7449f1dd6701275815a6e99441927
+   // Example merkle_root = 0x97619aea42a289b94acc9fb98f5030576fa7449f1dd6701275815a6e99441927
+   cast calldata "updateMerkleRoot(bytes32)" <merkle_root>
    ```
 2. Update the claim time limit
    ```
-   cast calldata "extendClaimPeriod(uint256)" 2733427550
+   // Example timestamp = 2733427549
+   cast calldata "extendClaimPeriod(uint256)" <timestamp>
    ```
 3. Approve the claimable proxy contract to spend the token from the distributor (_2.6B, taking into account the 18 decimals_)
    ```
-   cast calldata "approve(address,uint256)" 0x0234947ce63d1a5E731e5700b911FB32ec54C3c3 2600000000000000000000000000
+   // Example claim_proxy_address = 0x0234947ce63d1a5E731e5700b911FB32ec54C3c6
+   cast calldata "approve(address,uint256)" <claim_proxy_address> 2600000000000000000000000000
    ```
 4. Unpause the claimable contract (it is paused by default)
    ```


### PR DESCRIPTION
## Enabling Claimability

### By Calldata

> [!IMPORTANT]
>
> - This step-by-step **assumes** that the claimable proxy contract **is already deployed** and that **is already paused**. If it is not paused, the first transaction should be to pause it using this calldata `cast calldata "pause()"`.
> - This method **only** generates the necessary calldata to call the methods through transactions. It does **not** actually call the methods. This method is useful for copy-pasting the calldata into a multisig wallet.
> - Steps 1, 2, and 4 can be batched into a single transaction in a multisig wallet. This multisig must be the `ClaimableAirdrop` contract owner.
> - Step 3 must be done by the token distributor multisig as it is the one that has the tokens to be claimed.

> [!WARNING]
>
> - Double-check the data you passing into the commands, any mistake can lead to undesired behavior.
> - The data below is an example and should be replaced with the actual data.

1. Update the merkle root
   ```
   cast calldata "updateMerkleRoot(bytes32)" 0x97619aea42a289b94acc9fb98f5030576fa7449f1dd6701275815a6e99441927
   ```
2. Update the claim time limit
   ```
   cast calldata "extendClaimPeriod(uint256)" 2733427550
   ```
3. Approve the claimable proxy contract to spend the token from the distributor (_2.6B, taking into account the 18 decimals_)
   ```
   cast calldata "approve(address,uint256)" 0x0234947ce63d1a5E731e5700b911FB32ec54C3c3 2600000000000000000000000000
   ```
4. Unpause the claimable contract (it is paused by default)
   ```
   cast calldata "unpause()"
   ```