### PR TITLE
fix(operator): Operator panic's when reconnect fails after max retries

### DIFF
--- a/core/chainio/avs_subscriber.go
+++ b/core/chainio/avs_subscriber.go
@@ -128,7 +128,7 @@ func (s *AvsSubscriber) SubscribeToNewTasksV2(newTaskCreatedChan chan *servicema
 			case err := <-subFallback.Err():
 				s.logger.Warn("Error in fallback new task subscription", "err", err)
 				subFallback.Unsubscribe()
-				subFallback, err = SubscribeToNewTasksV2Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManagerFallback, internalChannel, nil, retry.NetworkRetryParams())
+				subFallback, err = SubscribeToNewTasksV2Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManagerFallback, internalChannel, nil, retry.SubscribeToNewTasksParams())
 				if err != nil {
 					errorChannel <- err
 				}

--- a/core/chainio/avs_subscriber.go
+++ b/core/chainio/avs_subscriber.go
@@ -180,6 +180,13 @@ func (s *AvsSubscriber) SubscribeToNewTasksV3(newTaskCreatedChan chan *servicema
 
 	// Handle errors and resubscribe
 	go func() {
+		defer func() {
+			err := recover() //stops panics
+			if err != nil {
+				s.logger.Error("SubscribeToNewTasksV3 error channel recovered from panic", "err", err)
+			}
+		}()
+
 		for {
 			select {
 			case err := <-sub.Err():

--- a/core/chainio/avs_subscriber.go
+++ b/core/chainio/avs_subscriber.go
@@ -192,14 +192,14 @@ func (s *AvsSubscriber) SubscribeToNewTasksV3(newTaskCreatedChan chan *servicema
 			case err := <-sub.Err():
 				s.logger.Warn("Error in new task subscription", "err", err)
 				sub.Unsubscribe()
-				sub, err = SubscribeToNewTasksV3Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManager, internalChannel, nil, retry.NetworkRetryParams())
+				sub, err = SubscribeToNewTasksV3Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManager, internalChannel, nil, retry.SubscribeToNewTasksV3Params())
 				if err != nil {
 					errorChannel <- err
 				}
 			case err := <-subFallback.Err():
 				s.logger.Warn("Error in fallback new task subscription", "err", err)
 				subFallback.Unsubscribe()
-				subFallback, err = SubscribeToNewTasksV3Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManagerFallback, internalChannel, nil, retry.NetworkRetryParams())
+				subFallback, err = SubscribeToNewTasksV3Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManagerFallback, internalChannel, nil, retry.SubscribeToNewTasksV3Params())
 				if err != nil {
 					errorChannel <- err
 				}

--- a/core/chainio/retryable.go
+++ b/core/chainio/retryable.go
@@ -196,7 +196,7 @@ func (s *AvsSubscriber) SubscribeNewHeadRetryable(ctx context.Context, c chan<- 
 SubscribeToNewTasksV2Retryable
 Subscribe to NewBatchV2 logs from the AVS contract.
 - All errors are considered Transient Errors
-- Retry times (3 retries): 1 sec, 2 sec, 4 sec.
+- Retry times (Infinite Retries): 1 sec, 2 sec, 4 sec, 8 sec, ..., 60 sec, ...,
 */
 func SubscribeToNewTasksV2Retryable(
 	opts *bind.WatchOpts,

--- a/core/chainio/retryable.go
+++ b/core/chainio/retryable.go
@@ -215,7 +215,7 @@ func SubscribeToNewTasksV2Retryable(
 SubscribeToNewTasksV3Retryable
 Subscribe to NewBatchV3 logs from the AVS contract.
 - All errors are considered Transient Errors
-- Retry times (3 retries): 1 sec, 2 sec, 4 sec.
+- Retry times (Infinite Retries): 1 sec, 2 sec, 4 sec, 8 sec, ..., 60 sec, ...,
 */
 func SubscribeToNewTasksV3Retryable(
 	opts *bind.WatchOpts,

--- a/core/retry.go
+++ b/core/retry.go
@@ -32,18 +32,21 @@ const (
 	NetworkMultiplier          float64 = 2                // Multiplier factor computed exponential retry interval is scaled by.
 	NetworkNumRetries          uint64  = 3                // Total number of retries attempted.
 
-	// Retry Params for Sending Tx to Chain
+	// Retry Parameters for Sending a Tx to Chain
 	ChainInitialInterval = 12 * time.Second // Initial delay for retry interval for contract calls. Corresponds to 1 ethereum block.
 	ChainMaxInterval     = 2 * time.Minute  // Maximum interval for an individual retry.
 
-	// Retry Params for WaitForTransactionReceipt in the Fee Bump
+	// Retry Parameters for WaitForTransactionReceipt in the Fee Bump
 	WaitForTxMaxInterval = 2 * time.Second // Maximum interval for an individual retry.
 	WaitForTxNumRetries  = 0               // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
 
 	// Retry Parameters for RespondToTaskV2 in the Fee Bump
-	RespondToTaskV2MaxInterval           = time.Millisecond * 500 // Maximum interval for an individual retry.
-	RespondToTaskV2MaxElapsedTime        = 0                      //	Maximum time all retries may take. `0` corresponds to no limit on the time of the retries.
-	RespondToTaskV2NumRetries     uint64 = 0                      // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
+	RespondToTaskV2MaxInterval    = time.Millisecond * 500 // Maximum interval for an individual retry.
+	RespondToTaskV2MaxElapsedTime = 0                      //	Maximum time all retries may take. `0` corresponds to no limit on the time of the retries.
+	RespondToTaskV2NumRetries     = 0                      // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
+
+	// Retry Parameters for SubscribeToNewTasksV3
+	SubscribeToNewTasksV3NumRetries = 0 // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
 )
 
 type RetryParams struct {
@@ -99,6 +102,17 @@ func WaitForTxRetryParams(maxElapsedTime time.Duration) *RetryParams {
 		RandomizationFactor: NetworkRandomizationFactor,
 		Multiplier:          NetworkMultiplier,
 		NumRetries:          WaitForTxNumRetries,
+	}
+}
+
+func SubscribeToNewTasksV3Params() *RetryParams {
+	return &RetryParams{
+		InitialInterval:     NetworkInitialInterval,
+		MaxInterval:         NetworkMaxInterval,
+		MaxElapsedTime:      NetworkMaxElapsedTime,
+		RandomizationFactor: NetworkRandomizationFactor,
+		Multiplier:          NetworkMultiplier,
+		NumRetries:          SubscribeToNewTasksV3NumRetries,
 	}
 }
 

--- a/core/retry.go
+++ b/core/retry.go
@@ -45,8 +45,8 @@ const (
 	RespondToTaskV2MaxElapsedTime = 0                      //	Maximum time all retries may take. `0` corresponds to no limit on the time of the retries.
 	RespondToTaskV2NumRetries     = 0                      // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
 
-	// Retry Parameters for SubscribeToNewTasksV3
-	SubscribeToNewTasksNumRetries = 0 // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
+	// Retry Parameters for SubscribeToNewTasks
+	SubscribeToNewTasksNumRetries = 0 // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime (60 sec) is reached.
 )
 
 type RetryParams struct {

--- a/core/retry.go
+++ b/core/retry.go
@@ -46,7 +46,7 @@ const (
 	RespondToTaskV2NumRetries     = 0                      // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
 
 	// Retry Parameters for SubscribeToNewTasksV3
-	SubscribeToNewTasksV3NumRetries = 0 // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
+	SubscribeToNewTasksNumRetries = 0 // Total number of retries attempted. If 0, retries indefinitely until maxElapsedTime is reached.
 )
 
 type RetryParams struct {
@@ -105,14 +105,14 @@ func WaitForTxRetryParams(maxElapsedTime time.Duration) *RetryParams {
 	}
 }
 
-func SubscribeToNewTasksV3Params() *RetryParams {
+func SubscribeToNewTasksParams() *RetryParams {
 	return &RetryParams{
 		InitialInterval:     NetworkInitialInterval,
 		MaxInterval:         NetworkMaxInterval,
 		MaxElapsedTime:      NetworkMaxElapsedTime,
 		RandomizationFactor: NetworkRandomizationFactor,
 		Multiplier:          NetworkMultiplier,
-		NumRetries:          SubscribeToNewTasksV3NumRetries,
+		NumRetries:          SubscribeToNewTasksNumRetries,
 	}
 }
 


### PR DESCRIPTION
# Fix: Operator Panic when reconnect fails after max Retries

## Description

Closes #960. 
`SubscribeToNewTasksV2Retryable` and `SubscribeToNewTasksV3Retryable` are called when the [operator starts](https://github.com/yetanotherco/aligned_layer/blob/staging/operator/pkg/operator.go#L208) . `SubscribeToNewTasksV2Retryable` and `SubscribeToNewTasksV3Retryable` both spawn a go-routine to handle errors from the subscription to two rpc's a primary and a fallback. Upon erroring the go-routine attempts to subscribe again up to a retry limit.

When `SubscribeToNewTasksV2Retryable` and `SubscribeToNewTasksV3Retryable` exhaust the maximum number of retries the respective subscribe functions panics due to dereferencing a `nil` reference within the auto-generated contract bindings. 

In the case that one of the subscriptions errors and then fails to re-connect the operator will panic while one subscription (the fallback subscription) is still available and the operator can continue to function as normal. 

In the case that both connections fail error and fail to reconnect then the operator should shut down.

If the operator fails to subscribe initially the operator should shut down.

This pr addressed this issue by:
1.) Adding a `defer()` to the go routine the converts the panic into an error before the operator process exits.
2.) Changing the retry parameters for `SubscribeToNewTasksV2Retryable` and `SubscribeToNewTasksV3Retryable` to retry infinitely (up to retry intervals of 60 sec).

### To Test:
- install and use nginx  as a proxy to test the connection `brew install nginx`
- create a directory nginx with the file nginx.conf inside of it, with this content:
```
events { }

http {
    server {
        listen 8082;

        location /main/ {
            proxy_pass http://host.docker.internal:8545/;  # Note the trailing slashes
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_http_version 1.1;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection "upgrade";
            proxy_connect_timeout 1d;
            proxy_send_timeout 1d;
            proxy_read_timeout 1d;
        }
    }
}
```
- create a docker-compose.yml with the following contents:
```
version: '3'
services:
  nginx:
    image: nginx:alpine
    container_name: nginx-anvil-proxy
    volumes:
      - ./nginx:/etc/nginx
    ports:
      - "8082:8082"
 ```
- Make sure the nginx.conf file is located within ./nignx folder and you docker-compose-file has the proper path to the ngix.conf file.
 - change the respective Operator RPC url's in `config-files` within the aligned-layer repo to use `:8082/main/` port and path.
 - Start a local anvil node `make anvil_start_with_block_time`
 - Start nginx in a docker container via `docker compose -f nginx-docker-compose.yaml up -d`
 - Observe proof verification is successful.
 - kill the connection to anvil via `docker compose -f nginx-docker-compose.yaml stop`
 - observe operator blocks with the following message:
 
<img width="1048" alt="Screenshot 2024-12-30 at 17 08 42" src="https://github.com/user-attachments/assets/be4627db-0eee-4bf9-a94c-186b8214afd6" />

- Start the nginx proxy again `docker compose -f nginx-docker-compose.yaml up -d` && restart the aggregator `make aggregator_start`
- Observe the operator reconnects and start verifying batches
<img width="1048" alt="Screenshot 2024-12-30 at 17 10 41" src="https://github.com/user-attachments/assets/2df42296-0c87-4942-af36-29c668d30bb8" />
Panic Operation:
- change line 49 in `core/retry.go` to 	
```
SubscribeToNewTasksNumRetries = 1
```
- Start the local network with the nginx proxy as described above and kill the proxy
- Observe the operator errors and shuts down with the panic wrapped within an error.

<img width="1048" alt="Screenshot 2024-12-30 at 16 42 17" src="https://github.com/user-attachments/assets/f8d09d6a-24bd-4b4d-9edf-2f42147d5e64" />


## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
