### PR TITLE
fix(examples): use correct `verifyBatchInclusion` function and update python scripts on `examples/verify`

### DIFF
--- a/examples/verify/README.md
+++ b/examples/verify/README.md
@@ -38,21 +38,31 @@ This will output the address of the deployed contract. You will need this addres
 First encode the ethereum call to the contract using the following command:
 
 ```bash
-python3 encode_verification_data.py --aligned-verification-data [PATH_TO_ALIGNED_VERIFICATION_DATA]
+python3 encode_verification_data.py --aligned-verification-data [PATH_TO_ALIGNED_VERIFICATION_DATA] --sender-address [SENDER_ADDRESS]
 ```
 
 Replace `[PATH_TO_ALIGNED_VERIFICATION_DATA]` with the path to the json file containing the verification data. 
 This is the output when submitting a proof from the aligned cli.
 
+Replace `[SENDER_ADDRESS]` with the address of the `BatcherPaymentService` contract.
+
 This will output the encoded call. You can then use this encoded call to check your submitted proof with the associated data is verified in Ethereum by running the following command:
 
 ```bash
-curl -H "Content-Type: application/json" \
-    --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"to": "<CONTRACT_ADDRESS>", "data": "<CALL_DATA>"}]}' \
-    -X POST <RPC_URL>
+curl -X POST http://localhost:8545 \
+-H "Content-Type: application/json" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "eth_call",
+    "params": [{
+        "to": "<CONTRACT_ADDRESS>",
+        "data": "<CALLDATA>"
+    }],
+    "id": 1
+}'
 ```
 
-Replace `<CONTRACT_ADDRESS>` with the address of the contract you deployed earlier (or `0x58F280BeBE9B34c9939C3C39e0890C81f163B623` for Aligned ServiceManager in Holesky), `<CALL_DATA>` with the encoded call, 
+Replace `<CONTRACT_ADDRESS>` with the address of the contract you deployed earlier (or `0x58F280BeBE9B34c9939C3C39e0890C81f163B623` for Aligned ServiceManager in Holesky), `<CALLDATA>` with the encoded call, 
 and `<RPC_URL>` with the RPC URL of the blockchain you are using.
 
 The output data should be something like this:
@@ -61,7 +71,7 @@ The output data should be something like this:
 {
   "jsonrpc":"2.0",
   "result":"0x0000000000000000000000000000000000000000000000000000000000000001",
-  "id":null
+  "id":q
 }
 ```
 
@@ -78,13 +88,17 @@ Note that if result ends in 1 it means that your submitted proof with the associ
 
 Then, you can run the script by running the following command:
 ```bash
-python3 verify.py --contract-address [CONTRACT_ADDRESS] --aligned-verification-data [PATH_TO_ALIGNED_VERIFICATION_DATA]
+python3 verify.py --contract-address [CONTRACT_ADDRESS] --aligned-verification-data [PATH_TO_ALIGNED_VERIFICATION_DATA] --sender-address [SENDER_ADDRESS]
 ```
 
-Replace `[CONTRACT_ADDRESS]`, and `[PATH_TO_ALIGNED_VERIFICATION_DATA]` with your actual values.
+Replace `[CONTRACT_ADDRESS]`, `[PATH_TO_ALIGNED_VERIFICATION_DATA]` and `[SENDER_ADDRESS]` with your actual values.
 
 #### Example Command
 
 ```bash
-python3 verify.py --contract-address 0x623926229DD27c45AE40B4e16ba4CD6522fC4d22 --aligned-verification-data ../../aligned_verification_data/7553cb14bff387c06e016cb3e7946e91d9fe44a54ad5d888ce8343ddb16116a7_118.json
+python3 verify.py --contract-address 0x58F280BeBE9B34c9939C3C39e0890C81f163B623 --aligned-verification-data ../../aligned_verification_data/b8c17406_4.json --sender-address 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
+
+In this case, `--contract-address` is the address of the `AlignedLayerServiceManager` and `--sender-address` is the address of the `BatcherPaymentService` in Holesky Testnet.
+
+You need to replace the `--aligned-verification-data` with the path to the JSON file containing the verification data. This is the output when submitting a proof.

--- a/examples/verify/encode_verification_data.py
+++ b/examples/verify/encode_verification_data.py
@@ -4,40 +4,34 @@ from eth_abi import encode
 from Crypto.Hash import keccak
 
 
-def encode_call(file):
+def encode_call(file, sender_address):
     with open(file) as f:
         data = load(f)
 
-        verification_data_commitment = data['verification_data_commitment']
-        proof_commitment = bytearray(verification_data_commitment['proof_commitment'])
-        pub_input_commitment = bytearray(verification_data_commitment['pub_input_commitment'])
-        proving_system_aux_data_commitment = bytearray(
-            verification_data_commitment['proving_system_aux_data_commitment'])
-        proof_generator_addr = bytearray(verification_data_commitment['proof_generator_addr'])
-        batch_merkle_root = bytearray(data['batch_merkle_root'])
+        proof_commitment = bytearray.fromhex(data['proof_commitment'])
+        pub_input_commitment = bytearray.fromhex(data['pub_input_commitment'])
+        proving_system_aux_data_commitment = bytearray.fromhex(data['program_id_commitment'])
+        proof_generator_addr = bytearray.fromhex(data['proof_generator_addr'])
+        batch_merkle_root = bytearray.fromhex(data['batch_merkle_root'])
+        merkle_proof = bytearray.fromhex(data['merkle_proof'])
+        verification_data_batch_index = data['verification_data_batch_index']
 
-        merkle_path_arr = data['batch_inclusion_proof']['merkle_path']
-        merkle_proof = bytearray()
-        for i in range(0, len(merkle_path_arr)):
-            merkle_proof += bytearray(merkle_path_arr[i])
-
-        index = data['index_in_batch']
-
-        output = encode(['bytes32', 'bytes32', 'bytes32', 'bytes20', 'bytes32', 'bytes', 'uint256'],
+        output = encode(['bytes32', 'bytes32', 'bytes32', 'bytes20', 'bytes32', 'bytes', 'uint256', 'address'],
                         [proof_commitment, pub_input_commitment, proving_system_aux_data_commitment,
-                         proof_generator_addr, batch_merkle_root, merkle_proof, index])
+                         proof_generator_addr, batch_merkle_root, merkle_proof, verification_data_batch_index,
+                         sender_address])
 
         k = keccak.new(digest_bits=256)
-        k.update(b'verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256)')
+        k.update(b'verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256,address)')
         signature = k.hexdigest()[:8]
-
         return '0x' + signature + output.hex()
 
 
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument('--aligned-verification-data', help='Path to JSON file with the verification data')
+    parser.add_argument('--sender-address',  help='Address that sent the batch to Aligned')
     args = parser.parse_args()
 
-    data = encode_call(args.aligned_verification_data)
+    data = encode_call(args.aligned_verification_data, args.sender_address)
     print(data)

--- a/examples/verify/src/VerifyBatchInclusionCaller.sol
+++ b/examples/verify/src/VerifyBatchInclusionCaller.sol
@@ -15,18 +15,20 @@ contract VerifyBatchInclusionCaller {
         bytes20 proofGeneratorAddr,
         bytes32 batchMerkleRoot,
         bytes memory merkleProof,
-        uint256 verificationDataBatchIndex
+        uint256 verificationDataBatchIndex,
+        address senderAddress
     ) external view returns (bool) {
         (bool callWasSuccessfull, bytes memory proofIsIncluded) = targetContract.staticcall(
             abi.encodeWithSignature(
-                "verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256)",
+                "verifyBatchInclusion(bytes32,bytes32,bytes32,bytes20,bytes32,bytes,uint256,address)",
                 proofCommitment,
                 pubInputCommitment,
                 provingSystemAuxDataCommitment,
                 proofGeneratorAddr,
                 batchMerkleRoot,
                 merkleProof,
-                verificationDataBatchIndex
+                verificationDataBatchIndex,
+                senderAddress
             )
         );
 

--- a/examples/verify/verify.py
+++ b/examples/verify/verify.py
@@ -10,12 +10,13 @@ def main():
     parser.add_argument('--aligned-verification-data', help='Path to JSON file with the verification data',
                         required=True)
     parser.add_argument('--contract-address', help='Verifier Contract address', required=True)
+    parser.add_argument('--sender-address',  help='Address that sent the batch to Aligned')
 
     args = parser.parse_args()
 
     provider = Web3(Web3.HTTPProvider(args.rpc_url))
 
-    data = encode_call(args.aligned_verification_data)
+    data = encode_call(args.aligned_verification_data, args.sender_address)
 
     result = provider.eth.call({
         'to': args.contract_address,


### PR DESCRIPTION
# Use correct `verifyBatchInclusion` function and update python scripts on `examples/verify`

## Description

The example available in `examples/verify` uses the deprecated `verifyBatchInclusion` function which does not receive `senderAddress`. It should use the following function

```solidity
function verifyBatchInclusion(
        bytes32 proofCommitment,
        bytes32 pubInputCommitment,
        bytes32 provingSystemAuxDataCommitment,
        bytes20 proofGeneratorAddr,
        bytes32 batchMerkleRoot,
        bytes memory merkleProof,
        uint256 verificationDataBatchIndex,
        address senderAddress
    ) external view onlyWhenNotPaused(2) returns (bool) {
...
}
```

Also, the python scripts to generate the verification data does not work. It uses an old version of the encoded data file.

## How to Test

There are two cases to test, the first one is using cURL and the second one is using a Python script.

For both cases, there are some common steps:

1. Run aligned locally

```
make anvil_start_with_block_time
```

```
make batcher_start_local
```

```
make aggregator_start ENVIRONMENT=devnet
```

```
make operator_full_registration CONFIG_FILE=config-files/config-operator-1.yaml ENVIRONMENT=devnet
make operator_start CONFIG_FILE=config-files/config-operator-1.yaml ENVIRONMENT=devnet
```

2. Send some proofs

```
make batcher_send_burst_groth16
```

With send some proofs is enough. We need to use one of the verification data files received after the creation of the task

Proofs verification data should be available in `./aligned_verification_data/`


For example, 

```
b8c17406_0.cbor
b8c17406_0.json
```

3. Deploy a contract who will call to AlignedServiceManager to check the batch inclusion of your sent proofs

```
cd examples/verify
```

Complete the .env with the following values

```
PRIVATE_KEY=0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6
RPC_URL=http://localhost:8545
ALIGNED_DEPLOYMENT_OUTPUT=../../contracts/script/output/devnet/alignedlayer_deployment_output.json
```

Then run

```
./scripts/deploy_verify_batch_inclusion_caller.sh
```

This will output the address of the deployed contract. You will need this address to interact with the contract.

In my case it is `0xA15BB66138824a1c7167f5E85b957d04Dd34E468`

4. Install Python dependencies

```
pip3 install -r requirements.txt
```

### Use case 1: Using cURL to check the verification

1. Encode the data from the .json file

```
python3 encode_verification_data.py --aligned-verification-data ../../aligned_verification_data/b8c17406_0.json --sender-address 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650
```

Note: You need to change `b8c17406_0.json` with your json file

2. Call to Ethereum using cURL

```bash
curl -X POST http://localhost:8545 \
-H "Content-Type: application/json" \
-d '{
    "jsonrpc": "2.0",
    "method": "eth_call",
    "params": [{
        "to": "<CONTRACT_ADDRESS>",
        "data": "<CALLDATA>"
    }],
    "id": 1
}'
```

In this case we replace `CONTRACT_ADDRESS` with `0xA15BB66138824a1c7167f5E85b957d04Dd34E468` and `CALLDATA` with the output of step 1.

The output should be as follow 

```
{"jsonrpc":"2.0","id":1,"result":"0x0000000000000000000000000000000000000000000000000000000000000001"}
```

The `result`: `0x0000000000000000000000000000000000000000000000000000000000000001` means it was verified in Aligned

### Use case 2: Using a Python script to check the verification

1. Run the script with 

```
python3 verify.py --contract-address 0xA15BB66138824a1c7167f5E85b957d04Dd34E468 --aligned-verification-data ../../aligned_verification_data/b8c17406_0.json --sender-address 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650 --rpc-url http://localhost:8545
```

Replace `--contract-address` with your deployed contract and `--aligned-verification-data` with your proof data. `--sender-address` is the Devnet BatcherPaymentService contract.

It should return 

```
Submitted proof with associated data is verified in ethereum blockchain
```

## Type of change

- [x] Bug fix

close #1795

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
