### PR TITLE
Fix: wei usd read significant figures

### DIFF
--- a/explorer/lib/explorer_web/components/batches_table.ex
+++ b/explorer/lib/explorer_web/components/batches_table.ex
@@ -31,7 +31,7 @@ defmodule ExplorerWeb.BatchesTable do
       </:col>
 
       <:col :let={batch} label="Fee per proof">
-        <%= case EthConverter.wei_to_usd(batch.fee_per_proof, 6) do %>
+        <%= case EthConverter.wei_to_usd_sf(batch.fee_per_proof, 2) do %>
           <% {:ok, usd} -> %>
             <%= "#{usd} USD" %>
           <% {:error, _} -> %>

--- a/explorer/lib/explorer_web/live/eth_converter.ex
+++ b/explorer/lib/explorer_web/live/eth_converter.ex
@@ -43,6 +43,38 @@ defmodule EthConverter do
     end
   end
 
+  # rounds to significant figures, instead of decimal places
+  def wei_to_usd_sf(wei, significant_figures \\ 3) do
+    with eth_amount <- wei_to_eth(wei, 18),
+         {:ok, eth_price} <- get_eth_price_usd() do
+      usd_value =
+        Decimal.mult(Decimal.new(to_string(eth_amount)), Decimal.new(to_string(eth_price)))
+
+      rounded_value = round_to_sf(usd_value, significant_figures)
+
+      {:ok, Decimal.to_string(rounded_value, :normal)}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp round_to_sf(value, significant_figures) do
+    # Convert the value to a float and calculate the magnitude
+    value_float = Decimal.to_float(value)
+    magnitude = :math.log10(abs(value_float)) |> floor()
+
+    # Calculate the factor to multiply by for shifting the decimal point
+    factor = :math.pow(10, significant_figures - 1 - magnitude)
+
+    # Round, then shift back
+    rounded_value = value_float
+                    |> Kernel.*(factor)
+                    |> round()
+                    |> Kernel./(factor)
+
+    Decimal.new(Float.to_string(rounded_value))
+  end
+
   def multiply_eth_by_usd(eth, usd_price) do
     eth_float = to_float(eth)
     usd_float = to_float(usd_price)

--- a/explorer/lib/explorer_web/live/pages/batch/index.ex
+++ b/explorer/lib/explorer_web/live/pages/batch/index.ex
@@ -12,7 +12,7 @@ defmodule ExplorerWeb.Batch.Index do
           :empty
 
         %Batches{fee_per_proof: fee_per_proof} = batch ->
-          {_, fee_per_proof_usd} = EthConverter.wei_to_usd(fee_per_proof, 2)
+          {_, fee_per_proof_usd} = EthConverter.wei_to_usd_sf(fee_per_proof, 2)
 
           %{
             batch
@@ -58,7 +58,7 @@ defmodule ExplorerWeb.Batch.Index do
           :empty
 
         %{fee_per_proof: fee_per_proof} = batch ->
-          {_, fee_per_proof_usd} = EthConverter.wei_to_usd(fee_per_proof, 2)
+          {_, fee_per_proof_usd} = EthConverter.wei_to_usd_sf(fee_per_proof, 2)
 
           %{
             batch

--- a/explorer/lib/explorer_web/live/pages/home/index.ex
+++ b/explorer/lib/explorer_web/live/pages/home/index.ex
@@ -9,7 +9,7 @@ defmodule ExplorerWeb.Home.Index do
     avg_fee_per_proof = Batches.get_avg_fee_per_proof()
 
     avg_fee_per_proof_usd =
-      case EthConverter.wei_to_usd(avg_fee_per_proof, 2) do
+      case EthConverter.wei_to_usd_sf(avg_fee_per_proof, 2) do
         {:ok, value} -> value
         _ -> 0
       end
@@ -90,7 +90,7 @@ defmodule ExplorerWeb.Home.Index do
     points =
       Enum.map(batches, fn b ->
         fee_per_proof =
-          case EthConverter.wei_to_usd(b.fee_per_proof, 2) do
+          case EthConverter.wei_to_usd_sf(b.fee_per_proof, 2) do
             {:ok, value} ->
               value
 
@@ -117,7 +117,7 @@ defmodule ExplorerWeb.Home.Index do
         merkle_root: Enum.map(batches, fn b -> b.merkle_root end),
         fee_per_proof:
           Enum.map(batches, fn b ->
-            case EthConverter.wei_to_usd(b.fee_per_proof, 2) do
+            case EthConverter.wei_to_usd_sf(b.fee_per_proof, 2) do
               {:ok, value} ->
                 value
 


### PR DESCRIPTION
# wei_to_usd that takes amount of significant figures

## Description

We were always using `wei_to_usd` that takes amount of decimals.
This new function takes amount of significant figures, which is more appropriate for some use cases where the numbers vary in decimal places

## Type of change

Please delete options that are not relevant.

- [x] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
