### PR TITLE
fix: clippy

### DIFF
--- a/batcher/aligned-batcher/src/main.rs
+++ b/batcher/aligned-batcher/src/main.rs
@@ -10,10 +10,10 @@ use aligned_batcher::{types::errors::BatcherError, Batcher};
 /// Batcher main flow:
 /// There are two main tasks spawned: `listen_connections` and `listen_new_blocks`
 /// * `listen_connections` waits for websocket connections and adds verification data sent by clients
-///    to the batch.
+///   to the batch.
 /// * `listen_new_blocks` waits for new blocks and when one is received, checks if the conditions are met
-///    the current batch to be submitted. In other words, this task is the one that controls when a batch
-///    is to be posted.
+///   the current batch to be submitted. In other words, this task is the one that controls when a batch
+///   is to be posted.
 #[derive(Parser)]
 #[command(name = "Aligned Batcher")]
 #[command(about = "An application with server and client subcommands", long_about = None)]

--- a/batcher/aligned-batcher/src/types/batch_queue.rs
+++ b/batcher/aligned-batcher/src/types/batch_queue.rs
@@ -152,7 +152,7 @@ pub(crate) fn calculate_batch_size(batch_queue: &BatchQueue) -> Result<usize, Ba
 /// 1. Traverse each batch priority queue, starting from the one with minimum max fee.
 /// 2. Calculate the `fee_per_proof` for the whole batch and compare with the `max_fee` of the entry.
 /// 3. If `fee_per_proof` is less than the `max_fee` of the current entry, submit the batch. If not, pop this entry
-///     from the queue. then repeat step 1.
+///    from the queue. then repeat step 1.
 ///
 /// Returns the finalized batch.
 pub(crate) fn try_build_batch(

--- a/batcher/aligned-sdk/src/sdk.rs
+++ b/batcher/aligned-sdk/src/sdk.rs
@@ -115,7 +115,7 @@ pub async fn submit_multiple_and_wait_verification(
 /// To estimate the `max_fee` of a batch we compute it based on a batch size of 1 (Instant), 10 (Default), or a user supplied `number_proofs_in_batch` (Custom).
 /// The `max_fee` estimates therefore are:
 /// * `Default`: Specifies a `max_fee` equivalent to the cost of paying for one proof within a batch of 10 proofs i.e. 1 / 10 proofs.
-///        This estimates a default `max_fee` the user should specify for including there proof within the batch.
+///   This estimates a default `max_fee` the user should specify for including there proof within the batch.
 /// * `Instant`: Specifies a `max_fee` equivalent to the cost of paying for an entire batch ensuring the user's proof is included instantly assuming the proof is not competing with others for inclusion.
 /// * `Custom (number_proofs_in_batch)`: Specifies a `max_fee` equivalent to the cost of paying 1 proof / `number_proofs_in_batch` allowing the user a user to estimate the `max_fee` precisely based on the `number_proofs_in_batch`.
 ///


### PR DESCRIPTION
# Fix clippy indentation

## Description

Fix clippy indentation on code documentation

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
