### PR TITLE
 hotfix: eigensdk on Operator and Aggregator boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ _AGGREGATOR_:
 build_aggregator:
 	$(GET_SDK_VERSION)
 	@echo "Building aggregator"
-	@go build -o aggregator/aligned_layer/build/aligned-aggregator aggregator/aligned_layer/aggregator/cmd/main.go
+	@go build -o ./build/aligned-aggregator ./aggregator/cmd/main.go
 
 aggregator_start:
 	$(GET_SDK_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ operator_set_eigen_sdk_go_version_mainnet:
 	go get github.com/Layr-Labs/eigensdk-go@$(EIGEN_SDK_GO_VERSION_MAINNET)
 
 operator_set_eigen_sdk_go_version_error:
-	@echo "Error setting Eigen SDK version, missing ENVIRONMENT"
+	@echo "Error setting Eigen SDK version, missing ENVIRONMENT. Possible values for ENVIRONMENT=<devnet|testnet|mainnet>"
 	exit 1
 
 operator_full_registration: operator_get_eth operator_register_with_eigen_layer operator_mint_mock_tokens operator_deposit_into_mock_strategy operator_whitelist_devnet operator_register_with_aligned_layer

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ export OPERATOR_ADDRESS ?= $(shell yq -r '.operator.address' $(CONFIG_FILE))
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
 OPERATOR_VERSION=v0.13.0
+EIGEN_SDK_GO_VERSION_TESTNET=v0.2.0-beta.1
+EIGEN_SDK_GO_VERSION_MAINNET=v0.1.13
 
 ifeq ($(OS),Linux)
 	BUILD_ALL_FFI = $(MAKE) build_all_ffi_linux
@@ -28,6 +30,16 @@ endif
 
 ifeq ($(OS),Darwin)
 	BUILD_OPERATOR = $(MAKE) build_operator_macos
+endif
+	
+ifeq ($(ENVIRONMENT), devnet)
+	GET_SDK_VERSION = $(MAKE) operator_set_eigen_sdk_go_version_devnet
+else ifeq ($(ENVIRONMENT), testnet)
+	GET_SDK_VERSION = $(MAKE) operator_set_eigen_sdk_go_version_testnet
+else ifeq ($(ENVIRONMENT), devnet)
+	GET_SDK_VERSION = $(MAKE) operator_set_eigen_sdk_go_version_mainnet
+else
+	GET_SDK_VERSION = $(MAKE) operator_set_eigen_sdk_go_version_error
 endif
 
 
@@ -141,6 +153,7 @@ anvil_start_with_block_time_with_more_prefunded_accounts:
 _AGGREGATOR_:
 
 aggregator_start:
+	$(GET_SDK_VERSION)
 	@echo "Starting Aggregator..."
 	@go run aggregator/cmd/main.go --config $(AGG_CONFIG_FILE) \
 	2>&1 | zap-pretty
@@ -156,15 +169,31 @@ test_go_retries:
 __OPERATOR__:
 
 operator_start:
+	$(GET_SDK_VERSION)
 	@echo "Starting Operator..."
 	go run operator/cmd/main.go start --config $(CONFIG_FILE) \
 	2>&1 | zap-pretty
+
+operator_set_eigen_sdk_go_version_testnet:
+	@echo "Setting Eigen SDK version to: $(EIGEN_SDK_GO_VERSION_TESTNET)"
+	go get github.com/Layr-Labs/eigensdk-go@$(EIGEN_SDK_GO_VERSION_TESTNET)
+
+operator_set_eigen_sdk_go_version_devnet: operator_set_eigen_sdk_go_version_mainnet
+
+operator_set_eigen_sdk_go_version_mainnet:
+	@echo "Setting Eigen SDK version to: $(EIGEN_SDK_GO_VERSION_MAINNET)"
+	go get github.com/Layr-Labs/eigensdk-go@$(EIGEN_SDK_GO_VERSION_MAINNET)
+
+operator_set_eigen_sdk_go_version_error:
+	@echo "Error setting Eigen SDK version, missing ENVIRONMENT"
+	exit 1
 
 operator_full_registration: operator_get_eth operator_register_with_eigen_layer operator_mint_mock_tokens operator_deposit_into_mock_strategy operator_whitelist_devnet operator_register_with_aligned_layer
 
 operator_register_and_start: operator_full_registration operator_start
 
 build_operator: deps
+	$(GET_SDK_VERSION)
 	$(BUILD_OPERATOR)
 
 build_operator_macos:
@@ -178,6 +207,7 @@ build_operator_linux:
 	@echo "Operator built into /operator/build/aligned-operator"
 
 update_operator:
+	$(GET_SDK_VERSION)
 	@echo "Updating Operator..."
 	@./scripts/fetch_latest_release.sh
 	@make build_operator

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,11 @@ anvil_start_with_block_time_with_more_prefunded_accounts:
 
 _AGGREGATOR_:
 
+build_aggregator:
+	$(GET_SDK_VERSION)
+	@echo "Building aggregator"
+	@go build -o aggregator/aligned_layer/build/aligned-aggregator aggregator/aligned_layer/aggregator/cmd/main.go
+
 aggregator_start:
 	$(GET_SDK_VERSION)
 	@echo "Starting Aggregator..."

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifeq ($(ENVIRONMENT), devnet)
 	GET_SDK_VERSION = $(MAKE) operator_set_eigen_sdk_go_version_devnet
 else ifeq ($(ENVIRONMENT), testnet)
 	GET_SDK_VERSION = $(MAKE) operator_set_eigen_sdk_go_version_testnet
-else ifeq ($(ENVIRONMENT), devnet)
+else ifeq ($(ENVIRONMENT), mainnet)
 	GET_SDK_VERSION = $(MAKE) operator_set_eigen_sdk_go_version_mainnet
 else
 	GET_SDK_VERSION = $(MAKE) operator_set_eigen_sdk_go_version_error

--- a/docs/3_guides/6_setup_aligned.md
+++ b/docs/3_guides/6_setup_aligned.md
@@ -74,13 +74,13 @@ make bindings
 To start the [Aggregator](../2_architecture/components/5_aggregator.md):
 
 ```bash
-make aggregator_start
+make aggregator_start ENVIRONMENT=devnet
 ```
 
 or with a custom config:
 
 ```bash
-make aggregator_start CONFIG_FILE=<path_to_config_file>
+make aggregator_start ENVIRONMENT=devnet CONFIG_FILE=<path_to_config_file>
 ```
 
 ## Operator
@@ -88,13 +88,13 @@ make aggregator_start CONFIG_FILE=<path_to_config_file>
 To setup an [Operator](../2_architecture/components/4_operator.md) run:
 
 ```bash
-make operator_register_and_start
+make operator_register_and_start ENVIRONMENT=devnet
 ```
 
 or with a custom config:
 
 ```bash
-make operator_register_and_start CONFIG_FILE=<path_to_config_file>
+make operator_register_and_start ENVIRONMENT=devnet CONFIG_FILE=<path_to_config_file>
 ```
 
 Different configs for operators can be found in `config-files/config-operator`.
@@ -111,7 +111,7 @@ make operator_full_registration CONFIG_FILE<path_to_config_file>
 and to start it once it has been registered:
 
 ```bash
-make operator_start CONFIG_FILE=<path_to_config_file>
+make operator_start ENVIRONMENT=devnet CONFIG_FILE=<path_to_config_file>
 ```
 
 </details>

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -40,6 +40,7 @@
 * [Operator FAQ](operator_guides/1_operator_FAQ.md)
 * [Troubleshooting](operator_guides/2_troubleshooting.md)
 * Upgrading Guides
+    * [Upgrading to v0.14.0](operator_guides/upgrading_guides/v0_14_0.md)
     * [Upgrading to v0.10.2](operator_guides/upgrading_guides/v0_10_2.md)
     * [Upgrading to v0.9.2](operator_guides/upgrading_guides/v0_9_2.md)
 

--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -54,18 +54,30 @@ make install_foundry
 foundryup
 ```
 
-To build the operator binary, run:
+To build the operator binary for **Testnet**, run:
 
 ```bash
-make build_operator
+make build_operator ENVIRONMENT=testnet
+```
+
+To build the operator binary for **Mainnet**, run:
+
+```bash
+make build_operator ENVIRONMENT=mainnet
 ```
 
 ### Upgrading the Operator
 
-If you want to upgrade the operator, run:
+If you want to upgrade the operator in **Testnet**, run:
 
 ```bash
-make update_operator
+make update_operator ENVIRONMENT=testnet
+```
+
+If you want to upgrade the operator in **Mainnet**, run:
+
+```bash
+make update_operator ENVIRONMENT=mainnet
 ```
 
 This will recreate the binaries. You can then proceed to restart the operator.

--- a/docs/operator_guides/upgrading_guides/v0_14_0.md
+++ b/docs/operator_guides/upgrading_guides/v0_14_0.md
@@ -1,0 +1,120 @@
+# Upgrading to V0.14.0
+
+This guide will walk you through the process of upgrading your Aligned Operator to v0.14.0.
+
+Since EigenLayer released Slashing on Holesky Testnet, there are two versions of the [EigenSDK](https://github.com/Layr-Labs/eigensdk-go), one is compatible with Mainnet and the other one is compatible with Holesky Testnet. This guide will help you to upgrade your operator with the correct version of the EigenSDK.
+
+The EigenSDK version [v0.1.13](https://github.com/Layr-Labs/eigensdk-go/releases/tag/v0.1.13) is compatible with Mainnet.
+
+The EigenSDK version [v0.2.0-beta.1](https://github.com/Layr-Labs/eigensdk-go/releases/tag/v0.2.0-beta.1) is compatible with Holesky Testnet.
+
+## Changes
+
+This version includes the following changes:
+
+* hotfix: eigensdk on Operator and Aggregator boot in [#1740](https://github.com/yetanotherco/aligned_layer/pull/1740)
+
+## How to upgrade
+
+Depending on the network you are running, you will need to upgrade the EigenSDK version on your operator.
+
+For Mainnet this upgrade is optional, but for Holesky Testnet it is mandatory.
+
+### Mainnet Operator
+
+This upgrade is OPTIONAL for Mainnet operators. But, if you want to upgrade, you can follow the steps below:
+
+#### Step 1 - Pull the latest changes
+
+```shell
+cd <path/to/aligned/repository>
+git fetch origin
+git checkout v0.14.0
+```
+
+#### Step 2 - Update the Operator
+
+```shell
+make build_operator ENVIRONMENT=mainnet
+```
+
+This will install the version v0.1.13 of the EigenSDK, and then it will recompile the binaries.
+
+#### Step 3 - Check the Operator Version
+
+To see the operator version, run:
+
+```shell
+./operator/build/aligned-operator --version
+```
+
+This will display the current version of the operator binary. The output should be:
+
+```
+Aligned Layer Node Operator version v0.14.0
+```
+
+#### Step 4 - Restart the Operator
+
+Restart the operator based on your system configuration.
+
+### Testnet Operator
+
+This upgrade is MANDATORY for Testnet operators. Follow the steps below to upgrade your operator:
+
+#### Step 1 - Pull the latest changes
+
+```shell
+cd <path/to/aligned/repository>
+git fetch origin
+git checkout v0.14.0
+```
+
+#### Step 2 - Update the Operator
+
+```shell
+make build_operator ENVIRONMENT=testnet
+```
+
+This will install the version v0.2.0-beta.1 of the EigenSDK, and then it will recompile the binaries.
+
+#### Step 3 - Check the Operator Version
+
+To see the operator version, run:
+
+```shell
+./operator/build/aligned-operator --version
+```
+
+This will display the current version of the operator binary. The output should be:
+
+```
+Aligned Layer Node Operator version v0.14.0
+```
+
+#### Step 4 - Restart the Operator
+
+Restart the operator based on your system configuration.
+
+### Troubleshooting
+
+#### Operator not registered on Aligned
+
+If your operator is not registered on Aligned, or it was ejected from the network, you can follow the registration process again.
+
+- Mainnet:
+
+```bash
+make operator_register_with_aligned_layer CONFIG_FILE=./config-files/config-operator-mainnet.yaml
+```
+
+- Holesky:
+
+```bash
+make operator_register_with_aligned_layer CONFIG_FILE=./config-files/config-operator-holesky.yaml
+```
+
+{% hint style="danger" %}
+If you are going to run the server in this machine,
+delete the operator key
+{% endhint %}


### PR DESCRIPTION
# EigenSDK fix

## Description

EigenSDK made a breaking change that stops Operators from restarting, and stops a potential Aggregator restart as well.

This PR sets the SDK version to be used before the components are executed.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [x] Has a known issue
  - [ ] Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
