### PR TITLE
hotfix(operator): assign SubscribeToNewTasksV3() correctly

### DIFF
--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -239,7 +239,7 @@ func (o *Operator) Start(ctx context.Context) error {
 			}
 		case err := <-subV3:
 			o.Logger.Infof("Error in websocket subscription", "err", err)
-			subV2, err = o.SubscribeToNewTasksV3()
+			subV3, err = o.SubscribeToNewTasksV3()
 			if err != nil {
 				o.Logger.Fatal("Could not subscribe to new tasks V3")
 			}


### PR DESCRIPTION
# Assign SubscribeToNewTasksV3() correctly

## Description

In `operator/pkg/operator.go` the `SubscribeToNewTasksV3()` is being assigned to `subV2`

```go
		case err := <-subV3:
			o.Logger.Infof("Error in websocket subscription", "err", err)
			subV2, err = o.SubscribeToNewTasksV3()
			if err != nil {
				o.Logger.Fatal("Could not subscribe to new tasks V3")
			}
```

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
