### PR TITLE
refactor: use set_empty_values function

### DIFF
--- a/explorer/lib/explorer_web/live/pages/batch/index.ex
+++ b/explorer/lib/explorer_web/live/pages/batch/index.ex
@@ -2,6 +2,21 @@ defmodule ExplorerWeb.Batch.Index do
   require Logger
   use ExplorerWeb, :live_view
 
+  defp set_empty_values(socket) do
+    Logger.info("Setting empty values")
+
+    socket
+    |> assign(
+      merkle_root: :empty,
+      current_batch: :empty,
+      newBatchInfo: :empty,
+      batchWasResponded: :empty,
+      proof_hashes: :empty,
+      proofs: :empty,
+      eth_usd_price: :empty
+    )
+  end
+
   @impl true
   def mount(%{"merkle_root" => merkle_root}, _, socket) do
     if connected?(socket), do: Phoenix.PubSub.subscribe(Explorer.PubSub, "update_views")
@@ -38,16 +53,9 @@ defmodule ExplorerWeb.Batch.Index do
   rescue
     _ ->
       {:ok,
-       socket
-       |> assign(
-         merkle_root: :empty,
-         current_batch: :empty,
-         newBatchInfo: :empty,
-         batchWasResponded: :empty,
-         proof_hashes: :empty,
-         proofs: :empty,
-         eth_usd_price: :empty
-       )}
+        set_empty_values(socket)
+        |> put_flash(:error, "Something went wrong, please try again later.")
+    }
   end
 
   @impl true


### PR DESCRIPTION
# Use set_empty_values function

## Description

set_empty_values function is to centralize where we set empty values on an explorer page failure. This avoids a failure we had in prod where on a failure, not every value was set to its appropriate `empty` value, so phoenix crashed.

This was already implemented here #1676 

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [x] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
