### PR TITLE
docs: update to v0.15.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CONFIG_FILE?=config-files/config.yaml
 export OPERATOR_ADDRESS ?= $(shell yq -r '.operator.address' $(CONFIG_FILE))
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
-OPERATOR_VERSION=v0.15.0
+OPERATOR_VERSION=v0.15.1
 EIGEN_SDK_GO_VERSION_TESTNET=v0.2.0-beta.1
 EIGEN_SDK_GO_VERSION_MAINNET=v0.1.13
 

--- a/batcher/Cargo.lock
+++ b/batcher/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "aligned"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aligned-sdk",
  "clap",

--- a/batcher/aligned/Cargo.toml
+++ b/batcher/aligned/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aligned"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 
 [dependencies]

--- a/docs/3_guides/1_SDK_how_to.md
+++ b/docs/3_guides/1_SDK_how_to.md
@@ -12,7 +12,7 @@ To use this SDK in your Rust project, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.15.0" }
+aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.15.1" }
 ```
 
 To find the latest release tag go to [releases](https://github.com/yetanotherco/aligned_layer/releases) and copy the

--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -1,7 +1,7 @@
 # Register as an Aligned operator in testnet
 
 > **CURRENT VERSION:**
-> Aligned Operator [v0.15.0](https://github.com/yetanotherco/aligned_layer/releases/tag/v0.15.0)
+> Aligned Operator [v0.15.1](https://github.com/yetanotherco/aligned_layer/releases/tag/v0.15.1)
 
 > **IMPORTANT:** 
 > You must be [whitelisted](https://docs.google.com/forms/d/e/1FAIpQLSdH9sgfTz4v33lAvwj6BvYJGAeIshQia3FXz36PFfF-WQAWEQ/viewform) to become an Aligned operator.
@@ -30,7 +30,7 @@ The list of supported strategies can be found [here](../3_guides/7_contract_addr
 To start with, clone the Aligned repository and move inside it
 
 ```bash
-git clone https://github.com/yetanotherco/aligned_layer.git --branch v0.15.0
+git clone https://github.com/yetanotherco/aligned_layer.git --branch v0.15.1
 cd aligned_layer
 ```
 

--- a/explorer/.env.dev
+++ b/explorer/.env.dev
@@ -30,4 +30,4 @@ BATCH_TTL_MINUTES=5
 SCHEDULED_BATCH_INTERVAL_MINUTES=10
 
 # Latest aligned release that operators should be running
-LATEST_RELEASE=v0.15.0
+LATEST_RELEASE=v0.15.1

--- a/explorer/.env.example
+++ b/explorer/.env.example
@@ -28,4 +28,4 @@ BATCH_TTL_MINUTES=5
 SCHEDULED_BATCH_INTERVAL_MINUTES=360
 
 # Latest aligned release that operators should be running
-LATEST_RELEASE=v0.15.0
+LATEST_RELEASE=v0.15.1


### PR DESCRIPTION
# Update to v0.15.1

## Description

Update docs to v0.15.1

This update is just a hotfix for operators with the following error

```
error while loading shared libraries: libsp1_verifier_ffi.so: cannot open shared object file: No such file or directory
```

## Type of change


- [x] Documentation

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
