### PR TITLE
chore(explorer): enable CORS for /api endpoints

### DIFF
--- a/explorer/lib/explorer_web/router.ex
+++ b/explorer/lib/explorer_web/router.ex
@@ -29,6 +29,7 @@ defmodule ExplorerWeb.Router do
   end
 
   pipeline :api do
+    plug CORSPlug, origin: "*"
     plug :accepts, ["json"]
   end
 

--- a/explorer/mix.exs
+++ b/explorer/mix.exs
@@ -62,7 +62,8 @@ defmodule Explorer.MixProject do
       {:postgrex, ">= 0.0.0"},
       {:cachex, "~> 3.6"},
       {:mutex, "~> 2.0"},
-      {:tails, "~> 0.1.5"}
+      {:tails, "~> 0.1.5"},
+      {:cors_plug, "~> 3.0"},
     ]
   end
 


### PR DESCRIPTION
# Enable CORS for /api endpoints

## Description

The new website uses the `api/verified_batches_summary` endpoint from the explorer. This endpoint needs to have enabled CORS. If not, the client browser is blocked and cannot get the data.

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
