### PR TITLE
hotfix(docs): add link for sending proofs on mainnet

### DIFF
--- a/docs/1_introduction/1_try_aligned.md
+++ b/docs/1_introduction/1_try_aligned.md
@@ -4,7 +4,7 @@ In this tutorial, you will learn how to send your first SP1 proofs to get verifi
 
 {% hint style="warning" %}
 This tutorial is for sending proofs on Holesky network.
-To send proofs on mainnet, please refer to the [submitting proofs](../3_guides/0_submitting_proofs.md) guide.
+To send proofs on Mainnet, please refer to the [submitting proofs](../3_guides/0_submitting_proofs.md) guide.
 {% endhint %}
 
 ## Quickstart

--- a/docs/1_introduction/1_try_aligned.md
+++ b/docs/1_introduction/1_try_aligned.md
@@ -2,6 +2,11 @@
 
 In this tutorial, you will learn how to send your first SP1 proofs to get verified in Aligned in under 3 minutes.
 
+{% hint style="warning" %}
+This tutorial is for sending proofs on Holesky network.
+To send proofs on mainnet, please refer to the [submitting proofs](../3_guides/0_submitting_proofs.md) guide.
+{% endhint %}
+
 ## Quickstart
 
 We will download a previously generated SP1 proof, send it to Aligned for verification, and retrieve the results from Ethereum Holesky testnet.


### PR DESCRIPTION
# Add Link For Sending Proofs On Mainnet

## Description

Updates the `try_aligned.md` guide to have a link to `submititng_proofs.md`.
## Type of change

- [x] New feature

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
