### PR TITLE
fix: do GET_SDK_VERSION before operator_full_registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,6 @@ test_go_retries:
 __OPERATOR__:
 
 operator_start:
-	$(GET_SDK_VERSION)
 	@echo "Starting Operator..."
 	go run operator/cmd/main.go start --config $(CONFIG_FILE) \
 	2>&1 | zap-pretty
@@ -195,7 +194,7 @@ operator_set_eigen_sdk_go_version_error:
 
 operator_full_registration: operator_get_eth operator_register_with_eigen_layer operator_mint_mock_tokens operator_deposit_into_mock_strategy operator_whitelist_devnet operator_register_with_aligned_layer
 
-operator_register_and_start: operator_full_registration operator_start
+operator_register_and_start: $(GET_SDK_VERSION) operator_full_registration operator_start
 
 build_operator: deps
 	$(GET_SDK_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ test_go_retries:
 __OPERATOR__:
 
 operator_start:
+	$(GET_SDK_VERSION)
 	@echo "Starting Operator..."
 	go run operator/cmd/main.go start --config $(CONFIG_FILE) \
 	2>&1 | zap-pretty


### PR DESCRIPTION
# GET_SDK_VERSION before operator_full_registration

## Description

the appropriate SDK version is required during registration, this is why `GET_SDK_VERSION` should be done before `make operator_full_registration`, and not directly in `make operator_start`.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
