### PR TITLE
fix: merkle tree and blob data exceeding BLS_MODULUS

### DIFF
--- a/aggregation_mode/src/backend/merkle_tree.rs
+++ b/aggregation_mode/src/backend/merkle_tree.rs
@@ -10,14 +10,7 @@ pub fn combine_hashes(hash_a: &[u8; 32], hash_b: &[u8; 32]) -> [u8; 32] {
 
 /// Returns (merkle_root, leaves)
 pub fn compute_proofs_merkle_root(proofs: &[AlignedProof]) -> ([u8; 32], Vec<[u8; 32]>) {
-    let leaves: Vec<[u8; 32]> = proofs
-        .chunks(2)
-        .map(|chunk| match chunk {
-            [a, b] => combine_hashes(&a.hash(), &b.hash()),
-            [a] => combine_hashes(&a.hash(), &a.hash()),
-            _ => panic!("Unexpected chunk leaves"),
-        })
-        .collect();
+    let leaves: Vec<[u8; 32]> = proofs.iter().map(|proof| proof.hash()).collect();
 
     let mut root = leaves.clone();
 

--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -4,8 +4,11 @@ mod merkle_tree;
 mod s3;
 mod types;
 
-use crate::aggregators::{lib::{AggregatedProof, ProofAggregationError}, sp1_aggregator::{aggregate_proofs, SP1AggregationInput}, AlignedProof, ZKVMEngine};
-
+use crate::aggregators::{
+    lib::{AggregatedProof, ProofAggregationError},
+    sp1_aggregator::{aggregate_proofs, SP1AggregationInput},
+    AlignedProof, ZKVMEngine,
+};
 
 use alloy::{
     consensus::{Blob, BlobTransactionSidecar},
@@ -24,7 +27,6 @@ use sp1_sdk::HashableKey;
 use std::str::FromStr;
 use tracing::{error, info, warn};
 use types::{AlignedProofAggregationService, AlignedProofAggregationServiceContract};
-
 
 #[derive(Debug)]
 pub enum AggregatedProofSubmissionError {
@@ -122,8 +124,7 @@ impl ProofAggregator {
                     merkle_root,
                 };
 
-                aggregate_proofs(input)
-                    .map_err(AggregatedProofSubmissionError::Aggregation)?
+                aggregate_proofs(input).map_err(AggregatedProofSubmissionError::Aggregation)?
             }
         };
         info!("Proof aggregation program finished");
@@ -184,8 +185,17 @@ impl ProofAggregator {
         let data: Vec<u8> = leaves.iter().flat_map(|arr| arr.iter().copied()).collect();
         let mut blob_data: [u8; BYTES_PER_BLOB] = [0u8; BYTES_PER_BLOB];
 
-        for (i, byte) in data.iter().enumerate() {
-            blob_data[i] = *byte;
+        // We pad the data with 0x0 byte every 31 bytes so that the field elements
+        // constructed from the bytes are less than BLS_MODULUS.
+        //
+        // See https://github.com/ethereum/consensus-specs/blob/86fb82b221474cc89387fa6436806507b3849d88/specs/deneb/polynomial-commitments.md#bytes_to_bls_field
+        let mut offset = 0;
+        for chunk in data.chunks(31) {
+            blob_data[offset] = 0x00;
+            let start = offset + 1;
+            let end = start + chunk.len();
+            blob_data[start..end].copy_from_slice(chunk);
+            offset += 32;
         }
 
         // calculate kzg commitments for blob


### PR DESCRIPTION
## Description

- Fixes the merkle tree which was not returning the actual leaves but the second layer.
- Fixes the construction of blob data: fields elements were exceeding the `BLS_MODULUS` of the `bls12-381`.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
