### PR TITLE
modify anvil_start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,13 +140,9 @@ lint_contracts:
 
 anvil_start:
 	@echo "Starting Anvil..."
-	anvil --load-state contracts/scripts/anvil/state/alignedlayer-deployed-anvil-state.json
-
-anvil_start_with_block_time:
-	@echo "Starting Anvil..."
 	anvil --load-state contracts/scripts/anvil/state/alignedlayer-deployed-anvil-state.json --block-time 7
 
-anvil_start_with_block_time_with_more_prefunded_accounts:
+anvil_start_with_more_prefunded_accounts:
 	@echo "Starting Anvil..."
 	anvil --load-state contracts/scripts/anvil/state/alignedlayer-deployed-anvil-state.json --block-time 7 -a 2000
 

--- a/Makefile
+++ b/Makefile
@@ -1150,7 +1150,7 @@ setup_local_aligned_all:
 	tmux new-session -d -s aligned_layer
 
 	tmux new-window -t aligned_layer -n anvil
-	tmux send-keys -t aligned_layer 'make anvil_start_with_block_time' C-m
+	tmux send-keys -t aligned_layer 'make anvil_start' C-m
 
 	tmux new-window -t aligned_layer -n aggregator
 	tmux send-keys -t aligned_layer:aggregator 'make aggregator_start' C-m

--- a/batcher/aligned-task-sender/README.md
+++ b/batcher/aligned-task-sender/README.md
@@ -42,7 +42,7 @@ NUM_WALLETS=<N> make task_sender_generate_and_fund_wallets_holesky_stage
 ### In Devnet:
 Run anvil with more prefunded accounts, using the following make target:
 ```bash
-make anvil_start_with_more_prefunded
+make anvil_start_with_more_prefunded_accounts
 ```
 
 Then run the following make target, with `NUM_WALLETS` being the amount of wallets you want to deposit funds to aligned payment service, up to 1000.

--- a/batcher/aligned-task-sender/README.md
+++ b/batcher/aligned-task-sender/README.md
@@ -42,7 +42,7 @@ NUM_WALLETS=<N> make task_sender_generate_and_fund_wallets_holesky_stage
 ### In Devnet:
 Run anvil with more prefunded accounts, using the following make target:
 ```bash
-make anvil_start_with_block_time_with_more_prefunded
+make anvil_start_with_more_prefunded
 ```
 
 Then run the following make target, with `NUM_WALLETS` being the amount of wallets you want to deposit funds to aligned payment service, up to 1000.

--- a/docs/3_guides/6_setup_aligned.md
+++ b/docs/3_guides/6_setup_aligned.md
@@ -33,7 +33,7 @@ This will:
 To start anvil, a local Ethereum devnet with all necessary contracts already deployed and ready to be interacted with, run:
 
 ```shell
-make anvil_start_with_block_time
+make anvil_start
 ```
 
 <details>


### PR DESCRIPTION
# Modify make anvil_start command

## Description

Changed the make command to start with a block time of 7.

## Type of change

Please delete options that are not relevant.

- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
