### PR TITLE
hotfix: resolve ambiguity in signature result

### DIFF
--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -69,7 +69,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 	defer cancel() // Ensure the cancel function is called to release resources
 
 	// Create a channel to signal when the task is done
-	done := make(chan struct{})
+	done := make(chan uint8)
 
 	agg.logger.Info("Starting bls signature process")
 	go func() {
@@ -80,9 +80,11 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 
 		if err != nil {
 			agg.logger.Warnf("BLS aggregation service error: %s", err)
+			done<- 1
 			// todo shouldn't we here close the channel with a reply = 1?
 		} else {
 			agg.logger.Info("BLS process succeeded")
+			done<- 0
 		}
 
 		close(done)
@@ -94,10 +96,10 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 	case <-ctx.Done():
 		// The context's deadline was exceeded or it was canceled
 		agg.logger.Info("Bls process timed out, operator signature will be lost. Batch may not reach quorum")
-	case <-done:
+	case res := <-done:
 		// The task completed successfully
-		agg.logger.Info("Bls context finished correctly")
-		*reply = 0
+		agg.logger.Info("Bls context finished on time")
+		*reply = res
 	}
 
 	return nil


### PR DESCRIPTION
`ProcessOperatorSignedTaskResponseV2` would set `*reply` to `0` in all
non-timeout scenarios, regardless of errors. Use the `done` channel to
report actual result and use that instead.

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible

## Testing

Signature errors should now log the correct value. The error is still lost tho.
