### PR TITLE
feat(alerts): Add slack alerts for task sender error messages

### DIFF
--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -94,10 +94,20 @@ do
     --rpc_url $RPC_URL \
     --batcher_url $BATCHER_URL \
     --network $NETWORK \
-    --max_fee 4000000000000000 \
+    --max_fee 0.04ether \
     2>&1)
 
   echo "$submit"
+
+  submit_errors=$(echo "$submit" | grep -oE 'ERROR[^]]*]([^[]*)' | sed 's/^[^]]*]//;s/[[:space:]]*$//')
+  
+  # Loop through each error found and print with the custom message
+  while IFS= read -r error; do
+      if [[ -n "$error" ]]; then
+          slack_error_message="Error submitting proof to $NETWORK: $error"
+          send_slack_message "$slack_error_message"
+      fi
+  done <<< "$submit_errors"
   
   echo "Waiting $VERIFICATION_WAIT_TIME seconds for verification"
   sleep $VERIFICATION_WAIT_TIME


### PR DESCRIPTION
# Add slack alerts for task sender error messages

## Description

Detects error messages logged returned from when the task sender sends proofs and sends them as separate slack messages to the slack alerts channel.

### To Test:
- start a local devnet
- Specify a `PRIVATE_KEY` and `SENDER_ADDRESS` in `./alerts/.env` that does not have a batcher balance to trigger `InsufficientBalance Errors`
- execute the alert script via `./alerts/sender_with_alert.sh ./alerts/.env`
You should observe that the error messages printed in the slack alerts channel as follows:

```
Error submitting proof to devnet:  Batcher responded with insufficient balance
```

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
