### PR TITLE
feat(sdk): Add msg to batcher errors telling a users their funds have not been spent

### DIFF
--- a/batcher/aligned-sdk/src/communication/messaging.rs
+++ b/batcher/aligned-sdk/src/communication/messaging.rs
@@ -199,7 +199,9 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             Err(SubmitError::InvalidChainId)
         }
         Ok(SubmitProofResponseMessage::InvalidReplacementMessage) => {
-            error!("Batcher responded with invalid replacement message. Funds have not been spent.");
+            error!(
+                "Batcher responded with invalid replacement message. Funds have not been spent."
+            );
             Err(SubmitError::InvalidReplacementMessage)
         }
         Ok(SubmitProofResponseMessage::AddToBatchError) => {
@@ -209,7 +211,8 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
         Ok(SubmitProofResponseMessage::EthRpcError) => {
             error!("Batcher experienced Eth RPC connection error. Funds have not been spent.");
             Err(SubmitError::EthereumProviderError(
-                "Batcher experienced Eth RPC connection error. Funds have not been spent.".to_string(),
+                "Batcher experienced Eth RPC connection error. Funds have not been spent."
+                    .to_string(),
             ))
         }
         Ok(SubmitProofResponseMessage::InvalidPaymentServiceAddress(
@@ -226,11 +229,17 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             ))
         }
         Ok(SubmitProofResponseMessage::InvalidProof(reason)) => {
-            error!("Batcher responded with invalid proof: {}. Funds have not been spent.", reason);
+            error!(
+                "Batcher responded with invalid proof: {}. Funds have not been spent.",
+                reason
+            );
             Err(SubmitError::InvalidProof(reason))
         }
         Ok(SubmitProofResponseMessage::CreateNewTaskError(merkle_root, error)) => {
-            error!("Batcher responded with create new task error: {}. Funds have not been spent.", error);
+            error!(
+                "Batcher responded with create new task error: {}. Funds have not been spent.",
+                error
+            );
             Err(SubmitError::BatchSubmissionFailed(
                 "Could not create task with merkle root ".to_owned()
                     + &merkle_root
@@ -250,11 +259,17 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             Err(SubmitError::ProofQueueFlushed)
         }
         Ok(SubmitProofResponseMessage::Error(e)) => {
-            error!("Batcher responded with error: {}. Funds have not been spent.", e);
+            error!(
+                "Batcher responded with error: {}. Funds have not been spent.",
+                e
+            );
             Err(SubmitError::GenericError(e))
         }
         Err(e) => {
-            error!("Error while deserializing batch inclusion data: {}. Funds have not been spent.", e);
+            error!(
+                "Error while deserializing batch inclusion data: {}. Funds have not been spent.",
+                e
+            );
             Err(SubmitError::SerializationError(e))
         }
     }

--- a/batcher/aligned-sdk/src/communication/messaging.rs
+++ b/batcher/aligned-sdk/src/communication/messaging.rs
@@ -191,7 +191,7 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             Err(SubmitError::InvalidMaxFee)
         }
         Ok(SubmitProofResponseMessage::InsufficientBalance(addr)) => {
-            error!("Batcher responded with insufficient balance. Funds have not been spent.");
+            error!("Batcher responded with insufficient balance. Funds have not been spent for submittions which had insufficient balance.");
             Err(SubmitError::InsufficientBalance(addr))
         }
         Ok(SubmitProofResponseMessage::InvalidChainId) => {

--- a/batcher/aligned-sdk/src/communication/messaging.rs
+++ b/batcher/aligned-sdk/src/communication/messaging.rs
@@ -175,41 +175,41 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             Ok(batch_inclusion_data)
         }
         Ok(SubmitProofResponseMessage::InvalidNonce) => {
-            error!("Batcher responded with invalid nonce");
+            error!("Batcher responded with invalid nonce. Funds have not been spent.");
             Err(SubmitError::InvalidNonce)
         }
         Ok(SubmitProofResponseMessage::InvalidSignature) => {
-            error!("Batcher responded with invalid signature");
+            error!("Batcher responded with invalid signature. Funds have not been spent.");
             Err(SubmitError::InvalidSignature)
         }
         Ok(SubmitProofResponseMessage::ProofTooLarge) => {
-            error!("Batcher responded with proof too large");
+            error!("Batcher responded with proof too large. Funds have not been spent.");
             Err(SubmitError::ProofTooLarge)
         }
         Ok(SubmitProofResponseMessage::InvalidMaxFee) => {
-            error!("Batcher responded with invalid max fee");
+            error!("Batcher responded with invalid max fee. Funds have not been spent.");
             Err(SubmitError::InvalidMaxFee)
         }
         Ok(SubmitProofResponseMessage::InsufficientBalance(addr)) => {
-            error!("Batcher responded with insufficient balance");
+            error!("Batcher responded with insufficient balance. Funds have not been spent.");
             Err(SubmitError::InsufficientBalance(addr))
         }
         Ok(SubmitProofResponseMessage::InvalidChainId) => {
-            error!("Batcher responded with invalid chain id");
+            error!("Batcher responded with invalid chain id. Funds have not been spent.");
             Err(SubmitError::InvalidChainId)
         }
         Ok(SubmitProofResponseMessage::InvalidReplacementMessage) => {
-            error!("Batcher responded with invalid replacement message");
+            error!("Batcher responded with invalid replacement message. Funds have not been spent.");
             Err(SubmitError::InvalidReplacementMessage)
         }
         Ok(SubmitProofResponseMessage::AddToBatchError) => {
-            error!("Batcher responded with add to batch error");
+            error!("Batcher responded with add to batch error. Funds have not been spent.");
             Err(SubmitError::AddToBatchError)
         }
         Ok(SubmitProofResponseMessage::EthRpcError) => {
-            error!("Batcher experienced Eth RPC connection error");
+            error!("Batcher experienced Eth RPC connection error. Funds have not been spent.");
             Err(SubmitError::EthereumProviderError(
-                "Batcher experienced Eth RPC connection error".to_string(),
+                "Batcher experienced Eth RPC connection error. Funds have not been spent.".to_string(),
             ))
         }
         Ok(SubmitProofResponseMessage::InvalidPaymentServiceAddress(
@@ -217,7 +217,7 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             expected_addr,
         )) => {
             error!(
-                "Batcher responded with invalid payment service address: {:?}, expected: {:?}",
+                "Batcher responded with invalid payment service address: {:?}, expected: {:?}. Funds have not been spent.",
                 received_addr, expected_addr
             );
             Err(SubmitError::InvalidPaymentServiceAddress(
@@ -226,11 +226,11 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             ))
         }
         Ok(SubmitProofResponseMessage::InvalidProof(reason)) => {
-            error!("Batcher responded with invalid proof: {}", reason);
+            error!("Batcher responded with invalid proof: {}. Funds have not been spent.", reason);
             Err(SubmitError::InvalidProof(reason))
         }
         Ok(SubmitProofResponseMessage::CreateNewTaskError(merkle_root, error)) => {
-            error!("Batcher responded with create new task error: {}", error);
+            error!("Batcher responded with create new task error: {}. Funds have not been spent.", error);
             Err(SubmitError::BatchSubmissionFailed(
                 "Could not create task with merkle root ".to_owned()
                     + &merkle_root
@@ -239,22 +239,22 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             ))
         }
         Ok(SubmitProofResponseMessage::ProtocolVersion(_)) => {
-            error!("Batcher responded with protocol version instead of batch inclusion data");
+            error!("Batcher responded with protocol version instead of batch inclusion data. Funds have not been spent.");
             Err(SubmitError::UnexpectedBatcherResponse(
-                "Batcher responded with protocol version instead of batch inclusion data"
+                "Batcher responded with protocol version instead of batch inclusion data. Funds have not been spent."
                     .to_string(),
             ))
         }
         Ok(SubmitProofResponseMessage::BatchReset) => {
-            error!("Batcher responded with batch reset");
+            error!("Batcher responded with batch reset. Funds have not been spent.");
             Err(SubmitError::ProofQueueFlushed)
         }
         Ok(SubmitProofResponseMessage::Error(e)) => {
-            error!("Batcher responded with error: {}", e);
+            error!("Batcher responded with error: {}. Funds have not been spent.", e);
             Err(SubmitError::GenericError(e))
         }
         Err(e) => {
-            error!("Error while deserializing batch inclusion data: {}", e);
+            error!("Error while deserializing batch inclusion data: {}. Funds have not been spent.", e);
             Err(SubmitError::SerializationError(e))
         }
     }


### PR DESCRIPTION
# Add msg to batcher errors telling a users there funds have not been spent

## Description

Addresses the third item of #1568 

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
