### PR TITLE
fix(zkquiz): update sdk usage 

### DIFF
--- a/examples/zkquiz/Makefile
+++ b/examples/zkquiz/Makefile
@@ -7,6 +7,7 @@ deploy_verifier_devnet:
 	. ./contracts/.devnet.env && . ./contracts/deploy.sh
 
 CONTRACT_ADDRESS=0x1adFb00CC74Ff26bB05419953006c66B1abFCD45
+STAGE_CONTRACT_ADDRESS=0xc4da6fcfa317eaf166b09ef276c0bdf43648a65f
 RPC_URL=https://ethereum-holesky-rpc.publicnode.com
 
 answer_quiz:
@@ -14,6 +15,13 @@ answer_quiz:
 		--keystore-path $(KEYSTORE_PATH) \
  		--rpc-url $(RPC_URL) \
   		--verifier-contract-address $(CONTRACT_ADDRESS)
+
+answer_quiz_stage:
+	@cd quiz/script && cargo run -r -- \
+		--keystore-path $(KEYSTORE_PATH) \
+		--rpc-url $(RPC_URL) \
+		--network holesky-stage \
+		--verifier-contract-address $(STAGE_CONTRACT_ADDRESS)
 
 answer_quiz_local: 
 	@cd quiz/script && cargo run -r -- \

--- a/examples/zkquiz/contracts/deploy.sh
+++ b/examples/zkquiz/contracts/deploy.sh
@@ -33,4 +33,6 @@ forge script script/Deployer.s.sol \
     --rpc-url "$RPC_URL" \
     --private-key "$PRIVATE_KEY" \
     --broadcast \
+    --verify \
+    --etherscan-api-key $ETHERSCAN_API_KEY \
     --sig "run(address _alignedServiceManager, address _paymentService)"


### PR DESCRIPTION
# Update sdk usage 

## Description

Due to changes in Network parameter, zkquiz need to be updated to use the correct version

This is only affected on STAGING branch

## How to test

You need a keystore with some funds in holesky

```
make answer_quiz_stage KEYSTORE_PATH=<path/to/keystore> RPC_URL=https://ethereum-holesky-rpc.publicnode.com
```

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
