### PR TITLE
fix(CI):  missing go.sum entry for module providing package golang.org/x/net/proxy (imported by github.com/gorilla/websocket) on aggregator build

### DIFF
--- a/docker/aggregator.Dockerfile
+++ b/docker/aggregator.Dockerfile
@@ -10,6 +10,7 @@ COPY metrics      ./metrics
 COPY contracts/bindings/ ./contracts/bindings
 
 RUN go get github.com/ethereum/go-ethereum@latest
+RUN go get github.com/gorilla/websocket@v1.5.1
 RUN go build -o ./aligned-layer-aggregator aggregator/cmd/main.go
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
# Missing go.sum entry for module providing package golang.org/x/net/proxy (imported by github.com/gorilla/websocket) on aggregator build

## Description

When the CI tries to build the aggregator, it gets the following error

```
1.544 /root/go/pkg/mod/github.com/gorilla/websocket@v1.5.1/client.go:23:2: missing go.sum entry for module providing package golang.org/x/net/proxy (imported by github.com/gorilla/websocket); to add:
1.544 	go get github.com/gorilla/websocket@v1.5.1
```

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
