### PR TITLE
fix: remove required=true from privatekeytype in CLI

### DIFF
--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -226,7 +226,7 @@ pub struct GetUserNonceArgs {
 }
 
 #[derive(Args, Debug)]
-#[group(required = true, multiple = false)]
+#[group(multiple = false)]
 pub struct PrivateKeyType {
     #[arg(name = "path_to_keystore", long = "keystore_path")]
     keystore_path: Option<PathBuf>,


### PR DESCRIPTION
# remove required=true from PrivateKeyType

## Description

PrivateKeyType should be able to be empty, so we can handle the "using nonpaying address" for testnet proof submitions

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
