### PR TITLE
fix: update 404 links in documentation

### DIFF
--- a/docs/3_guides/2.2_modify_zkquiz_questions.md
+++ b/docs/3_guides/2.2_modify_zkquiz_questions.md
@@ -74,7 +74,7 @@ if output
 ## 3. Compile the Program
 
 Now we need to compile the updated Program, generating the binary file that will be run by the zkVM (ELF).
-For this, ensure that the [SP1 Rust toolchain](https://docs.succinct.xyz/introduction.html) is installed. Run:
+For this, ensure that the [SP1 Rust toolchain](https://docs.succinct.xyz/docs/sp1/introduction) is installed. Run:
 
 ```
 make compile_elf

--- a/docs/3_guides/2_build_your_first_aligned_application.md
+++ b/docs/3_guides/2_build_your_first_aligned_application.md
@@ -96,7 +96,7 @@ ZkQuiz has three main components:
 The user interacts with ZkQuiz App to solve a trivia challenge answering questions. Then, the App generates a Zk Proof with the Program generated using SP1.
 
 {% hint style="info" %}
-The ZkQuiz Program is built using SP1 following the [quickstart guide](https://docs.succinct.xyz/getting-started/quickstart.html#project-overview). For your projects, you can user any of the [prooving systems supported by Aligned](../2_architecture/0_supported_verifiers.md).
+The ZkQuiz Program is built using SP1 following the [quickstart guide](https://docs.succinct.xyz/docs/sp1/getting-started/quickstart#project-overview). For your projects, you can user any of the [prooving systems supported by Aligned](../2_architecture/0_supported_verifiers.md).
 {% endhint %}
 
 Once the proof is generated, the App sends the proof to Aligned, and once it is verified, the App calls to the ZkQuiz Verifier Contract to check the proof verification and send an NFT to the user is the proof was verified in Aligned.

--- a/docs/3_guides/3_validating_public_input.md
+++ b/docs/3_guides/3_validating_public_input.md
@@ -7,7 +7,7 @@ This guide demonstrates how to validate Risc0 and SP1 proofs using the Aligned S
 In this case, the Fibonacci number to be calculated is **500** and the last two numbers of the sequence modulo 7919 are **1268** and **1926**.
 
 ## Requirements
-- [SP1](https://docs.succinct.xyz/getting-started/install.html)
+- [SP1](https://docs.succinct.xyz/docs/sp1/getting-started/install)
 - [Risc0](https://dev.risczero.com/api/zkvm/install)
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 
@@ -29,7 +29,7 @@ For `SP1`, the Fibonacci program is located in `examples/validating-public-input
 
 > [!IMPORTANT]
 > To generate the proof ensure you have [docker](https://www.docker.com/get-started/) installed and the docker daemon running.
-> This is necessary to ensure deterministic builds of the binary we want to generate a proof of. If not used, builds may differ depending on the system you are running on. To know more about this, check [this link](https://dev.risczero.com/terminology#deterministic-builds) from RiscZero docs or [this](https://docs.succinct.xyz/writing-programs/compiling.html#advanced-build-options-1) from SP1.
+> This is necessary to ensure deterministic builds of the binary we want to generate a proof of. If not used, builds may differ depending on the system you are running on. To know more about this, check [this link](https://dev.risczero.com/terminology#deterministic-builds) from RiscZero docs or [this](https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#advanced-build-options-1) from SP1.
 
 To submit proofs to **Aligned** and get them verified, you first need to generate those proofs. Every proving system has its own method for generating proofs.
 


### PR DESCRIPTION
## Description

Hi! I fixes dead links (404 errors) in the documentation files. The outdated links have been updated to point to the correct and current locations in the documentation. 

## Type of change

- [x] Bug fix
