### PR TITLE
hotfix(aggregator): nil dereference for invalid signature

### DIFF
--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -51,7 +51,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 		"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
 
 	if signedTaskResponse.BlsSignature.G1Point == nil {
-		agg.logger.Error("invalid operator response with nil signature",
+		agg.logger.Warn("invalid operator response with nil signature",
 			"BatchMerkleRoot", "0x"+hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),
 			"SenderAddress", "0x"+hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 			"BatchIdentifierHash", "0x"+hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),

--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -56,6 +56,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 			"SenderAddress", "0x"+hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 			"BatchIdentifierHash", "0x"+hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
 			"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
+		*reply = 1
 		return errors.New("invalid response: nil signature")
 	}
 

--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/rpc"
@@ -48,6 +49,16 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 		"SenderAddress", "0x"+hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 		"BatchIdentifierHash", "0x"+hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
 		"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
+
+	if signedTaskResponse.BlsSignature.G1Point == nil {
+		agg.logger.Error("invalid operator response with nil signature",
+			"BatchMerkleRoot", "0x"+hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),
+			"SenderAddress", "0x"+hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
+			"BatchIdentifierHash", "0x"+hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
+			"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
+		return errors.New("invalid response: nil signature")
+	}
+
 	taskIndex := uint32(0)
 
 	// The Aggregator may receive the Task Identifier after the operators.


### PR DESCRIPTION
An operator could trigger a `nil`-dereference in the aggregator and bring it down by sending a message with a `nil`-signature.
Catch this error, log a warning and return an error instead.

The log is level warning to avoid polluting with unnecessary stack traces.

Fixes #1747

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible

## Testing

Apply the following patch:
```diff
diff --git a/operator/pkg/rpc_client.go b/operator/pkg/rpc_client.go
index 5726f14d..414f9c86 100644
--- a/operator/pkg/rpc_client.go
+++ b/operator/pkg/rpc_client.go
@@ -38,6 +38,10 @@ func NewAggregatorRpcClient(aggregatorIpPortAddr string, logger logging.Logger)
 // their signed task response.
 func (c *AggregatorRpcClient) SendSignedTaskResponseToAggregator(signedTaskResponse *types.SignedTaskResponse) {
 	var reply uint8
+
+	// @audit nil derefernce
+	signedTaskResponse.BlsSignature.G1Point = nil
+
 	for retries := 0; retries < MaxRetries; retries++ {
 		err := c.rpcClient.Call("Aggregator.ProcessOperatorSignedTaskResponseV2", signedTaskResponse, &reply)
 		if err != nil {
```

Then start sending proofs, the aggregator should log an error an keep going. In testnet this should crash the aggregator.
