### PR TITLE
hotfix(explorer): Add `fee_per_proof` average to the data endpoint.

### DIFF
--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -170,12 +170,17 @@ defmodule Batches do
 
     query = from(b in Batches,
       where: b.is_verified == true and b.submission_timestamp > ^threshold_datetime,
-      select: sum(b.amount_of_proofs))
+      select: {sum(b.amount_of_proofs), avg(b.fee_per_proof)})
 
-    case Explorer.Repo.one(query) do
-      nil -> 0
-      result -> result
+    {amount_of_proofs, fee_per_proof} = case Explorer.Repo.one(query) do
+      nil -> {0, 0.0}
+      {amount_of_proofs, fee_per_proof} -> {Decimal.to_float(amount_of_proofs), fee_per_proof}
     end
+
+    %{
+      amount_of_proofs: amount_of_proofs,
+      fee_per_proof: fee_per_proof
+    }
   end
 
   def insert_or_update(batch_changeset, proofs) do

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -164,7 +164,7 @@ defmodule Batches do
     end
   end
 
-  def get_verified_proofs_in_last_24_hours() do
+  def get_last_24h_verified_proof_stats() do
     minutes_in_a_day = 1440
     threshold_datetime = DateTime.utc_now() |> DateTime.add(-1 * minutes_in_a_day, :minute) # Last 24 hours
 
@@ -174,7 +174,7 @@ defmodule Batches do
 
     {amount_of_proofs, avg_fee_per_proof} = case Explorer.Repo.one(query) do
       nil -> {0, 0.0}
-      {amount_of_proofs, avg_fee_per_proof} -> {amount_of_proofs, avg_fee_per_proof}
+      result -> result
     end
 
     %{

--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -172,14 +172,14 @@ defmodule Batches do
       where: b.is_verified == true and b.submission_timestamp > ^threshold_datetime,
       select: {sum(b.amount_of_proofs), avg(b.fee_per_proof)})
 
-    {amount_of_proofs, fee_per_proof} = case Explorer.Repo.one(query) do
+    {amount_of_proofs, avg_fee_per_proof} = case Explorer.Repo.one(query) do
       nil -> {0, 0.0}
-      {amount_of_proofs, fee_per_proof} -> {Decimal.to_float(amount_of_proofs), fee_per_proof}
+      {amount_of_proofs, avg_fee_per_proof} -> {amount_of_proofs, avg_fee_per_proof}
     end
 
     %{
       amount_of_proofs: amount_of_proofs,
-      fee_per_proof: fee_per_proof
+      avg_fee_per_proof: avg_fee_per_proof
     }
   end
 

--- a/explorer/lib/explorer_web/controllers/data_controller.ex
+++ b/explorer/lib/explorer_web/controllers/data_controller.ex
@@ -2,7 +2,14 @@ defmodule ExplorerWeb.DataController do
   use ExplorerWeb, :controller
 
   def verified_proofs_in_last_24_hours(conn, _params) do
-    verified_proofs_in_last_24_hours = Batches.get_verified_proofs_in_last_24_hours()
-    render(conn, :show, count: verified_proofs_in_last_24_hours)
+    %{
+      amount_of_proofs: amount_of_proofs,
+      avg_fee_per_proof: avg_fee_per_proof
+    } = Batches.get_verified_proofs_in_last_24_hours()
+
+    render(conn, :show, %{
+      amount_of_proofs: amount_of_proofs,
+      avg_fee_per_proof: avg_fee_per_proof
+    })
   end
 end

--- a/explorer/lib/explorer_web/controllers/data_controller.ex
+++ b/explorer/lib/explorer_web/controllers/data_controller.ex
@@ -5,11 +5,17 @@ defmodule ExplorerWeb.DataController do
     %{
       amount_of_proofs: amount_of_proofs,
       avg_fee_per_proof: avg_fee_per_proof
-    } = Batches.get_verified_proofs_in_last_24_hours()
+    } = Batches.get_last_24h_verified_proof_stats()
+
+    avg_fee_per_proof_usd =
+      case EthConverter.wei_to_usd_sf(avg_fee_per_proof, 2) do
+        {:ok, value} -> value
+        _ -> 0
+      end
 
     render(conn, :show, %{
       amount_of_proofs: amount_of_proofs,
-      avg_fee_per_proof: avg_fee_per_proof
+      avg_fee_per_proof_usd: avg_fee_per_proof_usd
     })
   end
 end

--- a/explorer/lib/explorer_web/controllers/data_json.ex
+++ b/explorer/lib/explorer_web/controllers/data_json.ex
@@ -1,13 +1,11 @@
 defmodule ExplorerWeb.DataJSON do
-  def show(
+  def show(%{
+        amount_of_proofs: amount_of_proofs,
+        avg_fee_per_proof: avg_fee_per_proof
+      }) do
     %{
       amount_of_proofs: amount_of_proofs,
-      fee_per_proof: fee_per_proof
-    }
-) do
-    %{
-      amount_of_proofs: amount_of_proofs,
-      fee_per_proof: fee_per_proof
+      avg_fee_per_proof: avg_fee_per_proof
     }
   end
 end

--- a/explorer/lib/explorer_web/controllers/data_json.ex
+++ b/explorer/lib/explorer_web/controllers/data_json.ex
@@ -1,7 +1,13 @@
 defmodule ExplorerWeb.DataJSON do
-  def show(%{count: last_verified_proofs_count}) do
+  def show(
     %{
-      count: last_verified_proofs_count
+      amount_of_proofs: amount_of_proofs,
+      fee_per_proof: fee_per_proof
+    }
+) do
+    %{
+      amount_of_proofs: amount_of_proofs,
+      fee_per_proof: fee_per_proof
     }
   end
 end

--- a/explorer/lib/explorer_web/controllers/data_json.ex
+++ b/explorer/lib/explorer_web/controllers/data_json.ex
@@ -1,11 +1,11 @@
 defmodule ExplorerWeb.DataJSON do
   def show(%{
         amount_of_proofs: amount_of_proofs,
-        avg_fee_per_proof: avg_fee_per_proof
+        avg_fee_per_proof_usd: avg_fee_per_proof_usd
       }) do
     %{
       amount_of_proofs: amount_of_proofs,
-      avg_fee_per_proof: avg_fee_per_proof
+      avg_fee_per_proof_usd: avg_fee_per_proof_usd
     }
   end
 end


### PR DESCRIPTION
# Add `fee_per_proof` average to the data endpoint

## Description

This PR adds the `fee_per_proof` average on all verified proofs of the last 24 hours on the `/data/last_verified_proofs` endpoint.

## Type of change

Please delete options that are not relevant.

- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [X] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
