### PR TITLE
hotfix(telemetry): do not discard operators without metadata

### DIFF
--- a/telemetry_api/lib/telemetry_api/operators.ex
+++ b/telemetry_api/lib/telemetry_api/operators.ex
@@ -146,7 +146,6 @@ defmodule TelemetryApi.Operators do
     else
       {:error, reason} ->
         Logger.error("Failed to fetch metadata for operator: #{op_data.address}. Reason: #{inspect(reason)}")
-        {:error, "Failed to fetch metadata for operator: #{op_data.address}"}
         operator = %{
           id: op_data.id,
           address: op_data.address,

--- a/telemetry_api/lib/telemetry_api/operators.ex
+++ b/telemetry_api/lib/telemetry_api/operators.ex
@@ -1,4 +1,6 @@
 defmodule TelemetryApi.Operators do
+  require Logger
+
   @moduledoc """
   The Operators context.
   """
@@ -130,6 +132,7 @@ defmodule TelemetryApi.Operators do
   #    {:error, string}
   #
   defp add_operator_metadata(op_data) do
+    Logger.info("Fetching metadata for operator: #{op_data.address}")
     with {:ok, url} <- DelegationManager.get_operator_url(op_data.address),
          {:ok, metadata} <- TelemetryApi.Utils.fetch_json_data(url) do
       operator = %{
@@ -140,6 +143,18 @@ defmodule TelemetryApi.Operators do
       }
 
       {:ok, operator}
+    else
+      {:error, reason} ->
+        Logger.error("Failed to fetch metadata for operator: #{op_data.address}. Reason: #{inspect(reason)}")
+        {:error, "Failed to fetch metadata for operator: #{op_data.address}"}
+        operator = %{
+          id: op_data.id,
+          address: op_data.address,
+          stake: op_data.stake,
+          name: op_data.address
+        }
+
+        {:ok, operator}
     end
   end
 

--- a/telemetry_api/lib/telemetry_api/utils.ex
+++ b/telemetry_api/lib/telemetry_api/utils.ex
@@ -1,4 +1,6 @@
 defmodule TelemetryApi.Utils do
+  require Logger
+  
   @moduledoc """
   Some utility functions
   """
@@ -15,6 +17,7 @@ defmodule TelemetryApi.Utils do
       {:error, message}
   """
   def fetch_json_data(url) do
+    Logger.info("Fetching data from #{url}")
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(url) do
       Jason.decode(body)
     else


### PR DESCRIPTION
# Do not discard operators without metadata

## Description

When the telemetry api fetches the operator metadata and the request fails, the operator is not stored in the database

With this PR, the telemetry API stores the operator using the `address` as `name` instead of discarding it

closes #1802

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
