### PR TITLE
fix(CI): update foundry-gas-diff to version v3.21

### DIFF
--- a/.github/workflows/foundry-gas-diff.yml
+++ b/.github/workflows/foundry-gas-diff.yml
@@ -35,7 +35,7 @@ jobs:
           FOUNDRY_FUZZ_SEED: 0x${{ github.event.pull_request.base.sha || github.sha }}
 
       - name: Compare gas reports
-        uses: Rubilmax/foundry-gas-diff@v3.16
+        uses: Rubilmax/foundry-gas-diff@v3.21
         with:
           summaryQuantile: 0.9 # only display the 10% most significant gas diffs in the summary (defaults to 20%)
           sortCriteria: avg,max # sort diff rows by criteria


### PR DESCRIPTION
# Update foundry-gas-diff to version v3.21

## Description

Gas diff report is failing with the following error

```
Error: Create Artifact Container failed: The artifact name 1761-featcontract-add-amount_of_proofs-in-taskcreated-event.gasreport.ansi is not valid. Request URL https://pipelinesghubeus13.actions.githubusercontent.com/cYZQXBGeY5K3sV7lEtZpwKQOeeiQYOSUI5jrVEEF3mjEO5MAA5/_apis/pipelines/workflows/13208738459/artifacts?api-version=6.0-preview
```

Updating from version v3.16 to v3.21 fixes the error

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
