### PR TITLE
hotfix: change cost_per_proof_chart var name

### DIFF
--- a/explorer/lib/explorer_web/live/eth_converter.ex
+++ b/explorer/lib/explorer_web/live/eth_converter.ex
@@ -58,7 +58,7 @@ defmodule EthConverter do
     end
   end
 
-  defp round_to_sf(0, _), do: Decimal.new("0")
+  defp round_to_sf(%Decimal{coef: 0} = _value, _sf), do: Decimal.new("0")
 
   defp round_to_sf(value, significant_figures) do
     # Convert the value to a float and calculate the magnitude

--- a/explorer/lib/explorer_web/live/eth_converter.ex
+++ b/explorer/lib/explorer_web/live/eth_converter.ex
@@ -58,6 +58,8 @@ defmodule EthConverter do
     end
   end
 
+  defp round_to_sf(0, _), do: Decimal.new("0")
+
   defp round_to_sf(value, significant_figures) do
     # Convert the value to a float and calculate the magnitude
     value_float = Decimal.to_float(value)

--- a/explorer/lib/explorer_web/live/pages/home/index.ex
+++ b/explorer/lib/explorer_web/live/pages/home/index.ex
@@ -154,7 +154,7 @@ defmodule ExplorerWeb.Home.Index do
     |> assign(
       stats: [],
       latest_batches: [],
-      cost_per_proof_data: %{points: [], extra_data: %{}},
+      cost_per_proof_chart: %{points: [], extra_data: %{}},
       batch_size_chart_data: %{points: [], extra_data: %{}}
     )
   end


### PR DESCRIPTION
# Hotfix explorer

## Description

The explorer had errors when started with no proofs.
One is it tried to make log10(0) when no proofs where present.
Another one is the `cost_per_proof_chart` var name was not updated in `set_empty_values()`

## To test

Start an explorer with no proofs, make sure it starts with no errors.
Send some proofs, make sure it works as expected

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
