### PR TITLE
chore: add mainnet-stage to SDK

### DIFF
--- a/batcher/aligned-sdk/src/core/types.rs
+++ b/batcher/aligned-sdk/src/core/types.rs
@@ -402,6 +402,7 @@ pub enum Network {
     Holesky,
     HoleskyStage,
     Mainnet,
+    MainnetStage,
 }
 
 impl FromStr for Network {
@@ -413,8 +414,9 @@ impl FromStr for Network {
             "holesky-stage" => Ok(Network::HoleskyStage),
             "devnet" => Ok(Network::Devnet),
             "mainnet" => Ok(Network::Mainnet),
+            "mainnet-stage" => Ok(Network::MainnetStage),
             _ => Err(
-                "Invalid network, possible values are: \"holesky\", \"holesky-stage\", \"devnet\", \"mainnet\""
+                "Invalid network, possible values are: \"holesky\", \"holesky-stage\", \"devnet\", \"mainnet\", \"mainnet-stage\""
                     .to_string(),
             ),
         }

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -279,6 +279,7 @@ pub fn get_payment_service_address(network: Network) -> ethers::types::H160 {
             H160::from_str("0x7577Ec4ccC1E6C529162ec8019A49C13F6DAd98b").unwrap()
         }
         Network::Mainnet => H160::from_str("0xb0567184A52cB40956df6333510d6eF35B89C8de").unwrap(),
+        Network::MainnetStage => H160::from_str("0x88ad27EfBeF16b6fC5b2E40c5155d61876f847c5").unwrap(),
     }
 }
 
@@ -290,6 +291,7 @@ pub fn get_aligned_service_manager_address(network: Network) -> ethers::types::H
             H160::from_str("0x9C5231FC88059C086Ea95712d105A2026048c39B").unwrap()
         }
         Network::Mainnet => H160::from_str("0xeF2A435e5EE44B2041100EF8cbC8ae035166606c").unwrap(),
+        Network::MainnetStage => H160::from_str("0x96b6a29D7B98519Ae66E6398BD27A76B30a5dC3f").unwrap(),
     }
 }
 

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -279,7 +279,9 @@ pub fn get_payment_service_address(network: Network) -> ethers::types::H160 {
             H160::from_str("0x7577Ec4ccC1E6C529162ec8019A49C13F6DAd98b").unwrap()
         }
         Network::Mainnet => H160::from_str("0xb0567184A52cB40956df6333510d6eF35B89C8de").unwrap(),
-        Network::MainnetStage => H160::from_str("0x88ad27EfBeF16b6fC5b2E40c5155d61876f847c5").unwrap(),
+        Network::MainnetStage => {
+            H160::from_str("0x88ad27EfBeF16b6fC5b2E40c5155d61876f847c5").unwrap()
+        }
     }
 }
 
@@ -291,7 +293,9 @@ pub fn get_aligned_service_manager_address(network: Network) -> ethers::types::H
             H160::from_str("0x9C5231FC88059C086Ea95712d105A2026048c39B").unwrap()
         }
         Network::Mainnet => H160::from_str("0xeF2A435e5EE44B2041100EF8cbC8ae035166606c").unwrap(),
-        Network::MainnetStage => H160::from_str("0x96b6a29D7B98519Ae66E6398BD27A76B30a5dC3f").unwrap(),
+        Network::MainnetStage => {
+            H160::from_str("0x96b6a29D7B98519Ae66E6398BD27A76B30a5dC3f").unwrap()
+        }
     }
 }
 

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -224,6 +224,7 @@ enum NetworkArg {
     Holesky,
     HoleskyStage,
     Mainnet,
+    MainnetStage,
 }
 
 impl From<NetworkArg> for Network {
@@ -233,6 +234,7 @@ impl From<NetworkArg> for Network {
             NetworkArg::Holesky => Network::Holesky,
             NetworkArg::HoleskyStage => Network::HoleskyStage,
             NetworkArg::Mainnet => Network::Mainnet,
+            NetworkArg::MainnetStage => Network::MainnetStage
         }
     }
 }

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -234,7 +234,7 @@ impl From<NetworkArg> for Network {
             NetworkArg::Holesky => Network::Holesky,
             NetworkArg::HoleskyStage => Network::HoleskyStage,
             NetworkArg::Mainnet => Network::Mainnet,
-            NetworkArg::MainnetStage => Network::MainnetStage
+            NetworkArg::MainnetStage => Network::MainnetStage,
         }
     }
 }


### PR DESCRIPTION
# chore: add mainnet-stage to SDK

## Description

This PR adds the Mainnet-stage addresses for the AlignedLayerServiceManager and BatcherPaymentService

Both addresses are the proxies, so it is not needed to change it on contracts upgrades

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
