### PR TITLE
hotfix: workaround gnark 0.10.0 unsoundness bug

### DIFF
--- a/batcher/aligned-batcher/gnark/verifier.go
+++ b/batcher/aligned-batcher/gnark/verifier.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
+	bn254 "github.com/consensys/gnark/backend/groth16/bn254"
 	"github.com/consensys/gnark/backend/plonk"
 	"github.com/consensys/gnark/backend/witness"
 )
@@ -95,6 +96,17 @@ func verifyGroth16Proof(proofBytesRef C.ListRef, pubInputBytesRef C.ListRef, ver
 	proof := groth16.NewProof(curve)
 	if _, err := proof.ReadFrom(proofReader); err != nil {
 		log.Printf("Could not deserialize proof: %v", err)
+		return false
+	}
+
+	bn254Proof, ok := proof.(*bn254.Proof)
+	if !ok {
+		log.Printf("groth16 proof is not bn254")
+		return false
+	}
+	numCommitments := len(bn254Proof.Commitments)
+	if numCommitments > 1 {
+		log.Printf("too many commitments (%v) for groth16 proof (unsound for v0.10.0)", numCommitments)
 		return false
 	}
 


### PR DESCRIPTION
A lot of time passed since gnark v0.10.0 unsoundness bug[0] was reported
and fixed. We posponed the upgrade because the fixed release, v0.11.0,
contains another vulnerability, an OOM[1], for which a fix has been in
main since last November but no release appeared until now.

Our options here are limited, and none quite happy:
- We can `redirect` to a commit in `main`;
- We can disable groth16 verifiers from the network, which we currently
  use; or
- We can enforce that proofs have only one commitment, as the
  unsoundness can only be triggered with multiple commitments per proof.

This implements the latter option, being the least invasive one.

[0]: https://www.zellic.io/blog/gnark-bug-groth16-commitments
[1]: https://github.com/Consensys/gnark/security/advisories/GHSA-cph5-3pgr-c82g

Fixes #1749

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible

## Testing

You'll need to compare the behavior of batcher and operators in both `testnet` and `hotfix/gnark_workaround` branches.

Download the attached file to your repo checkout and extract it with `tar xf fake_proof.tgz`. The contents are a witness, proof and verification key that should not be accepted by gnark but are, and they were generated with the following [PoC](https://gist.github.com/Oppen/3166ce50e3cd1922846d1cf4799be3e2). The PoC relies on a modified checkout of gnark, as explained in the document explaining the vulnerability.

Then apply this patch:
```diff
diff --git a/Makefile b/Makefile
index ad1ee3e7..4fc322dc 100644
--- a/Makefile
+++ b/Makefile
@@ -444,9 +444,9 @@ batcher_send_groth16_bn254_task: batcher/target/release/aligned
 	@echo "Sending Groth16Bn254 1!=0 task to Batcher..."
 	@cd batcher/aligned/ && cargo run --release -- submit \
 		--proving_system Groth16Bn254 \
-		--proof ../../scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.proof \
-		--public_input ../../scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.pub \
-		--vk ../../scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_1_groth16.vk \
+		--proof ../../scripts/test_files/gnark_groth16_bn254_script/fake_groth16.proof \
+		--public_input ../../scripts/test_files/gnark_groth16_bn254_script/fake_groth16.pub \
+		--vk ../../scripts/test_files/gnark_groth16_bn254_script/fake_groth16.vk \
 		--proof_generator_addr 0x66f9664f97F2b50F62D13eA064982f936dE76657 \
 		--rpc_url $(RPC_URL) \
 		--network $(NETWORK)
```

Start a devnet and run:
```sh
make batcher_send_groth16_bn254_task
```

On `testnet` you should see a successful batch verification, as it's vulnerable to the unsoundness bug. On `hotfix/gnark_workaround` you should see both the batcher and operators (I suggest trying them separately with the rest of the stack running from `testnet`, to be able to test each of them) reject the proof, logging that it has too many commitments.

[fake_proof.tgz](https://github.com/user-attachments/files/18481737/fake_proof.tgz)
