### PR TITLE
feat(alerts): Add slack alerts for task submission sender

### DIFF
--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -90,9 +90,10 @@ do
   ## Generate Proof
   nonce=$(aligned get-user-nonce --batcher_url $BATCHER_URL --user_addr $SENDER_ADDRESS 2>&1 | awk '{print $9}')
   if ! [[ "$nonce" =~ ^[0-9]+$ ]]; then
-    echo "Failed getting nonce value, exiting"
+    echo "Failed getting user nonce, exiting"
     exit 1
   fi
+
   x=$((nonce + 1)) # So we don't have any issues with nonce = 0
   echo "Generating proof $x != 0, nonce: $nonce"
   go run ./scripts/test_files/gnark_groth16_bn254_infinite_script/cmd/main.go $x

--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -85,6 +85,10 @@ function send_slack_message() {
 while true
 do
 
+  ## Remove Proof Data
+  rm -rf ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/*
+  rm -rf ./aligned_verification_data/*
+
   mkdir -p ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs
 
   ## Generate Proof

--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -94,10 +94,20 @@ do
     --rpc_url $RPC_URL \
     --batcher_url $BATCHER_URL \
     --network $NETWORK \
-    --max_fee 4000000000000000 \
+    --max_fee 0.04ether \
     2>&1)
 
   echo "$submit"
+
+  submit_errors=$(echo "$submit" | grep -oE 'ERROR[^]]*]([^[]*)' | sed 's/^[^]]*]//;s/[[:space:]]*$//')
+
+  # Loop through each error found and print with the custom message
+  while IFS= read -r error; do
+      if [[ -n "$error" ]]; then
+          slack_error_message="Error submitting proof to $NETWORK: $error"
+          send_slack_message "$slack_error_message"
+      fi
+  done <<< "$submit_errors"
   
   echo "Waiting $VERIFICATION_WAIT_TIME seconds for verification"
   sleep $VERIFICATION_WAIT_TIME

--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -89,8 +89,12 @@ do
 
   ## Generate Proof
   nonce=$(aligned get-user-nonce --batcher_url $BATCHER_URL --user_addr $SENDER_ADDRESS 2>&1 | awk '{print $9}')
+  if ! [[ "$nonce" =~ ^[0-9]+$ ]]; then
+    echo "Failed getting nonce value, exiting"
+    exit 1
+  fi
   x=$((nonce + 1)) # So we don't have any issues with nonce = 0
-  echo "Generating proof $x != 0"
+  echo "Generating proof $x != 0, nonce: $nonce"
   go run ./scripts/test_files/gnark_groth16_bn254_infinite_script/cmd/main.go $x
 
   ## Send Proof

--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -93,9 +93,11 @@ do
 
   ## Generate Proof
   nonce=$(aligned get-user-nonce --batcher_url $BATCHER_URL --user_addr $SENDER_ADDRESS 2>&1 | awk '{print $9}')
+  echo $nonce
   if ! [[ "$nonce" =~ ^[0-9]+$ ]]; then
-    echo "Failed getting user nonce, exiting"
-    exit 1
+    echo "Failed getting user nonce, retrying in 10 seconds"
+    sleep 10
+    continue
   fi
 
   x=$((nonce + 1)) # So we don't have any issues with nonce = 0
@@ -123,12 +125,21 @@ do
   submit_errors=$(echo "$submit" | grep -oE 'ERROR[^]]*]([^[]*)' | sed 's/^[^]]*]//;s/[[:space:]]*$//')
 
   # Loop through each error found and print with the custom message
+  is_error=0
   while IFS= read -r error; do
       if [[ -n "$error" ]]; then
           slack_error_message="Error submitting proof to $NETWORK: $error"
           send_slack_message "$slack_error_message"
+          is_error=1
       fi
   done <<< "$submit_errors"
+
+  if [ $is_error -eq 1 ]; then
+    echo "Error submitting proofs to $NETWORK, retrying in 60 seconds"
+    send_slack_message "Error submitting proofs to $NETWORK, retrying in 60 seconds"
+    sleep 60
+    continue
+  fi
   
   echo "Waiting $VERIFICATION_WAIT_TIME seconds for verification"
   sleep $VERIFICATION_WAIT_TIME
@@ -179,7 +190,7 @@ do
   spent_amount_usd=$(echo "$spent_amount * $eth_usd" | bc | awk '{printf "%.2f", $1}')
 
   slack_messsage=""
-  verified=0
+  verified=1
 
   ## Verify Proofs
   echo "Verifying $REPETITIONS proofs $x != 0"
@@ -196,9 +207,9 @@ do
       message="Proof verification failed for $proof [ ${batch_explorer_urls[@]} ]"
       echo "$message"
       send_pagerduty_alert "$message"
+      verified=0 # Some proofs failed, so we should not send the success message
       break
     elif echo "$verification" | grep -q verified; then
-      ((verified++))
       echo "Proof verification succeeded for $proof"
     fi
   done

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -284,7 +284,7 @@ pub fn get_payment_service_address(network: Network) -> ethers::types::H160 {
 
 pub fn get_aligned_service_manager_address(network: Network) -> ethers::types::H160 {
     match network {
-        Network::Devnet => H160::from_str("0x1613beB3B2C4f22Ee086B2b38C1476A3cE7f78E8").unwrap(),
+        Network::Devnet => H160::from_str("0x851356ae760d987E095750cCeb3bC6014560891C").unwrap(),
         Network::Holesky => H160::from_str("0x58F280BeBE9B34c9939C3C39e0890C81f163B623").unwrap(),
         Network::HoleskyStage => {
             H160::from_str("0x9C5231FC88059C086Ea95712d105A2026048c39B").unwrap()
@@ -499,7 +499,9 @@ async fn _is_proof_verified(
     eth_rpc_provider: Provider<Http>,
 ) -> Result<bool, errors::VerificationError> {
     let contract_address = get_aligned_service_manager_address(network);
+    println!("aligned service manager: {:?}", contract_address);
     let payment_service_addr = get_payment_service_address(network);
+    println!("batcher_payment_service: {:?}", payment_service_addr);
 
     // All the elements from the merkle proof have to be concatenated
     let merkle_proof: Vec<u8> = aligned_verification_data

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -499,9 +499,7 @@ async fn _is_proof_verified(
     eth_rpc_provider: Provider<Http>,
 ) -> Result<bool, errors::VerificationError> {
     let contract_address = get_aligned_service_manager_address(network);
-    println!("aligned service manager: {:?}", contract_address);
     let payment_service_addr = get_payment_service_address(network);
-    println!("batcher_payment_service: {:?}", payment_service_addr);
 
     // All the elements from the merkle proof have to be concatenated
     let merkle_proof: Vec<u8> = aligned_verification_data


### PR DESCRIPTION
#  Add slack alerts for task submission sender

## Description

Detects error messages logged returned from when the task sender sends proofs and sends them as separate slack messages to the slack alerts channel.

### To Test:
- start a local devnet
- Specify a `PRIVATE_KEY` and `SENDER_ADDRESS` in `./alerts/.env` that does not have a batcher balance to trigger `InsufficientBalance Errors`
- execute the alert script via `./alerts/sender_with_alert.sh ./alerts/.env`
You should observe that the error messages printed in the slack alerts channel as follows:

```
Error submitting proof to devnet:  Batcher responded with insufficient balance
```

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
