### PR TITLE
hotfix(operator): add SP1 path to LD_LIBRARY_PATH and OPERATOR_FFIS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ ifeq ($(OS),Darwin)
 endif
 
 ifeq ($(OS),Linux)
-	export LD_LIBRARY_PATH+=$(CURDIR)/operator/risc_zero/lib
-	OPERATOR_FFIS=$(CURDIR)/operator/risc_zero/lib
+	export LD_LIBRARY_PATH+=$(CURDIR)/operator/risc_zero/lib:$(CURDIR)/operator/sp1/lib
+	OPERATOR_FFIS=$(CURDIR)/operator/risc_zero/lib:$(CURDIR)/operator/sp1/lib
 endif
 
 ifeq ($(OS),Linux)


### PR DESCRIPTION
# Add SP1 path to LD_LIBRARY_PATH and OPERATOR_FFIS

## Description

This update is just a hotfix for operators with the following error

```
error while loading shared libraries: libsp1_verifier_ffi.so: cannot open shared object file: No such file or directory
```

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
