### PR TITLE
fix(docs): batcher and explorer urls

### DIFF
--- a/docs/3_guides/0_submitting_proofs.md
+++ b/docs/3_guides/0_submitting_proofs.md
@@ -112,6 +112,7 @@ Proof submission is done via the `submit` command of the Aligned CLI. The argume
 * `batcher_url`: The batcher websocket URL. Can be:
   * mainnet: `wss://mainnet.batcher.alignedlayer.com`
   * holesky: `wss://batcher.alignedlayer.com`
+  * devnet: `ws://localhost:8080`
 * `network` to specify the network to be used. Can be `devnet`, `holesky` or `mainnet`.
 * `rpc_url`: The RPC Ethereum node URL.
 * `proof_generator_addr`: An optional parameter that can be used in some applications to avoid front-running.

--- a/docs/3_guides/0_submitting_proofs.md
+++ b/docs/3_guides/0_submitting_proofs.md
@@ -4,6 +4,8 @@ Make sure you have Aligned installed as specified [here](../1_introduction/1_try
 
 If you run the examples below, make sure you are in Aligned's repository root.
 
+You can check your submitted proofs on our explorer at https://explorer.alignedlayer.com (for Holesky: https://holesky.explorer.alignedlayer.com).
+
 ## Supported Verifiers
 
 The following is the list of the verifiers currently supported by Aligned:
@@ -68,8 +70,8 @@ To use it, you can use the `aligned` CLI, as shown with the following example:
 
 ```bash
 aligned deposit-to-batcher \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---network holesky \
+--rpc_url https://ethereum-rpc.publicnode.com \
+--network mainnet \
 --keystore_path <keystore_path> \
 --amount 0.1ether
 ```
@@ -77,7 +79,7 @@ aligned deposit-to-batcher \
 This command allows the usage of the following flags:
 
 - `--rpc_url` to specify the rpc url to be used.
-- `--network` to specify the netowrk to be used. Can be `devnet`, `holesky-stage` or `holesky`.
+- `--network` to specify the netowrk to be used. Can be `devnet`, `holesky` or `mainnet`.
 - `--keystore_path` the path to the keystore.
 - `--amount` the number of ethers to transfer to the Batcher.
 - Note: `--amount` flag parameter must be with the shown format, `XX.XXether`.
@@ -86,20 +88,20 @@ After depositing funds, you can verify the Service has correctly received them b
 
 ```bash
 aligned get-user-balance \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---network holesky \
+--rpc_url https://ethereum-rpc.publicnode.com \
+--network mainnet \
 --user_addr <user_addr>
 ```
 
 These commands allow the usage of the following flags:
 
 - `--rpc_url` to specify the rpc url to be used.
-- `--network` to specify the netowrk to be used. Can be `devnet`, `holesky-stage` or `holesky`.
+- `--network` to specify the netowrk to be used. Can be `devnet`, `holesky` or `mainnet`.
 - `--user_addr` the address of the user that funded the Batcher.
 
 ## 3. Submit your proof to the batcher
 
-This guide will focus on how to submit proofs using the Aligned CLI. To integrate the proof submission process into your application, check the [First Aligned Application tutorial](../3_guides/2_build_your_first_aligned_application.md#app) where we explain how to generate and submit a proof using the Aligned SDK.
+This guide will focus on how to submit proofs using the Aligned CLI. To integrate the proof submission process into your application, check the [First Aligned Application tutorial](../3_guides/2_build_your_first_aligned_application.md) where we explain how to generate and submit a proof using the Aligned SDK.
 
 Proof submission is done via the `submit` command of the Aligned CLI. The arguments for the submit command are:
 
@@ -107,8 +109,10 @@ Proof submission is done via the `submit` command of the Aligned CLI. The argume
 * `proof`: The path of the proof associated to the computation to be verified.
 * `vm_program`: When the proving system involves the execution of a program in a zkVM, this argument is associated with the compiled program or some other identifier of the program.
 * `pub_input`: The path to the file with the public input associated with the proof.
-* `batcher_url`: The batcher websocket URL.
-* `network` to specify the netowrk to be used. Can be `devnet`, `holesky-stage` or `holesky`.
+* `batcher_url`: The batcher websocket URL. Can be:
+  * mainnet: `wss://mainnet.batcher.alignedlayer.com`
+  * holesky: `wss://batcher.alignedlayer.com`
+* `network` to specify the network to be used. Can be `devnet`, `holesky` or `mainnet`.
 * `rpc_url`: The RPC Ethereum node URL.
 * `proof_generator_addr`: An optional parameter that can be used in some applications to avoid front-running.
 * `batch_inclusion_data_directory_path`: An optional parameter indicating the directory where to store the batcher response data. If not provided, the folder with the responses will be created in the current directory.
@@ -125,12 +129,12 @@ aligned submit \
 --proving_system SP1 \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
---batcher_url wss://batcher.alignedlayer.com \
+--batcher_url wss://mainnet.batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network mainnet \
+--rpc_url https://ethereum-rpc.publicnode.com
 ```
 
 **Example**
@@ -141,10 +145,10 @@ aligned submit \
 --proving_system SP1 \
 --proof ./scripts/test_files/sp1/sp1_fibonacci.proof \
 --vm_program ./scripts/test_files/sp1/sp1_fibonacci.elf \
---batcher_url wss://batcher.alignedlayer.com \
+--batcher_url wss://mainnet.batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network mainnet \
+--rpc_url https://ethereum-rpc.publicnode.com
 ```
 
 ### Risc0 proof
@@ -160,12 +164,12 @@ aligned submit \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
 --pub_input <pub_input_file> \
---batcher_url wss://batcher.alignedlayer.com \
+--batcher_url wss://mainnet.batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network mainnet \
+--rpc_url https://ethereum-rpc.publicnode.com
 ```
 
 **NOTE**: As said above, Aligned currently supports Risc0 proofs from `risc0-zkvm` version `v1.1.2`. For generating proofs using `cargo risc-zero` please ensure you are using `v1.1.2` or your proof will not be verified. 
@@ -188,11 +192,11 @@ aligned submit \
 --proof ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.proof \
 --vm_program ./scripts/test_files/risc_zero/fibonacci_proof_generator/fibonacci_id.bin \
 --public_input ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.pub \
---batcher_url wss://batcher.alignedlayer.com \
+--batcher_url wss://mainnet.batcher.alignedlayer.com \
 --aligned_verification_data_path ~/.aligned/aligned_verification_data \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network mainnet \
+--rpc_url https://ethereum-rpc.publicnode.com
 ```
 
 ### GnarkPlonkBn254, GnarkPlonkBls12_381 and Groth16Bn254
@@ -206,12 +210,12 @@ aligned submit \
 --proof <proof_file> \
 --public_input <public_input_file> \
 --vk <verification_key_file> \
---batcher_url wss://batcher.alignedlayer.com \
+--batcher_url wss://mainnet.batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network mainnet \
+--rpc_url https://ethereum-rpc.publicnode.com
 ```
 
 **Examples**:
@@ -223,10 +227,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_plonk_bn254_script/plonk.proof \
 --public_input ./scripts/test_files/gnark_plonk_bn254_script/plonk_pub_input.pub \
 --vk ./scripts/test_files/gnark_plonk_bn254_script/plonk.vk \
---batcher_url wss://batcher.alignedlayer.com \
+--batcher_url wss://mainnet.batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network mainnet \
+--rpc_url https://ethereum-rpc.publicnode.com
 ```
 
 ```bash
@@ -236,10 +240,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_plonk_bls12_381_script/plonk.proof \
 --public_input ./scripts/test_files/gnark_plonk_bls12_381_script/plonk_pub_input.pub \
 --vk ./scripts/test_files/gnark_plonk_bls12_381_script/plonk.vk \
---batcher_url wss://batcher.alignedlayer.com \
+--batcher_url wss://mainnet.batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network mainnet \
+--rpc_url https://ethereum-rpc.publicnode.com
 ```
 
 ```bash
@@ -249,8 +253,8 @@ aligned submit \
 --proof ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.proof \
 --public_input ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.pub \
 --vk ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.vk \
---batcher_url wss://batcher.alignedlayer.com \
+--batcher_url wss://mainnet.batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com 
+--network mainnet \
+--rpc_url https://ethereum-rpc.publicnode.com
 ```

--- a/docs/3_guides/0_submitting_proofs.md
+++ b/docs/3_guides/0_submitting_proofs.md
@@ -4,7 +4,7 @@ Make sure you have Aligned installed as specified [here](../1_introduction/1_try
 
 If you run the examples below, make sure you are in Aligned's repository root.
 
-You can check your submitted proofs on our explorer at https://explorer.alignedlayer.com (for Holesky: https://holesky.explorer.alignedlayer.com).
+You can check your submitted proofs on [Mainnet Explorer](https://explorer.alignedlayer.com) and [Holesky Explorer](https://holesky.explorer.alignedlayer.com).
 
 ## Supported Verifiers
 

--- a/docs/3_guides/0_submitting_proofs.md
+++ b/docs/3_guides/0_submitting_proofs.md
@@ -70,8 +70,8 @@ To use it, you can use the `aligned` CLI, as shown with the following example:
 
 ```bash
 aligned deposit-to-batcher \
---rpc_url https://ethereum-rpc.publicnode.com \
---network mainnet \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--network holesky \
 --keystore_path <keystore_path> \
 --amount 0.1ether
 ```
@@ -79,7 +79,7 @@ aligned deposit-to-batcher \
 This command allows the usage of the following flags:
 
 - `--rpc_url` to specify the rpc url to be used.
-- `--network` to specify the netowrk to be used. Can be `devnet`, `holesky` or `mainnet`.
+- `--network` to specify the network to be used. Can be `devnet`, `holesky` or `mainnet`.
 - `--keystore_path` the path to the keystore.
 - `--amount` the number of ethers to transfer to the Batcher.
 - Note: `--amount` flag parameter must be with the shown format, `XX.XXether`.
@@ -88,15 +88,15 @@ After depositing funds, you can verify the Service has correctly received them b
 
 ```bash
 aligned get-user-balance \
---rpc_url https://ethereum-rpc.publicnode.com \
---network mainnet \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--network holesky \
 --user_addr <user_addr>
 ```
 
 These commands allow the usage of the following flags:
 
 - `--rpc_url` to specify the rpc url to be used.
-- `--network` to specify the netowrk to be used. Can be `devnet`, `holesky` or `mainnet`.
+- `--network` to specify the network to be used. Can be `devnet`, `holesky` or `mainnet`.
 - `--user_addr` the address of the user that funded the Batcher.
 
 ## 3. Submit your proof to the batcher
@@ -129,12 +129,12 @@ aligned submit \
 --proving_system SP1 \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
---batcher_url wss://mainnet.batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network mainnet \
---rpc_url https://ethereum-rpc.publicnode.com
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com
 ```
 
 **Example**
@@ -145,10 +145,10 @@ aligned submit \
 --proving_system SP1 \
 --proof ./scripts/test_files/sp1/sp1_fibonacci.proof \
 --vm_program ./scripts/test_files/sp1/sp1_fibonacci.elf \
---batcher_url wss://mainnet.batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network mainnet \
---rpc_url https://ethereum-rpc.publicnode.com
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com
 ```
 
 ### Risc0 proof
@@ -164,12 +164,12 @@ aligned submit \
 --proof <proof_file> \
 --vm_program <vm_program_file> \
 --pub_input <pub_input_file> \
---batcher_url wss://mainnet.batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network mainnet \
---rpc_url https://ethereum-rpc.publicnode.com
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com
 ```
 
 **NOTE**: As said above, Aligned currently supports Risc0 proofs from `risc0-zkvm` version `v1.1.2`. For generating proofs using `cargo risc-zero` please ensure you are using `v1.1.2` or your proof will not be verified. 
@@ -192,11 +192,11 @@ aligned submit \
 --proof ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.proof \
 --vm_program ./scripts/test_files/risc_zero/fibonacci_proof_generator/fibonacci_id.bin \
 --public_input ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci.pub \
---batcher_url wss://mainnet.batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --aligned_verification_data_path ~/.aligned/aligned_verification_data \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network mainnet \
---rpc_url https://ethereum-rpc.publicnode.com
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com
 ```
 
 ### GnarkPlonkBn254, GnarkPlonkBls12_381 and Groth16Bn254
@@ -210,12 +210,12 @@ aligned submit \
 --proof <proof_file> \
 --public_input <public_input_file> \
 --vk <verification_key_file> \
---batcher_url wss://mainnet.batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network mainnet \
---rpc_url https://ethereum-rpc.publicnode.com
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com
 ```
 
 **Examples**:
@@ -227,10 +227,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_plonk_bn254_script/plonk.proof \
 --public_input ./scripts/test_files/gnark_plonk_bn254_script/plonk_pub_input.pub \
 --vk ./scripts/test_files/gnark_plonk_bn254_script/plonk.vk \
---batcher_url wss://mainnet.batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network mainnet \
---rpc_url https://ethereum-rpc.publicnode.com
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com
 ```
 
 ```bash
@@ -240,10 +240,10 @@ aligned submit \
 --proof ./scripts/test_files/gnark_plonk_bls12_381_script/plonk.proof \
 --public_input ./scripts/test_files/gnark_plonk_bls12_381_script/plonk_pub_input.pub \
 --vk ./scripts/test_files/gnark_plonk_bls12_381_script/plonk.vk \
---batcher_url wss://mainnet.batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network mainnet \
---rpc_url https://ethereum-rpc.publicnode.com
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com
 ```
 
 ```bash
@@ -253,8 +253,8 @@ aligned submit \
 --proof ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.proof \
 --public_input ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.pub \
 --vk ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.vk \
---batcher_url wss://mainnet.batcher.alignedlayer.com \
+--batcher_url wss://batcher.alignedlayer.com \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network mainnet \
---rpc_url https://ethereum-rpc.publicnode.com
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com
 ```

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -123,6 +123,7 @@ pub async fn submit_and_wait_verification(
 - `batcher_url` - The url of the batcher to which the proof will be submitted
   - mainnet: `wss://mainnet.batcher.alignedlayer.com`
   - holesky: `wss://batcher.alignedlayer.com`
+  - devnet: `ws://localhost:8080`
 - `eth_rpc_url` - The URL of the Ethereum RPC node.
 - `network` - The network on which the verification will be done (`devnet | holesky | mainnet`)
 - `verification_data` - The verification data for the proof.

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -71,6 +71,7 @@ pub async fn submit_multiple(
 - `batcher_url` - The url of the batcher to which the proof will be submitted:
   - mainnet: `wss://mainnet.batcher.alignedlayer.com`
   - holesky: `wss://batcher.alignedlayer.com`
+  - devnet: `ws://localhost:8080`
 - `network` - The network on which the proof will be submitted (`devnet | holesky | mainnet`)
 - `verification_data` - A verification data array.
 - `max_fees` - A max fee array.

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -179,6 +179,7 @@ pub async fn submit_multiple_and_wait_verification(
 - `batcher_url` - The url of the batcher to which the proof will be submitted:
   - mainnet: `wss://mainnet.batcher.alignedlayer.com`
   - holesky: `wss://batcher.alignedlayer.com`
+  - devnet: `ws://localhost:8080`
 - `eth_rpc_url` - The URL of the Ethereum RPC node.
 - `network` - The network on which the verification will be done (`devnet | holesky | mainnet`)
 - `verification_data` - A verification data array.

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -19,8 +19,10 @@ pub async fn submit(
 
 #### Arguments
 
-- `batcher_url` - The url of the batcher to which the proof will be submitted.
-- `network` - The network on which the proof will be submitted (`devnet | holesky-stage | holesky`)
+- `batcher_url` - The url of the batcher to which the proof will be submitted:
+  - mainnet: `wss://mainnet.batcher.alignedlayer.com`
+  - holesky: `wss://batcher.alignedlayer.com`
+- `network` - The network on which the proof will be submitted (`devnet | holesky | mainnet`)
 - `verification_data` - The verification data for the proof.
 - `max_fee` - The maximum fee that the submitter is willing to pay for the proof verification.
 - `wallet` - The wallet used to sign the proof. Should be using correct chain id. See `get_chain_id`.
@@ -65,8 +67,10 @@ pub async fn submit_multiple(
 
 #### Arguments
 
-- `batcher_url` - The url of the batcher to which the proof will be submitted.
-- `network` - The network on which the proof will be submitted (`devnet | holesky-stage | holesky`)
+- `batcher_url` - The url of the batcher to which the proof will be submitted:
+  - mainnet: `wss://mainnet.batcher.alignedlayer.com`
+  - holesky: `wss://batcher.alignedlayer.com`
+- `network` - The network on which the proof will be submitted (`devnet | holesky | mainnet`)
 - `verification_data` - A verification data array.
 - `max_fees` - A max fee array.
 - `wallet` - The wallet used to sign the proof. Should be using correct chain id. See `get_chain_id`.
@@ -114,9 +118,11 @@ pub async fn submit_and_wait_verification(
 
 #### Arguments
 
-- `batcher_url` - The url of the batcher to which the proof will be submitted.
+- `batcher_url` - The url of the batcher to which the proof will be submitted
+  - mainnet: `wss://mainnet.batcher.alignedlayer.com`
+  - holesky: `wss://batcher.alignedlayer.com`
 - `eth_rpc_url` - The URL of the Ethereum RPC node.
-- `network` - The network on which the verification will be done (`devnet | holesky-stage | holesky`)
+- `network` - The network on which the verification will be done (`devnet | holesky | mainnet`)
 - `verification_data` - The verification data for the proof.
 - `max_fee` - The maximum fee that the submitter is willing to pay for the proof verification.
 - `wallet` - The wallet used to sign the proof. Should be using correct chain id. See `get_chain_id`.
@@ -167,9 +173,11 @@ pub async fn submit_multiple_and_wait_verification(
 
 #### Arguments
 
-- `batcher_url` - The url of the batcher to which the proof will be submitted.
+- `batcher_url` - The url of the batcher to which the proof will be submitted:
+  - mainnet: `wss://mainnet.batcher.alignedlayer.com`
+  - holesky: `wss://batcher.alignedlayer.com`
 - `eth_rpc_url` - The URL of the Ethereum RPC node.
-- `network` - The network on which the verification will be done (`devnet | holesky-stage | holesky`)
+- `network` - The network on which the verification will be done (`devnet | holesky | mainnet`)
 - `verification_data` - A verification data array.
 - `max_fees` - A max fee array.
 - `wallet` - The wallet used to sign the proof. Should be using correct chain id. See `get_chain_id`.
@@ -218,7 +226,7 @@ pub async fn is_proof_verified(
 #### Arguments
 
 - `aligned_verification_data` - The aligned verification data obtained when submitting the proofs.
-- `network` - The network on which the verification will be done (`devnet | holesky-stage | holesky`)
+- `network` - The network on which the verification will be done (`devnet | holesky | mainnet`)
 - `eth_rpc_url` - The URL of the Ethereum RPC node.
 - `payment_service_addr` - The address of the batcher payment service contract.
 
@@ -296,7 +304,9 @@ pub async fn get_nonce_from_batcher(
 #### Arguments
 
 
-- `batcher_url` - The batcher websocket url.
+- `batcher_url` - The batcher websocket url:
+  - mainnet: `wss://mainnet.batcher.alignedlayer.com`
+  - holesky: `wss://batcher.alignedlayer.com`
 - `address` - The user address for which the nonce will be retrieved.
 
 #### Returns

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -22,6 +22,7 @@ pub async fn submit(
 - `batcher_url` - The url of the batcher to which the proof will be submitted:
   - mainnet: `wss://mainnet.batcher.alignedlayer.com`
   - holesky: `wss://batcher.alignedlayer.com`
+  - devnet: `ws://localhost:8080`
 - `network` - The network on which the proof will be submitted (`devnet | holesky | mainnet`)
 - `verification_data` - The verification data for the proof.
 - `max_fee` - The maximum fee that the submitter is willing to pay for the proof verification.

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -311,6 +311,7 @@ pub async fn get_nonce_from_batcher(
 - `batcher_url` - The batcher websocket url:
   - mainnet: `wss://mainnet.batcher.alignedlayer.com`
   - holesky: `wss://batcher.alignedlayer.com`
+  - devnet: `ws://localhost:8080`
 - `address` - The user address for which the nonce will be retrieved.
 
 #### Returns

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -45,6 +45,8 @@
 
 ## Useful links
 
+* [Mainnet Explorer](https://explorer.alignedlayer.com)
+* [Holesky Explorer](https://holesky.explorer.alignedlayer.com)
 * [All the proof aggregation solutions will use RISC-V zkvms](https://blog.alignedlayer.com/all-the-proof-aggregation-solutions-will-use-risc-v-zkvms/)
 * [Manifesto](https://blog.alignedlayer.com/aligned-manifesto/)
 


### PR DESCRIPTION
# Fix Batcher and Explorer urls

## Description

- Adds Explorer url to docs (mainnet and Holesky).
- Updates batcher url for mainnet.

## Type of change

- [x] Refactor

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
