### PR TITLE
feat: add `--addr` flag to batcher

### DIFF
--- a/batcher/aligned-batcher/src/main.rs
+++ b/batcher/aligned-batcher/src/main.rs
@@ -24,12 +24,15 @@ struct Cli {
     env_file: Option<String>,
     #[arg(short, long)]
     port: Option<u16>,
+    #[arg(short, long)]
+    addr: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), BatcherError> {
     let cli = Cli::parse();
     let port = cli.port.unwrap_or(8080);
+    let addr = cli.addr.unwrap_or("localhost".to_string());
 
     match cli.env_file {
         Some(env_file) => dotenvy::from_filename(env_file).ok(),
@@ -40,7 +43,7 @@ async fn main() -> Result<(), BatcherError> {
     let batcher = Batcher::new(cli.config).await;
     let batcher = Arc::new(batcher);
 
-    let addr = format!("localhost:{}", port);
+    let address = format!("{addr}:{port}");
 
     // spawn task to listening for incoming blocks
     tokio::spawn({
@@ -54,7 +57,7 @@ async fn main() -> Result<(), BatcherError> {
 
     batcher.metrics.inc_batcher_restart();
 
-    batcher.listen_connections(&addr).await?;
+    batcher.listen_connections(&address).await?;
 
     Ok(())
 }


### PR DESCRIPTION
# Add `--addr` flag to batcher

## Description

This PR adds a CLI flag to the batcher, to be able to specify another address to expose the RPC in. Currently, it uses localhost, which makes testing via docker difficult. This behavior is preserved by making it the default.

## Type of change

New feature

## Checklist

- [X] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
