### PR TITLE
fix(examples): use new version of the SDK on `validating public input` example

### DIFF
--- a/docs/3_guides/3_validating_public_input.md
+++ b/docs/3_guides/3_validating_public_input.md
@@ -175,7 +175,7 @@ This command will log the address of the deployed contract like so:
 
 ```
 == Return ==
-0: address 0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f
+0: address 0xFE5aBfb5E754e4AeFE1e8eC413ca6D2CCF99d5Ed
 ```
 
 Make sure to save this address, as you'll need it for the next step.
@@ -183,11 +183,13 @@ Make sure to save this address, as you'll need it for the next step.
 Now, to call our verifier contract and check the inclusion of the proof along with the validation of the public inputs, use the following command based on the verifier you used:
 
 - For Risc0:
+
   ```bash
   make verify_risc0_batch_inclusion FIBONACCI_VALIDATOR_ADDRESS=<FIBONACCI_VALIDATOR_ADDRESS> DATA_FILE_NAME=<DATA_FILE_NAME>
   ```
 
 - For SP1:
+
   ```bash
   make verify_sp1_batch_inclusion FIBONACCI_VALIDATOR_ADDRESS=<FIBONACCI_VALIDATOR_ADDRESS> DATA_FILE_NAME=<DATA_FILE_NAME>
   ```

--- a/examples/validating-public-input/Makefile
+++ b/examples/validating-public-input/Makefile
@@ -13,19 +13,19 @@ generate_sp1_fibonacci_proof:
 
 submit_fibonacci_sp1_proof_devnet:
 	@cd aligned-integration && \
-	RUST_LOG=info cargo run --release -- --proving-system "SP1" --network "devnet" --batcher-url "ws://localhost:8080" --rpc-url "http://localhost:8545"
+	RUST_LOG=info cargo run --release -- --proving-system "SP1" --network "devnet" --rpc-url "http://localhost:8545"
 
 submit_fibonacci_sp1_proof:
 	@cd aligned-integration && \
-	RUST_LOG=info cargo run --release -- --keystore-path $(KEYSTORE_PATH) --proving-system "SP1"
+	RUST_LOG=info cargo run --release -- --keystore-path $(KEYSTORE_PATH) --proving-system "SP1" --network "holesky"
 
 submit_fibonacci_risc0_proof_devnet:
 	@cd aligned-integration && \
-	RUST_LOG=info cargo run --release -- --proving-system "Risc0" --network "devnet" --batcher-url "ws://localhost:8080" --rpc-url "http://localhost:8545"
+	RUST_LOG=info cargo run --release -- --proving-system "Risc0" --network "devnet" --rpc-url "http://localhost:8545"
 
 submit_fibonacci_risc0_proof:
 	@cd aligned-integration && \
-	RUST_LOG=info cargo run --release -- --keystore-path $(KEYSTORE_PATH) --proving-system "Risc0"
+	RUST_LOG=info cargo run --release -- --keystore-path $(KEYSTORE_PATH) --proving-system "Risc0" --network "holesky"
 
 verify_sp1_batch_inclusion:
 	@. ./contracts/.env  && . ./contracts/validate_batch_inclusion.sh $(FIBONACCI_VALIDATOR_ADDRESS) $(DATA_FILE_NAME) SP1

--- a/examples/validating-public-input/aligned-integration/src/main.rs
+++ b/examples/validating-public-input/aligned-integration/src/main.rs
@@ -45,8 +45,8 @@ pub enum ProvingSystemArg {
 struct Args {
     #[arg(short, long, default_value = "wss://batcher.alignedlayer.com")]
     batcher_url: String,
-    #[arg(short, long, default_value = "holesky")]
-    network: Network,
+    #[clap(flatten)]
+    network: NetworkArg,
     #[arg(short, long)]
     keystore_path: Option<String>,
     #[arg(short, long)]
@@ -57,6 +57,93 @@ struct Args {
         default_value = "https://ethereum-holesky-rpc.publicnode.com"
     )]
     rpc_url: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum NetworkNameArg {
+    Devnet,
+    Holesky,
+    HoleskyStage,
+    Mainnet,
+}
+
+impl FromStr for NetworkNameArg {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "devnet" => Ok(NetworkNameArg::Devnet),
+            "holesky" => Ok(NetworkNameArg::Holesky),
+            "holesky-stage" => Ok(NetworkNameArg::HoleskyStage),
+            "mainnet" => Ok(NetworkNameArg::Mainnet),
+            _ => Err(
+                "Unknown network. Possible values: devnet, holesky, holesky-stage, mainnet"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, clap::Args, Clone)]
+struct NetworkArg {
+    #[arg(
+        name = "The working network's name",
+        long = "network",
+        default_value = "devnet",
+        help = "[possible values: devnet, holesky, holesky-stage, mainnet]"
+    )]
+    network: Option<NetworkNameArg>,
+    #[arg(
+        name = "Aligned Service Manager Contract Address",
+        long = "aligned_service_manager",
+        conflicts_with("The working network's name"),
+        requires("Batcher Payment Service Contract Address"),
+        requires("Batcher URL")
+    )]
+    aligned_service_manager_address: Option<String>,
+
+    #[arg(
+        name = "Batcher Payment Service Contract Address",
+        long = "batcher_payment_service",
+        conflicts_with("The working network's name"),
+        requires("Aligned Service Manager Contract Address"),
+        requires("Batcher URL")
+    )]
+    batcher_payment_service_address: Option<String>,
+
+    #[arg(
+        name = "Batcher URL",
+        long = "batcher_url",
+        conflicts_with("The working network's name"),
+        requires("Aligned Service Manager Contract Address"),
+        requires("Batcher Payment Service Contract Address")
+    )]
+    batcher_url: Option<String>,
+}
+
+impl From<NetworkArg> for Network {
+    fn from(network_arg: NetworkArg) -> Self {
+        let mut processed_network_argument = network_arg.clone();
+
+        if network_arg.batcher_url.is_some()
+            || network_arg.aligned_service_manager_address.is_some()
+            || network_arg.batcher_payment_service_address.is_some()
+        {
+            processed_network_argument.network = None; // We need this because network is Devnet as default, which is not true for a Custom network
+        }
+
+        match processed_network_argument.network {
+            None => Network::Custom(
+                network_arg.aligned_service_manager_address.unwrap(),
+                network_arg.batcher_payment_service_address.unwrap(),
+                network_arg.batcher_url.unwrap(),
+            ),
+            Some(NetworkNameArg::Devnet) => Network::Devnet,
+            Some(NetworkNameArg::Holesky) => Network::Holesky,
+            Some(NetworkNameArg::HoleskyStage) => Network::HoleskyStage,
+            Some(NetworkNameArg::Mainnet) => Network::Mainnet,
+        }
+    }
 }
 
 #[tokio::main]
@@ -73,7 +160,7 @@ async fn main() -> Result<(), SubmitError> {
         .await
         .expect("Failed to get chain_id");
 
-    let network: Network = args.network;
+    let network: Network = args.network.clone().into();
     let wallet = match network {
         Network::Holesky => {
             let keystore_password = rpassword::prompt_password("Enter keystore password: ")
@@ -128,15 +215,14 @@ async fn main() -> Result<(), SubmitError> {
     // Set a fee of 0.01 Eth
     let max_fee = U256::from(100_000_000_000_000u128);
 
-    let nonce = get_nonce_from_ethereum(&args.rpc_url, wallet.address(), network)
+    let nonce = get_nonce_from_ethereum(&args.rpc_url, wallet.address(), network.clone())
         .await
         .expect("Failed to get next nonce");
 
     info!("Submitting Fibonacci proof to Aligned and waiting for verification...");
     let aligned_verification_data = submit_and_wait_verification(
-        &args.batcher_url,
         &args.rpc_url,
-        network,
+        network.clone().into(),
         &verification_data,
         max_fee,
         wallet,


### PR DESCRIPTION
# Use new version of the SDK on `validating public input` example

## Description

closes #1797 

Due to changes in Network parameter, `Validating public inputs` example needs to be updated to use the correct version

This is only affected on STAGING branch

## How to Test

You can follow the guide available hiere (https://github.com/yetanotherco/aligned_layer/blob/0faf6e152229113bd0a2029e5e29e2054d6f105d/docs/3_guides/3_validating_public_input.md)

This guide uses Holesky Testnet and you will need a wallet with some funds in Holesky

You can deploy your own Fibonacci validator, or use  `0xFE5aBfb5E754e4AeFE1e8eC413ca6D2CCF99d5Ed` in Holesky

### Risc0

1. Generate a Risc0 proof

```
make generate_risc0_fibonacci_proof
```

2. Submit the Risc0 proof to Aligned

```
make submit_fibonacci_risc0_proof KEYSTORE_PATH=<KEYSTORE_PATH>
```

3. Verify the batch inclusion

```
make verify_risc0_batch_inclusion FIBONACCI_VALIDATOR_ADDRESS=<FIBONACCI_VALIDATOR_ADDRESS> DATA_FILE_NAME=<DATA_FILE_NAME>
```

### SP1

1. Generate an SP1 proof

```
make generate_sp1_fibonacci_proof
```

2. Submit the SP1 proof to Aligned

```
make submit_fibonacci_sp1_proof KEYSTORE_PATH=<KEYSTORE_PATH>
```

3. Verify the batch inclusion

```
make verify_sp1_batch_inclusion FIBONACCI_VALIDATOR_ADDRESS=<FIBONACCI_VALIDATOR_ADDRESS> DATA_FILE_NAME=<DATA_FILE_NAME>
```

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
