### PR TITLE
chore: output `BatcherPaymentService` addresses as JSON

### DIFF
--- a/contracts/script/deploy/BatcherPaymentServiceDeployer.s.sol
+++ b/contracts/script/deploy/BatcherPaymentServiceDeployer.s.sol
@@ -8,26 +8,15 @@ import "forge-std/Script.sol";
 import "forge-std/StdJson.sol";
 
 contract BatcherPaymentServiceDeployer is Script {
-    function run(
-        string memory batcherConfigPath
-    ) external returns (address, address) {
+    function run(string memory batcherConfigPath, string memory outputPath) external returns (address, address) {
         // READ JSON CONFIG DATA
         string memory config_data = vm.readFile(batcherConfigPath);
 
-        address batcherWallet = stdJson.readAddress(
-            config_data,
-            ".address.batcherWallet"
-        );
+        address batcherWallet = stdJson.readAddress(config_data, ".address.batcherWallet");
 
-        address alignedLayerServiceManager = stdJson.readAddress(
-            config_data,
-            ".address.alignedLayerServiceManager"
-        );
+        address alignedLayerServiceManager = stdJson.readAddress(config_data, ".address.alignedLayerServiceManager");
 
-        address batcherPaymentServiceOwner = stdJson.readAddress(
-            config_data,
-            ".permissions.owner"
-        );
+        address batcherPaymentServiceOwner = stdJson.readAddress(config_data, ".permissions.owner");
 
         vm.startBroadcast();
 
@@ -44,6 +33,15 @@ contract BatcherPaymentServiceDeployer is Script {
         );
 
         vm.stopBroadcast();
+
+        string memory addresses = "addresses";
+        vm.serializeAddress(addresses, "batcherPaymentService", address(proxy));
+        string memory addressesStr =
+            vm.serializeAddress(addresses, "batcherPaymentServiceImplementation", address(batcherPaymentService));
+
+        string memory parentObject = "parent";
+        string memory finalJson = vm.serializeString(parentObject, "addresses", addressesStr);
+        vm.writeJson(finalJson, outputPath);
 
         return (address(proxy), address(batcherPaymentService));
     }

--- a/contracts/scripts/.env.example.holesky
+++ b/contracts/scripts/.env.example.holesky
@@ -5,4 +5,5 @@ DEPLOY_CONFIG_PATH=./script/deploy/config/holesky/aligned.holesky.config.json
 OUTPUT_PATH=./script/output/holesky/alignedlayer_deployment_output.json
 ETHERSCAN_API_KEY=<etherscan_api_key>
 BATCHER_PAYMENT_SERVICE_CONFIG_PATH=./script/deploy/config/holesky/batcher-payment-service.holesky.config.json
+BATCHER_PAYMENT_SERVICE_OUTPUT_PATH=./script/output/holesky/batcher_deployment_output.json
 MULTISIG=<false|true>

--- a/contracts/scripts/.env.holesky
+++ b/contracts/scripts/.env.holesky
@@ -3,6 +3,7 @@ PRIVATE_KEY=<YOUR_PRIVATE_KEY>
 EXISTING_DEPLOYMENT_INFO_PATH=./script/output/holesky/eigenlayer_deployment_output.json
 DEPLOY_CONFIG_PATH=./script/deploy/config/holesky/aligned.holesky.config.json
 BATCHER_PAYMENT_SERVICE_CONFIG_PATH=./script/deploy/config/holesky/batcher-payment-service.holesky.config.json
+BATCHER_PAYMENT_SERVICE_OUTPUT_PATH=./script/output/holesky/batcher_deployment_output.json
 OUTPUT_PATH=./script/output/holesky/alignedlayer_deployment_output.json
 ETHERSCAN_API_KEY=<YOUR_ETHERSCAN_API_KEY>
 MULTISIG=false

--- a/contracts/scripts/.env.mainnet
+++ b/contracts/scripts/.env.mainnet
@@ -3,6 +3,7 @@ PRIVATE_KEY=<YOUR_PRIVATE_KEY>
 EXISTING_DEPLOYMENT_INFO_PATH=./script/output/mainnet/eigenlayer_deployment_output.json
 DEPLOY_CONFIG_PATH=./script/deploy/config/mainnet/aligned.mainnet.config.json
 BATCHER_PAYMENT_SERVICE_CONFIG_PATH=./script/deploy/config/mainnet/batcher-payment-service.mainnet.config.json
+BATCHER_PAYMENT_SERVICE_OUTPUT_PATH=./script/output/mainnet/batcher_deployment_output.json
 OUTPUT_PATH=./script/output/mainnet/alignedlayer_deployment_output.json
 ETHERSCAN_API_KEY=<YOUR_ETHERSCAN_API_KEY>
 MULTISIG=false

--- a/contracts/scripts/.env.sepolia
+++ b/contracts/scripts/.env.sepolia
@@ -3,6 +3,7 @@ PRIVATE_KEY=<YOUR_PRIVATE_KEY>
 EXISTING_DEPLOYMENT_INFO_PATH=./script/output/sepolia/eigenlayer_deployment_output.json
 DEPLOY_CONFIG_PATH=./script/deploy/config/sepolia/aligned.sepolia.config.json
 BATCHER_PAYMENT_SERVICE_CONFIG_PATH=./script/deploy/config/sepolia/batcher-payment-service.sepolia.config.json
+BATCHER_PAYMENT_SERVICE_OUTPUT_PATH=./script/output/sepolia/batcher_deployment_output.json
 OUTPUT_PATH=./script/output/sepolia/alignedlayer_deployment_output.json
 ETHERSCAN_API_KEY=<YOUR_ETHERSCAN_API_KEY>
 MULTISIG=false

--- a/contracts/scripts/anvil/deploy_aligned_contracts.sh
+++ b/contracts/scripts/anvil/deploy_aligned_contracts.sh
@@ -38,13 +38,13 @@ forge script ../examples/verify/script/VerifyBatchInclusionCallerDeployer.s.sol 
 output_path=./script/output/devnet/batcher_deployment_output.json
 
 # Deploy Batcher Payments Contract
-forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
+forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     ./script/deploy/config/devnet/batcher-payment-service.devnet.config.json \
     $output_path \
     --rpc-url "http://localhost:8545" \
     --private-key "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" \
     --broadcast \
-    --sig "run(string batcherConfigPath, string outputPath)")
+    --sig "run(string batcherConfigPath, string outputPath)"
 
 # Extract the batcher payment service values from the output
 # new_aligned_layer_service_manager_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')

--- a/contracts/scripts/anvil/deploy_aligned_contracts.sh
+++ b/contracts/scripts/anvil/deploy_aligned_contracts.sh
@@ -47,7 +47,6 @@ forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     --sig "run(string batcherConfigPath, string outputPath)"
 
 # Extract the batcher payment service values from the output
-# new_aligned_layer_service_manager_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')
 batcher_payment_service_proxy=$(jq -r '.addresses.batcherPaymentService' $output_path)
 batcher_payment_service_implementation=$(jq -r '.addresses.batcherPaymentServiceImplementation' $output_path)
 

--- a/contracts/scripts/anvil/deploy_aligned_contracts.sh
+++ b/contracts/scripts/anvil/deploy_aligned_contracts.sh
@@ -38,10 +38,11 @@ forge script ../examples/verify/script/VerifyBatchInclusionCallerDeployer.s.sol 
 # Deploy Batcher Payments Contract
 forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     ./script/deploy/config/devnet/batcher-payment-service.devnet.config.json \
+    ./script/deploy/output/devnet/batcher_deployment_output.json \
     --rpc-url "http://localhost:8545" \
     --private-key "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" \
     --broadcast \
-    --sig "run(string batcherConfigPath)")
+    --sig "run(string batcherConfigPath, string outputPath)")
 
 # Extract the batcher payment service values from the output
 # new_aligned_layer_service_manager_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')

--- a/contracts/scripts/anvil/deploy_aligned_contracts.sh
+++ b/contracts/scripts/anvil/deploy_aligned_contracts.sh
@@ -35,10 +35,12 @@ forge script ../examples/verify/script/VerifyBatchInclusionCallerDeployer.s.sol 
     --broadcast \
     --sig "run(address _targetContract)"
 
+output_path=./script/output/devnet/batcher_deployment_output.json
+
 # Deploy Batcher Payments Contract
 forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     ./script/deploy/config/devnet/batcher-payment-service.devnet.config.json \
-    ./script/deploy/output/devnet/batcher_deployment_output.json \
+    $output_path \
     --rpc-url "http://localhost:8545" \
     --private-key "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" \
     --broadcast \
@@ -46,8 +48,8 @@ forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
 
 # Extract the batcher payment service values from the output
 # new_aligned_layer_service_manager_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')
-batcher_payment_service_proxy=$(echo "$forge_output" | awk '/0: address/ {print $3}')
-batcher_payment_service_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')
+batcher_payment_service_proxy=$(jq -r '.addresses.batcherPaymentService' $output_path)
+batcher_payment_service_implementation=$(jq -r '.addresses.batcherPaymentServiceImplementation' $output_path)
 
 # Give initial funds to ServiceManager for the Batcher
 cast send $ALIGNED_LAYER_SERVICE_MANAGER_ADDRESS "depositToBatcher(address)()" $batcher_payment_service_proxy --value 1ether --private-key "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" --rpc-url "http://localhost:8545"

--- a/contracts/scripts/deploy_batcher_payment_service.sh
+++ b/contracts/scripts/deploy_batcher_payment_service.sh
@@ -10,7 +10,7 @@ cd ../
 
 source scripts/.env
 
-BATCHER_PAYMENT_SERVICE_OUTPUT_PATH=./script/deploy/output/devnet/batcher_deployment_output.json
+BATCHER_PAYMENT_SERVICE_OUTPUT_PATH=./script/output/devnet/batcher_deployment_output.json
 
 # Deploy Batcher Payments Contract
 forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \

--- a/contracts/scripts/deploy_batcher_payment_service.sh
+++ b/contracts/scripts/deploy_batcher_payment_service.sh
@@ -10,23 +10,26 @@ cd ../
 
 source scripts/.env
 
+BATCHER_PAYMENT_SERVICE_OUTPUT_PATH=./script/deploy/output/devnet/batcher_deployment_output.json
+
 # Deploy Batcher Payments Contract
 forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     $BATCHER_PAYMENT_SERVICE_CONFIG_PATH \
+    $BATCHER_PAYMENT_SERVICE_OUTPUT_PATH \
     --rpc-url $RPC_URL \
     --private-key $PRIVATE_KEY \
     --broadcast \
     --legacy \
     --verify \
     --etherscan-api-key $ETHERSCAN_API_KEY \
-    --sig "run(string memory batcherConfigPath)")
+    --sig "run(string memory batcherConfigPath, string memory outputPath)")
 
 echo "$forge_output"
 
 # Extract the batcher payment service values from the output
 # new_aligned_layer_service_manager_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')
-batcher_payment_service_proxy=$(echo "$forge_output" | awk '/0: address/ {print $3}')
-batcher_payment_service_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')
+batcher_payment_service_proxy=$(jq -r '.addresses.batcherPaymentService' $BATCHER_PAYMENT_SERVICE_OUTPUT_PATH)
+batcher_payment_service_implementation=$(jq -r '.addresses.batcherPaymentServiceImplementation' $BATCHER_PAYMENT_SERVICE_OUTPUT_PATH)
 
 # Use the extracted value to replace the  batcher payment service values in alignedlayer_deployment_output.json and save it to a temporary file
 jq --arg batcher_payment_service_proxy "$batcher_payment_service_proxy" '.addresses.batcherPaymentService = $batcher_payment_service_proxy' $OUTPUT_PATH > $OUTPUT_PATH.temp2

--- a/contracts/scripts/deploy_batcher_payment_service.sh
+++ b/contracts/scripts/deploy_batcher_payment_service.sh
@@ -11,7 +11,7 @@ cd ../
 source scripts/.env
 
 # Deploy Batcher Payments Contract
-forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
+forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     $BATCHER_PAYMENT_SERVICE_CONFIG_PATH \
     $BATCHER_PAYMENT_SERVICE_OUTPUT_PATH \
     --rpc-url $RPC_URL \
@@ -20,9 +20,7 @@ forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     --legacy \
     --verify \
     --etherscan-api-key $ETHERSCAN_API_KEY \
-    --sig "run(string memory batcherConfigPath, string memory outputPath)")
-
-echo "$forge_output"
+    --sig "run(string memory batcherConfigPath, string memory outputPath)"
 
 # Extract the batcher payment service values from the output
 # new_aligned_layer_service_manager_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')

--- a/contracts/scripts/deploy_batcher_payment_service.sh
+++ b/contracts/scripts/deploy_batcher_payment_service.sh
@@ -10,8 +10,6 @@ cd ../
 
 source scripts/.env
 
-BATCHER_PAYMENT_SERVICE_OUTPUT_PATH=./script/output/devnet/batcher_deployment_output.json
-
 # Deploy Batcher Payments Contract
 forge_output=$(forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     $BATCHER_PAYMENT_SERVICE_CONFIG_PATH \

--- a/contracts/scripts/deploy_batcher_payment_service.sh
+++ b/contracts/scripts/deploy_batcher_payment_service.sh
@@ -23,7 +23,6 @@ forge script script/deploy/BatcherPaymentServiceDeployer.s.sol \
     --sig "run(string memory batcherConfigPath, string memory outputPath)"
 
 # Extract the batcher payment service values from the output
-# new_aligned_layer_service_manager_implementation=$(echo "$forge_output" | awk '/1: address/ {print $3}')
 batcher_payment_service_proxy=$(jq -r '.addresses.batcherPaymentService' $BATCHER_PAYMENT_SERVICE_OUTPUT_PATH)
 batcher_payment_service_implementation=$(jq -r '.addresses.batcherPaymentServiceImplementation' $BATCHER_PAYMENT_SERVICE_OUTPUT_PATH)
 


### PR DESCRIPTION
# Output BatcherPaymentService addresses as JSON

## Description

This PR changes the `BatcherPaymentService` deployment script to follow the convention of outputting the addresses of deployed contracts in a JSON file.

## Type of change

Refactor

## Checklist

- [X] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
