### PR TITLE
docs: update dependencies for operators

### DIFF
--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -46,6 +46,7 @@ Also, you have to install the following dependencies for Linux:
 
 - pkg-config
 - libssl-dev
+- g++
 
 To install foundry, run:
 

--- a/docs/operator_guides/2_troubleshooting.md
+++ b/docs/operator_guides/2_troubleshooting.md
@@ -44,3 +44,12 @@ If your operator is not showing up after 1 hour, please check the following:
 This error is caused by the operator not being able to get the RPC urls.
 
 Make sure you have configured the RPC correctly in the [config file](0_running_an_operator.md#step-3---update-the-configuration-for-your-specific-operator).
+
+### How to update Rust
+
+In case you have an unsupported version of Rust, you can update it following the [official page](https://www.rust-lang.org/tools/install)
+
+
+### Compiler family detection failed due to error: ToolNotFound: failed to find tool "c++": No such file or directory (os error 2)
+
+Run `sudo apt update && sudo apt install g++` to install the GNU C++ compiler.


### PR DESCRIPTION
# Update dependencies for operators

## Description

Update the required dependencies and troubleshooting guide for operators

## Type of change

- [x] Documentation

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
