### PR TITLE
refactor: simplify signature timeout logic

### DIFF
--- a/aggregator/pkg/server.go
+++ b/aggregator/pkg/server.go
@@ -49,6 +49,7 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 		"SenderAddress", "0x"+hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
 		"BatchIdentifierHash", "0x"+hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
 		"operatorId", hex.EncodeToString(signedTaskResponse.OperatorId[:]))
+	*reply = 1
 	taskIndex := uint32(0)
 
 	// The Aggregator may receive the Task Identifier after the operators.
@@ -59,7 +60,6 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 
 	if err != nil {
 		agg.logger.Warn("Task not found in the internal map, operator signature will be lost. Batch may not reach quorum")
-		*reply = 1
 		return errors.New("task not found in the internal map")
 	}
 	agg.telemetry.LogOperatorResponse(signedTaskResponse.BatchMerkleRoot, signedTaskResponse.OperatorId)
@@ -76,7 +76,6 @@ func (agg *Aggregator) ProcessOperatorSignedTaskResponseV2(signedTaskResponse *t
 	)
 	if err != nil {
 		agg.logger.Warnf("BLS aggregation service error: %s", err)
-		*reply = 1
 		return fmt.Errorf("bls aggregation failed: %v", err)
 	}
 


### PR DESCRIPTION
`ProcessNewSignature` already takes a context to handle cancellation and
timeout. We need just to create the context and pass it off, and it will
return an appropriate error if the timeout expires.

This saves us from creating a goroutine and handling messages just for
that.

Also improve a little bit of the error reporting.

## Type of change

- [x] Refactor

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible

## Testing

Basic testing: start a devnet, show it's able to verify proofs.
Alightly more involved testing: register three operators and leave only one up,
so it doesn't reach quorum, the timeout should kick.
