### PR TITLE
fix(explorer): Batch stats endpoint should return an array of summarized batches information

### DIFF
--- a/explorer/config/config.exs
+++ b/explorer/config/config.exs
@@ -8,6 +8,13 @@
 import Config
 
 config :explorer,
+  batcher_submission_gas_cost: 125000,
+  aggregator_gas_cost: 330000,
+  additional_submission_gas_cost_per_proof: 2000,
+  aggregator_fee_percentage_multiplier: 125,
+  percentage_divider: 100
+
+config :explorer,
   generators: [timestamp_type: :utc_datetime],
   tracker_api_url: System.get_env("TRACKER_API_URL")
 

--- a/explorer/lib/explorer_web/controllers/data_controller.ex
+++ b/explorer/lib/explorer_web/controllers/data_controller.ex
@@ -1,21 +1,11 @@
 defmodule ExplorerWeb.DataController do
   use ExplorerWeb, :controller
 
-  def verified_proofs_in_last_24_hours(conn, _params) do
-    %{
-      amount_of_proofs: amount_of_proofs,
-      avg_fee_per_proof: avg_fee_per_proof
-    } = Batches.get_last_24h_verified_proof_stats()
-
-    avg_fee_per_proof_usd =
-      case EthConverter.wei_to_usd_sf(avg_fee_per_proof, 2) do
-        {:ok, value} -> value
-        _ -> 0
-      end
+  def verified_batches_summary(conn, _params) do
+    batches = Batches.get_verified_batches_summary()
 
     render(conn, :show, %{
-      amount_of_proofs: amount_of_proofs,
-      avg_fee_per_proof_usd: avg_fee_per_proof_usd
+      batches: batches,
     })
   end
 end

--- a/explorer/lib/explorer_web/controllers/data_controller.ex
+++ b/explorer/lib/explorer_web/controllers/data_controller.ex
@@ -2,10 +2,11 @@ defmodule ExplorerWeb.DataController do
   use ExplorerWeb, :controller
 
   def verified_batches_summary(conn, _params) do
-    batches = Batches.get_verified_batches_summary()
+    batches_summary =
+      Batches.get_daily_verified_batches_summary()
 
     render(conn, :show, %{
-      batches: batches,
+      batches: batches_summary,
     })
   end
 end

--- a/explorer/lib/explorer_web/controllers/data_json.ex
+++ b/explorer/lib/explorer_web/controllers/data_json.ex
@@ -1,11 +1,9 @@
 defmodule ExplorerWeb.DataJSON do
   def show(%{
-        amount_of_proofs: amount_of_proofs,
-        avg_fee_per_proof_usd: avg_fee_per_proof_usd
+        batches: batches,
       }) do
     %{
-      amount_of_proofs: amount_of_proofs,
-      avg_fee_per_proof_usd: avg_fee_per_proof_usd
+      batches: batches,
     }
   end
 end

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -205,6 +205,12 @@ defmodule Utils do
                      _ -> 268_435_456
                    end)
 
+  @batcher_submission_gas_cost Application.compile_env(:explorer, :batcher_submission_gas_cost)
+  @aggregator_gas_cost Application.compile_env(:explorer, :aggregator_gas_cost)
+  @aggregator_fee_percentage_multiplier Application.compile_env(:explorer, :aggregator_fee_percentage_multiplier)
+  @percentage_divider Application.compile_env(:explorer, :percentage_divider)
+  @additional_submission_gas_cost_per_proof Application.compile_env(:explorer, :additional_submission_gas_cost_per_proof)
+
   def string_to_bytes32(hex_string) do
     # Remove the '0x' prefix
     hex =
@@ -408,5 +414,17 @@ defmodule Utils do
 
   def random_id(prefix) do
     prefix <> "_" <> (:crypto.strong_rand_bytes(8) |> Base.url_encode64(padding: false))
+  end
+
+  def constant_batch_submission_gas_cost() do
+    trunc(
+      @aggregator_gas_cost * @aggregator_fee_percentage_multiplier /
+      @percentage_divider +
+      @batcher_submission_gas_cost
+    )
+  end
+
+  def additional_batch_submission_gas_cost_per_proof() do
+    @additional_submission_gas_cost_per_proof
   end
 end

--- a/explorer/lib/explorer_web/router.ex
+++ b/explorer/lib/explorer_web/router.ex
@@ -34,7 +34,7 @@ defmodule ExplorerWeb.Router do
 
   scope "/api", ExplorerWeb do
     pipe_through :api
-    get "/proofs_verified_last_24h", DataController, :verified_proofs_in_last_24_hours
+    get "/verified_batches_summary", DataController, :verified_batches_summary
   end
 
   scope "/", ExplorerWeb do


### PR DESCRIPTION
# Batch stats endpoint should return an array of summarized batches information

## Description

This PR does the following changes:
* Rename the `/api/proofs_verified_last_24h` to `api/verified_batches_summary`
* Modifies the endpoint to return an array of batches summarized data
* Add config values to be used in batch gas cost calculation

The summarized data has the following format:

```json
{
  "batches": [
    {
      "date": "2025-01-07",
      "amount_of_proofs": 12,
      "gas_cost": 3249000
    },
    {
      "date": "2025-01-08",
      "amount_of_proofs": 826,
      "gas_cost": 223639500
    }
  ]
}
```

## How to test

1. Start a devnet
2. Send a fixed amount of proofs
3. Visit `/api/verified_batches_summary`
4. Check that the amount of proofs matches the ones shown in the explorer
5. Check that the gas cost calculation is correct

### How to calculate the gas cost

The gas cost for each batch is derived from the following formula:

```
CONSTANT_GAS_COST = AGGREGATOR_GAS_COST * AGGREGATOR_MULTIPLIER) / PERCENTAGE_DIVIDER + BATCHER_SUBMISSION_GAS_COST

BATCH_GAS_COST = CONSTANT_GAS_COST + amount_of_proofs * ADDITIONAL_SUBMISSION_GAS_COST_PER_PROOF
```

By using the following values:

```elixir
config :explorer,
  batcher_submission_gas_cost: 125000,
  aggregator_gas_cost: 330000,
  additional_submission_gas_cost_per_proof: 2000,
  aggregator_fee_percentage_multiplier: 125,
  percentage_divider: 100
```

The calculation is:

```
BATCH_GAS_COST = (330000 * 125 / 100 + 125000) + 2000 * amount_of_proofs
```

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [X] “Hotfix” to `testnet`, everything else to `staging`
- [X] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
