### PR TITLE
feat(alerts): Display the number of proofs in a batch from the created task

### DIFF
--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -61,10 +61,9 @@ function get_number_proofs_in_batch_from_create_task_tx() {
   else
     # Get the tx receipt from the blockchain
     calldata=$(cast tx $1 --rpc-url $RPC_URL | grep -i input | cut -d' ' -f2-)
-    decoded_calldata=$(cast --calldata-decode "createNewTask(bytes32 batchMerkleRoot, string batchDataPointer, address[] proofSubmitters, uint256 feeF
-orAggregator, uint256 feePerProof, uint256 respondToTaskFeeLimit)" $calldata)
+    decoded_calldata=$(cast --calldata-decode --json "createNewTask(bytes32 batchMerkleRoot, string batchDataPointer, address[] proofSubmitters, uint256 feeForAggregator, uint256 feePerProof, uint256 respondToTaskFeeLimit)" $calldata)
     # We count the number of proofSubmitters within the tx which corresponds to the number of proofs sent in the last batch
-    number_proofs_in_batch=$($decoded_calldata | jq '.[2] | [ match(","; "g")] | length + 1')
+    number_proofs_in_batch=$(echo $decoded_calldata | jq '.[2] | [ match(","; "g")] | length + 1')
 
     echo $number_proofs_in_batch
   fi
@@ -148,7 +147,6 @@ do
 
     # Calculate fees for transactions
     number_proofs_in_batch=$(get_number_proofs_in_batch_from_create_task_tx $task_creation_tx_hash)
-    echo "here 2"
     submission_fee_in_wei=$(fetch_tx_cost $submission_tx_hash)
     response_fee_in_wei=$(fetch_tx_cost $response_tx_hash)
     batch_fee_in_wei=$((submission_fee_in_wei + response_fee_in_wei))
@@ -190,9 +188,9 @@ do
   done
 
   if [ $verified -eq 1 ]; then
-    slack_message="$number_proofs_in_batch Proofs submitted and verified. Spent amount: $spent_amount ETH ($ $spent_amount_usd) [ ${batch_explorer_urls[@]} ]"
+    slack_message="$REPETITIONS Proofs in batch of size $number_proofs_in_batch submitted and verified. Spent amount: $spent_amount ETH ($ $spent_amount_usd) [ ${batch_explorer_urls[@]} ]"
   else
-    slack_message="$number_proofs_in_batch Proofs submitted but not verified. Spent amount: $spent_amount ETH ($ $spent_amount_usd) [ ${batch_explorer_urls[@]} ]"
+    slack_message="$REPETITIONS Proofs in batch of size $number_proofs_in_batch submitted but not verified. Spent amount: $spent_amount ETH ($ $spent_amount_usd) [ ${batch_explorer_urls[@]} ]"
   fi
 
   ## Send Update to Slack

--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -53,6 +53,23 @@ function fetch_tx_cost() {
   fi
 }
 
+# Function to get the tx cost from the tx hash
+# @param tx_hash
+function get_number_proofs_in_batch_from_create_task_tx() {
+  if [[ -z "$1" ]]; then
+    echo 0
+  else
+    # Get the tx receipt from the blockchain
+    calldata=$(cast tx $1 --rpc-url $RPC_URL | grep -i input | cut -d' ' -f2-)
+    decoded_calldata=$(cast --calldata-decode "createNewTask(bytes32 batchMerkleRoot, string batchDataPointer, address[] proofSubmitters, uint256 feeF
+orAggregator, uint256 feePerProof, uint256 respondToTaskFeeLimit)" $calldata)
+    # We count the number of proofSubmitters within the tx which corresponds to the number of proofs sent in the last batch
+    number_proofs_in_batch=$($decoded_calldata | jq '.[2] | [ match(","; "g")] | length + 1')
+
+    echo $number_proofs_in_batch
+  fi
+}
+
 # Function to send PagerDuty alert
 # @param message
 function send_pagerduty_alert() {
@@ -94,7 +111,7 @@ do
     --rpc_url $RPC_URL \
     --batcher_url $BATCHER_URL \
     --network $NETWORK \
-    --max_fee 4000000000000000 \
+    --max_fee 0.004ether \
     2>&1)
 
   echo "$submit"
@@ -120,6 +137,9 @@ do
     batch_explorer_url="$EXPLORER_URL/batches/$batch_merkle_root"
     batch_explorer_urls+=($batch_explorer_url)
 
+    log=$(cast logs --rpc-url $RPC_URL --from-block $from_block_number --to-block latest 'TaskCreated(bytes32 indexed batchMerkleRoot, uint256 feePerProof)' --address $SENDER_ADDRESS)
+    task_creation_tx_hash=$(echo "$log" | grep -oE "transactionHash: 0x[[:alnum:]]{64}" | awk '{ print $2 }')
+
     log=$(cast logs --rpc-url $RPC_URL --from-block $from_block_number --to-block latest 'NewBatchV3 (bytes32 indexed batchMerkleRoot, address senderAddress, uint32 taskCreatedBlock, string batchDataPointer, uint256 respondToTaskFeeLimit)' $batch_merkle_root)
     submission_tx_hash=$(echo "$log" | grep -oE "transactionHash: 0x[[:alnum:]]{64}" | awk '{ print $2 }')
 
@@ -127,6 +147,7 @@ do
     response_tx_hash=$(echo "$log" | grep -oE "transactionHash: 0x[[:alnum:]]{64}" | awk '{ print $2 }')
 
     # Calculate fees for transactions
+    number_proofs_in_batch=$(get_number_proofs_in_batch_from_create_task_tx $task_creation_tx_hash)
     submission_fee_in_wei=$(fetch_tx_cost $submission_tx_hash)
     response_fee_in_wei=$(fetch_tx_cost $response_tx_hash)
     batch_fee_in_wei=$((submission_fee_in_wei + response_fee_in_wei))
@@ -168,9 +189,9 @@ do
   done
 
   if [ $verified -eq 1 ]; then
-    slack_message="$REPETITIONS Proofs submitted and verified. Spent amount: $spent_amount ETH ($ $spent_amount_usd) [ ${batch_explorer_urls[@]} ]"
+    slack_message="$number_proofs_in_batch Proofs submitted and verified. Spent amount: $spent_amount ETH ($ $spent_amount_usd) [ ${batch_explorer_urls[@]} ]"
   else
-    slack_message="$REPETITIONS Proofs submitted but not verified. Spent amount: $spent_amount ETH ($ $spent_amount_usd) [ ${batch_explorer_urls[@]} ]"
+    slack_message="$number_proofs_in_batch Proofs submitted but not verified. Spent amount: $spent_amount ETH ($ $spent_amount_usd) [ ${batch_explorer_urls[@]} ]"
   fi
 
   ## Send Update to Slack

--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -137,7 +137,7 @@ do
     batch_explorer_url="$EXPLORER_URL/batches/$batch_merkle_root"
     batch_explorer_urls+=($batch_explorer_url)
 
-    log=$(cast logs --rpc-url $RPC_URL --from-block $from_block_number --to-block latest 'TaskCreated(bytes32 indexed batchMerkleRoot, uint256 feePerProof)' --address $SENDER_ADDRESS)
+    log=$(cast logs --rpc-url $RPC_URL --from-block $from_block_number --to-block latest 'TaskCreated (bytes32 indexed batchMerkleRoot, uint256 feePerProof)' --address $SENDER_ADDRESS)
     task_creation_tx_hash=$(echo "$log" | grep -oE "transactionHash: 0x[[:alnum:]]{64}" | awk '{ print $2 }')
 
     log=$(cast logs --rpc-url $RPC_URL --from-block $from_block_number --to-block latest 'NewBatchV3 (bytes32 indexed batchMerkleRoot, address senderAddress, uint32 taskCreatedBlock, string batchDataPointer, uint256 respondToTaskFeeLimit)' $batch_merkle_root)
@@ -148,6 +148,7 @@ do
 
     # Calculate fees for transactions
     number_proofs_in_batch=$(get_number_proofs_in_batch_from_create_task_tx $task_creation_tx_hash)
+    echo "here 2"
     submission_fee_in_wei=$(fetch_tx_cost $submission_tx_hash)
     response_fee_in_wei=$(fetch_tx_cost $response_tx_hash)
     batch_fee_in_wei=$((submission_fee_in_wei + response_fee_in_wei))

--- a/batcher/aligned-batcher/src/main.rs
+++ b/batcher/aligned-batcher/src/main.rs
@@ -24,12 +24,15 @@ struct Cli {
     env_file: Option<String>,
     #[arg(short, long)]
     port: Option<u16>,
+    #[arg(short, long)]
+    addr: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), BatcherError> {
     let cli = Cli::parse();
     let port = cli.port.unwrap_or(8080);
+    let addr = cli.addr.unwrap_or("localhost".to_string());
 
     match cli.env_file {
         Some(env_file) => dotenvy::from_filename(env_file).ok(),
@@ -40,7 +43,7 @@ async fn main() -> Result<(), BatcherError> {
     let batcher = Batcher::new(cli.config).await;
     let batcher = Arc::new(batcher);
 
-    let addr = format!("localhost:{}", port);
+    let address = format!("{addr}:{port}");
 
     // spawn task to listening for incoming blocks
     tokio::spawn({
@@ -54,7 +57,7 @@ async fn main() -> Result<(), BatcherError> {
 
     batcher.metrics.inc_batcher_restart();
 
-    batcher.listen_connections(&addr).await?;
+    batcher.listen_connections(&address).await?;
 
     Ok(())
 }


### PR DESCRIPTION
# Display the number of proofs in a batch from the created task

## Description

Currently the alert sender just sends the number of repetitions of sent proofs. This pr changes this to fetch the number of proof submitters in the batch from the `proofSubmitters` parameter of the [`createNewTask`](https://github.com/yetanotherco/aligned_layer/blob/testnet/contracts/src/core/BatcherPaymentService.sol#L87) function call. This parameters contains the addresses of each submitted proof therefore the number of submitters corresponds to the number of proofs in the batch.

### To Test:
- start a local devnet
- execute the alert script via `./alerts/sender_with_alert.sh ./alerts/.env`
You should observe that the correct number of proofs in a batch is displayed now and observe that if a second senders proofs are included in the batch the number of proofs are displayed. Adding additional task senders should increase the batch size.

```
16 Proofs in batch of size 16 submitted and verified. Spent amount: 0.000171417922653 ETH ($ 0.57) [ http://localhost:3000/batches/0x0a8dd28a8e7a38151a22b3f04315d17be3a583fdc5fc925d085084b4c8732b27 ]
```

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
