### PR TITLE
fix: dark mode toogle

### DIFF
--- a/explorer/assets/vendor/dark_mode.js
+++ b/explorer/assets/vendor/dark_mode.js
@@ -5,10 +5,7 @@ const isDark = () => {
 		.split("; ")
 		.find((row) => row.startsWith(`${themeCookieKey}=`))
 		?.split("=")[1];
-	return (
-		theme == "dark" ||
-		window.matchMedia("(prefers-color-scheme: dark)").matches
-	);
+	return theme == "dark";
 };
 
 const setThemeCookie = (theme) => {

--- a/explorer/lib/explorer_web/components/layouts/root.html.heex
+++ b/explorer/lib/explorer_web/components/layouts/root.html.heex
@@ -37,6 +37,8 @@
     />
     <meta name="csrf-token" content={get_csrf_token()} />
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
+    </script>
   </head>
   <body class="antialiased bg-gray-100 dark:bg-neutral-950">
     <%= @inner_content %>

--- a/explorer/lib/explorer_web/components/layouts/root.html.heex
+++ b/explorer/lib/explorer_web/components/layouts/root.html.heex
@@ -37,13 +37,6 @@
     />
     <meta name="csrf-token" content={get_csrf_token()} />
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
-    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
-      if (localStorage.getItem('theme') === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.classList.add('dark');
-      } else {
-        document.documentElement.classList.remove('dark')
-      }  
-    </script>
   </head>
   <body class="antialiased bg-gray-100 dark:bg-neutral-950">
     <%= @inner_content %>


### PR DESCRIPTION
## Description

Fix the dark mode switcher on explorer.

**Testing**
The error occurred for devices with dark-mode, users that had their device with light-mode didn't face it. 

To check the fix, do:
1. Change your device appearance to dark-mode.
2. Go to the mainnet explorer and try to switch color (it should fail)
3. Go to the stage explorer and try to switch color (it should work).

## Type of change
- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
