### PR TITLE
Grammar and Phrasing Improvements in Documentation

### DIFF
--- a/docs/0_internal/4_b_3_propose_unpause.md
+++ b/docs/0_internal/4_b_3_propose_unpause.md
@@ -20,7 +20,7 @@ To propose the unpause transaction you can follow the steps below:
 
 3. Get the `AlignedLayerServiceManager` address from ```contracts/script/output/mainnet/alignedlayer_deployment_output.json``` or ```contracts/script/output/holesky/alignedlayer_deployment_output.json``` or ```contracts/script/output/sepolia/alignedlayer_deployment_output.json```
 
-4. Paste the `AlignedLayerServiceManager` address on `Enter Address or ENS Name`
+4. Paste the `AlignedLayerServiceManager` address in `Enter Address or ENS Name`
 
    ![Enter Address](./images/4_b_1_unpause_3.png)
 
@@ -67,7 +67,7 @@ To propose the unpause transaction you can follow the steps below:
 
 3. Get the `BatcherPaymentService` address from ```contracts/script/output/mainnet/alignedlayer_deployment_output.json``` or ```contracts/script/output/holesky/alignedlayer_deployment_output.json``` or ```contracts/script/output/sepolia/alignedlayer_deployment_output.json```
 
-4. Paste the `BatcherPaymentService` address on `Enter Address or ENS Name`
+4. Paste the `BatcherPaymentService` address in `Enter Address or ENS Name`
 
    ![Enter Address](./images/4_b_1_unpause_3.png)
 

--- a/docs/about_aligned/features.md
+++ b/docs/about_aligned/features.md
@@ -26,12 +26,12 @@ $$C_{USD} = C_{gas} V_{gas} V_{ETH}$$
 For example, if the gas cost is 8 gwei/gas and ETH is worth 3000 USD/ETH, a transaction costs:
 $$C_{USD} = 21,000 \times 8 \times 10^{-9} \times 3000 = 0.504\ \mathrm{USD}$$
 
-Aligned reduces cost by splitting the cost of task creation and verification among several proofs. The gas cost per proof for a batch containing N proofs is:
+Aligned reduces costs by splitting the cost of task creation and verification among several proofs. The gas cost per proof for a batch containing N proofs is:
 $$C_{gas} = \frac{C_{task} + C_{verification}}{N} + C_{read}$$
 
 $C_{read}$ in this case is the cost the user has to pay to use the proof in a contract.
 
-The cost of verification depends on the mode chosen when using Aligned. For fast mode only, the cost of verification is the cost of a BLS signature check. This cost is based on the calculation of elliptic curve pairings, which costs 113,000 gas. It is important to note that while batching can reduce the costs of task creation and verification, the reading cost is fixed.
+The cost of verification depends on the mode chosen when using Aligned. For fast mode only, the cost of verification is thet cost of a BLS signature check. This cost is based on the calculation of elliptic curve pairings, which costs 113,000 gas. It is important to note that while batching can reduce the costs of task creation and verification, the reading cost is fixed.
 
 ## High throughput 
 


### PR DESCRIPTION
1. In docs/0_internal/4_b_3_propose_unpause.md:
Old:
"4. Paste the AlignedLayerServiceManager address on Enter Address or ENS Name"
"4. Paste the BatcherPaymentService address on Enter Address or ENS Name"
New:
"4. Paste the AlignedLayerServiceManager address in Enter Address or ENS Name"
"4. Paste the BatcherPaymentService address in Enter Address or ENS Name"
Reason: Corrected preposition "on" to "in" as the address is pasted in the field, not on it.

2. In docs/about_aligned/features.md:
Old:
"Aligned reduces cost by splitting the cost of task creation and verification among several proofs."
New:
"Aligned reduces costs by splitting the cost of task creation and verification among several proofs."
Reason: Changed "cost" to "costs" for plural accuracy.

Old:
"The cost of verification depends on the mode chosen when using Aligned. For fast mode only, the cost of verification is the cost of a BLS signature check."
New:
"The cost of verification depends on the mode chosen when using Aligned. For fast mode only, the cost of verification is that of a BLS signature check."
Reason: Replaced "the cost of" with "that of" for clarity.

Summary:
Corrected preposition use, pluralized "cost", and improved phrasing for conciseness.
