### PR TITLE
hotfix(explorer): Fix the proof price average

### DIFF
--- a/explorer/lib/explorer/models/batches.ex
+++ b/explorer/lib/explorer/models/batches.ex
@@ -144,7 +144,7 @@ defmodule Batches do
     query =
       from(b in Batches,
         where: b.is_verified == true,
-        select: avg(b.fee_per_proof)
+        select: sum(b.fee_per_proof * b.amount_of_proofs) / sum(b.amount_of_proofs)
       )
 
     case Explorer.Repo.one(query) do


### PR DESCRIPTION
# Fix the proof price average

## Description

This PR fixes the calculation of the proof price average.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [X] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
