### PR TITLE
1853 fix use  -z instead of  eq when checking if variable is empty

### DIFF
--- a/scripts/fund_operator_devnet.sh
+++ b/scripts/fund_operator_devnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Check that OPERATOR_ADDRESS is not empty
-if [[ "$OPERATOR_ADDRESS" -eq "" ]]; then
+if [[ -z "$OPERATOR_ADDRESS" ]]; then
   echo "OPERATOR_ADDRESS is empty, using default value 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
   OPERATOR_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 fi;

--- a/scripts/mint_mock_token.sh
+++ b/scripts/mint_mock_token.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # check that OPERATOR_ADDRESS is not empty
-if [[ "$OPERATOR_ADDRESS" -eq "" ]]; then
+if [[ -z "$OPERATOR_ADDRESS" ]]; then
   echo "OPERATOR_ADDRESS is empty, using default value 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
   OPERATOR_ADDRESS="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 fi;
@@ -17,7 +17,7 @@ mock_token_address=$(cast call "$mock_strategy_address" "underlyingToken()")
 
 operator_address=$(cat "$1" | yq -r '.operator.address')
 
-if [[ "$mock_token_address" -eq "" ]]; then
+if [[-z  "$mock_token_address" ]]; then
   echo "Mock token address is empty, please deploy the contracts first"
   exit 1
 fi;

--- a/scripts/user_fund_payment_service_devnet.sh
+++ b/scripts/user_fund_payment_service_devnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Check that OPERATOR_ADDRESS is not empty
-if [[ "$USER_ADDRESS" -eq "" ]]; then
+if [[ -z "$USER_ADDRESS" ]]; then
   echo "USER_ADDRESS is empty, using default value 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
   USER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
   USER_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80


### PR DESCRIPTION
# fix use -z instead of  -eq when checking if variable is empty

## Description

Based in #1807 

Incorrect use of -eq comparison when checking if variable is empty

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
