### PR TITLE
Refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x

### DIFF
--- a/batcher/aligned-task-sender/src/structs.rs
+++ b/batcher/aligned-task-sender/src/structs.rs
@@ -6,19 +6,19 @@ use clap::ValueEnum;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct TaskSenderArgs {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: TaskSenderCommands,
 }
 
 #[derive(Subcommand, Debug)]
 pub enum TaskSenderCommands {
-    #[clap(about = "Genere proofs")]
+    #[command(about = "Genere proofs")]
     GenerateProofs(GenerateProofsArgs),
-    #[clap(about = "Open socket connections with batcher")]
+    #[command(about = "Open socket connections with batcher")]
     TestConnections(TestConnectionsArgs),
-    #[clap(about = "Send infinite proofs from a private-keys file")]
+    #[command(about = "Send infinite proofs from a private-keys file")]
     SendInfiniteProofs(SendInfiniteProofsArgs),
-    #[clap(about = "Generates wallets and funds it in aligned from one wallet")]
+    #[command(about = "Generates wallets and funds it in aligned from one wallet")]
     GenerateAndFundWallets(GenerateAndFundWalletsArgs),
 }
 

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -36,27 +36,27 @@ use crate::AlignedCommands::VerifyProofOnchain;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct AlignedArgs {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: AlignedCommands,
 }
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
 pub enum AlignedCommands {
-    #[clap(about = "Submit proof to the batcher")]
+    #[command(about = "Submit proof to the batcher")]
     Submit(SubmitArgs),
-    #[clap(about = "Verify the proof was included in a verified batch on Ethereum")]
+    #[command(about = "Verify the proof was included in a verified batch on Ethereum")]
     VerifyProofOnchain(VerifyProofOnchainArgs),
-    #[clap(about = "Get commitment for file", name = "get-vk-commitment")]
+    #[command(about = "Get commitment for file", name = "get-vk-commitment")]
     GetVkCommitment(GetVkCommitmentArgs),
-    #[clap(
+    #[command(
         about = "Deposits Ethereum in the batcher to pay for proofs",
         name = "deposit-to-batcher"
     )]
     DepositToBatcher(DepositToBatcherArgs),
-    #[clap(about = "Get user balance from the batcher", name = "get-user-balance")]
+    #[command(about = "Get user balance from the batcher", name = "get-user-balance")]
     GetUserBalance(GetUserBalanceArgs),
-    #[clap(about = "Get user nonce from the batcher", name = "get-user-nonce")]
+    #[command(about = "Get user nonce from the batcher", name = "get-user-nonce")]
     GetUserNonce(GetUserNonceArgs),
 }
 
@@ -219,6 +219,7 @@ pub struct GetUserNonceArgs {
 }
 
 #[derive(Debug, Clone, ValueEnum, Copy)]
+#[value_enum(rename_all = "PascalCase")]
 enum NetworkArg {
     Devnet,
     Holesky,
@@ -238,16 +239,12 @@ impl From<NetworkArg> for Network {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
+#[value_enum(rename_all = "PascalCase")]
 pub enum ProvingSystemArg {
-    #[clap(name = "GnarkPlonkBls12_381")]
     GnarkPlonkBls12_381,
-    #[clap(name = "GnarkPlonkBn254")]
     GnarkPlonkBn254,
-    #[clap(name = "Groth16Bn254")]
     Groth16Bn254,
-    #[clap(name = "SP1")]
     SP1,
-    #[clap(name = "Risc0")]
     Risc0,
 }
 

--- a/examples/validating-public-input/aligned-integration/src/main.rs
+++ b/examples/validating-public-input/aligned-integration/src/main.rs
@@ -34,9 +34,9 @@ const ANVIL_PRIVATE_KEY: &str =
 
 #[derive(Debug, Clone, ValueEnum, PartialEq)]
 pub enum ProvingSystemArg {
-    #[clap(name = "SP1")]
+    #[value_enum(rename = "SP1")]
     SP1,
-    #[clap(name = "Risc0")]
+     #[value_enum(rename = "Risc0")]
     Risc0,
 }
 


### PR DESCRIPTION
## Description
This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

Fixes #1808 

## Type of change

Please delete options that are not relevant.
- [x] Optimization
- [X] Refactor

