### PR TITLE
hotfix: explorer new version

### DIFF
--- a/explorer/lib/explorer_web/live/pages/batches/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/batches/index.html.heex
@@ -34,7 +34,7 @@
         type="number"
         class={
           classes([
-            "border border-foreground/20 text-muted-foreground w-20 focus:ring-primary",
+            "text-center border border-foreground/20 text-muted-foreground w-20 focus:ring-primary",
             "phx-submit-loading:opacity-75 rounded-lg bg-card hover:bg-muted py-2 px-3",
             "text-sm font-semibold leading-6 text-foregound active:text-foregound/80",
             "[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"

--- a/explorer/lib/explorer_web/live/pages/home/index.ex
+++ b/explorer/lib/explorer_web/live/pages/home/index.ex
@@ -42,13 +42,21 @@ defmodule ExplorerWeb.Home.Index do
       %{
         title: "Proofs verified",
         value: Helpers.convert_number_to_shorthand(verified_proofs),
-        tooltip_text: "= #{Helpers.format_number(verified_proofs)} proofs",
+        tooltip_text:
+          case verified_proofs >= 1000 do
+            true -> "= #{Helpers.format_number(verified_proofs)} proofs"
+            _ -> nil
+          end,
         link: nil
       },
       %{
         title: "Total batches",
         value: Helpers.convert_number_to_shorthand(verified_batches),
-        tooltip_text: "= #{Helpers.format_number(verified_batches)} batches",
+        tooltip_text:
+          case verified_batches >= 1000 do
+            true -> "= #{Helpers.format_number(verified_batches)} batches"
+            _ -> nil
+          end,
         link: nil
       },
       %{

--- a/explorer/lib/explorer_web/live/pages/home/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/home/index.html.heex
@@ -34,7 +34,7 @@
     <div class="flex flex-wrap md:flex-row flex-col gap-5">
       <.card
         title="Cost per proof"
-        subtitle="Cost of proving over time"
+        subtitle="Verification cost over time"
         class="p-0 flex-1"
         header_container_class="px-10 pt-8"
       >

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -7,6 +7,11 @@ defmodule ExplorerWeb.Helpers do
     end
   end
 
+  def convert_number_to_shorthand(number) when number >= 1_000_000_000 do
+    formatted_number = Float.round(number / 1_000_000_000, 2)
+    "#{remove_trailing_zeros(formatted_number)}B"
+  end
+
   def convert_number_to_shorthand(number) when number >= 1_000_000 do
     formatted_number = Float.round(number / 1_000_000, 2)
     "#{remove_trailing_zeros(formatted_number)}M"


### PR DESCRIPTION
## Description

Fixes:
- Cost per proof chart description
- Add short hand for numbers in the billions
- Show proofs and batches tooltip in home stats only if the displayed number is a shorthand (> 1000).
- Centers page index in batches page.

## Type of change

- [x] Bug fix


## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
