### PR TITLE
hotfix: add flag to use random addresses for proof_generator_addr in Aligned CLI

### DIFF
--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -111,11 +111,11 @@ do
     --proof "./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_${x}_groth16.proof" \
     --public_input "./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_${x}_groth16.pub" \
     --vk "./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/ineq_${x}_groth16.vk" \
-    --proof_generator_addr $SENDER_ADDRESS \
     --private_key $PRIVATE_KEY \
     --rpc_url $RPC_URL \
     --network $NETWORK \
     --max_fee 0.004ether \
+    --random_address \
     2>&1)
 
   echo "$submit"

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -540,8 +540,8 @@ async fn main() -> Result<(), AlignedError> {
             // If random_address flag is enabled, change every address with a random value
             if submit_args.random_address {
                 info!("Randomizing proof generator address for each proof...");
-                for i in 0..repetitions {
-                    verification_data_arr[i].proof_generator_addr = Address::random();
+                for verification_data in verification_data_arr.iter_mut() {
+                    verification_data.proof_generator_addr = Address::random();
                 }
             }
 

--- a/batcher/aligned/src/main.rs
+++ b/batcher/aligned/src/main.rs
@@ -88,42 +88,61 @@ pub struct SubmitArgs {
         default_value = "http://localhost:8545"
     )]
     eth_rpc_url: String,
+
     #[arg(name = "Proving system", long = "proving_system")]
     proving_system_flag: ProvingSystemArg,
+
     #[arg(name = "Proof file path", long = "proof")]
     proof_file_name: PathBuf,
+
     #[arg(name = "Public input file name", long = "public_input")]
     pub_input_file_name: Option<PathBuf>,
+
     #[arg(name = "Verification key file name", long = "vk")]
     verification_key_file_name: Option<PathBuf>,
+
     #[arg(name = "VM prgram code file name", long = "vm_program")]
     vm_program_code_file_name: Option<PathBuf>,
+
     #[arg(
         name = "Number of repetitions",
         long = "repetitions",
         default_value = "1"
     )]
     repetitions: usize,
+
     #[arg(
         name = "Proof generator address",
         long = "proof_generator_addr",
         default_value = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
     )] // defaults to anvil address 1
     proof_generator_addr: String,
+
     #[arg(
         name = "Aligned verification data directory Path",
         long = "aligned_verification_data_path",
         default_value = "./aligned_verification_data/"
     )]
     batch_inclusion_data_directory_path: String,
+
     #[command(flatten)]
     private_key_type: PrivateKeyType,
+
     #[arg(name = "Nonce", long = "nonce")]
     nonce: Option<String>, // String because U256 expects hex
+
     #[clap(flatten)]
     network: NetworkArg,
+
     #[command(flatten)]
     fee_type: FeeType,
+
+    #[arg(
+        name = "Random Address",
+        long = "random_address",
+        default_value = "false"
+    )]
+    random_address: bool,
 }
 
 impl SubmitArgs {
@@ -516,7 +535,15 @@ async fn main() -> Result<(), AlignedError> {
 
             let verification_data = verification_data_from_args(&submit_args)?;
 
-            let verification_data_arr = vec![verification_data; repetitions];
+            let mut verification_data_arr = vec![verification_data; repetitions];
+
+            // If random_address flag is enabled, change every address with a random value
+            if submit_args.random_address {
+                info!("Randomizing proof generator address for each proof...");
+                for i in 0..repetitions {
+                    verification_data_arr[i].proof_generator_addr = Address::random();
+                }
+            }
 
             info!("Submitting proofs to the Aligned batcher...");
 

--- a/docs/3_guides/9_aligned_cli.md
+++ b/docs/3_guides/9_aligned_cli.md
@@ -86,7 +86,8 @@ Submit a proof to the Aligned Layer batcher.
   - `--default_fee_estimate`: Specifies a `max_fee` equivalent to the cost of 1 proof in a batch of size 10.
   - `--instant_fee_estimate`: Specifies a `max_fee` that ensures the proof is included instantly, equivalent to the cost of a proof in a batch of size 1.
   - `--custom_fee_estimate <amount_of_proofs_in_batch>`: Specifies a `max_fee` equivalent to the cost of 1 proof in a batch of size `num_proofs_in_batch`.
-
+- `random_address`: If set, random addresses will be used as `proof_generator_addr` for each proof.  
+  - Default: `false`
 
 #### Example:
 


### PR DESCRIPTION
# Add flag to use random addresses for proof_generator_addr in Aligned CLI

## Description

This PR adds a flag to set every proof_generator_address with a random value. 

## How to test

Run aligned fast mode

1. `make anvil_start_with_block_time`
2. `make aggregator_start`
3. `make operator_full_registration CONFIG_FILE=config-files/config-operator-1.yaml` 
4. `make operator_start CONFIG_FILE=config-files/config-operator-1.yaml`
5. `make batcher_start_local`
6. `make install_aligned_compiling`

Once you have the system running, send proofs using the following command

```
rm -rf ./aligned_verification_data/ &&
aligned submit \
--proving_system GnarkPlonkBn254 \
--proof ./scripts/test_files/gnark_plonk_bn254_script/plonk.proof \
--public_input ./scripts/test_files/gnark_plonk_bn254_script/plonk_pub_input.pub \
--vk ./scripts/test_files/gnark_plonk_bn254_script/plonk.vk \
--network devnet \
--rpc_url http://localhost:8545 \
--random_address \
--repetitions 8
```

Once you the batch has been sent, send a new batch of proof using the same command

You should see that there were created two batches with the same amount of proofs with different merkle roots

## Type of change

- [x] Bug fix

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
