### PR TITLE
refactor: agg mode

### DIFF
--- a/aggregation_mode/aggregation_programs/sp1/src/lib.rs
+++ b/aggregation_mode/aggregation_programs/sp1/src/lib.rs
@@ -2,12 +2,12 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
 #[derive(Serialize, Deserialize)]
-pub struct SP1ProofInput {
+pub struct SP1VkAndPubInputs {
     pub vk: [u32; 8],
     pub public_inputs: Vec<u8>,
 }
 
-impl SP1ProofInput {
+impl SP1VkAndPubInputs {
     pub fn hash(&self) -> [u8; 32] {
         let mut hasher = Keccak256::new();
         for &word in &self.vk {
@@ -19,20 +19,20 @@ impl SP1ProofInput {
 }
 
 #[derive(Serialize, Deserialize)]
-pub enum ProofInput {
-    SP1Compressed(SP1ProofInput),
+pub enum ProofDataInput {
+    SP1Compressed(SP1VkAndPubInputs),
 }
 
-impl ProofInput {
+impl ProofDataInput {
     pub fn hash(&self) -> [u8; 32] {
         match self {
-            ProofInput::SP1Compressed(proof) => proof.hash(),
+            ProofDataInput::SP1Compressed(proof_data) => proof_data.hash(),
         }
     }
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct Input {
-    pub proofs: Vec<ProofInput>,
+    pub proofs_data: Vec<ProofDataInput>,
     pub merkle_root: [u8; 32],
 }

--- a/aggregation_mode/aggregation_programs/sp1/src/lib.rs
+++ b/aggregation_mode/aggregation_programs/sp1/src/lib.rs
@@ -19,20 +19,20 @@ impl SP1VkAndPubInputs {
 }
 
 #[derive(Serialize, Deserialize)]
-pub enum ProofDataInput {
+pub enum ProofVkAndPubInputs {
     SP1Compressed(SP1VkAndPubInputs),
 }
 
-impl ProofDataInput {
+impl ProofVkAndPubInputs {
     pub fn hash(&self) -> [u8; 32] {
         match self {
-            ProofDataInput::SP1Compressed(proof_data) => proof_data.hash(),
+            ProofVkAndPubInputs::SP1Compressed(proof_data) => proof_data.hash(),
         }
     }
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct Input {
-    pub proofs_data: Vec<ProofDataInput>,
+    pub proofs_vk_and_pub_inputs: Vec<ProofVkAndPubInputs>,
     pub merkle_root: [u8; 32],
 }

--- a/aggregation_mode/aggregation_programs/sp1/src/lib.rs
+++ b/aggregation_mode/aggregation_programs/sp1/src/lib.rs
@@ -11,7 +11,7 @@ impl SP1VkAndPubInputs {
     pub fn hash(&self) -> [u8; 32] {
         let mut hasher = Keccak256::new();
         for &word in &self.vk {
-            hasher.update(word.to_le_bytes());
+            hasher.update(word.to_be_bytes());
         }
         hasher.update(&self.public_inputs);
         hasher.finalize().into()

--- a/aggregation_mode/aggregation_programs/sp1/src/main.rs
+++ b/aggregation_mode/aggregation_programs/sp1/src/main.rs
@@ -3,7 +3,7 @@ sp1_zkvm::entrypoint!(main);
 
 use sha2::{Digest, Sha256};
 use sha3::Keccak256;
-use sp1_aggregation_program::{Input, ProofInput};
+use sp1_aggregation_program::{Input, ProofDataInput};
 
 fn combine_hashes(hash_a: &[u8; 32], hash_b: &[u8; 32]) -> [u8; 32] {
     let mut hasher = Keccak256::new();
@@ -13,7 +13,7 @@ fn combine_hashes(hash_a: &[u8; 32], hash_b: &[u8; 32]) -> [u8; 32] {
 }
 
 /// Computes the merkle root for the given proofs using the vk
-fn compute_merkle_root(proofs: &[ProofInput]) -> [u8; 32] {
+fn compute_merkle_root(proofs: &[ProofDataInput]) -> [u8; 32] {
     let mut leaves: Vec<[u8; 32]> = proofs
         .chunks(2)
         .map(|chunk| match chunk {
@@ -41,9 +41,9 @@ pub fn main() {
     let input = sp1_zkvm::io::read::<Input>();
 
     // Verify the proofs.
-    for proof in input.proofs.iter() {
+    for proof in input.proofs_data.iter() {
         match proof {
-            ProofInput::SP1Compressed(proof) => {
+            ProofDataInput::SP1Compressed(proof) => {
                 let vkey = proof.vk;
                 let public_values = &proof.public_inputs;
                 let public_values_digest = Sha256::digest(public_values);
@@ -52,7 +52,7 @@ pub fn main() {
         }
     }
 
-    let merkle_root = compute_merkle_root(&input.proofs);
+    let merkle_root = compute_merkle_root(&input.proofs_data);
 
     assert_eq!(merkle_root, input.merkle_root);
 

--- a/aggregation_mode/aggregation_programs/sp1/src/main.rs
+++ b/aggregation_mode/aggregation_programs/sp1/src/main.rs
@@ -3,7 +3,7 @@ sp1_zkvm::entrypoint!(main);
 
 use sha2::{Digest, Sha256};
 use sha3::Keccak256;
-use sp1_aggregation_program::{Input, ProofDataInput};
+use sp1_aggregation_program::{Input, ProofVkAndPubInputs};
 
 fn combine_hashes(hash_a: &[u8; 32], hash_b: &[u8; 32]) -> [u8; 32] {
     let mut hasher = Keccak256::new();
@@ -13,7 +13,7 @@ fn combine_hashes(hash_a: &[u8; 32], hash_b: &[u8; 32]) -> [u8; 32] {
 }
 
 /// Computes the merkle root for the given proofs using the vk
-fn compute_merkle_root(proofs: &[ProofDataInput]) -> [u8; 32] {
+fn compute_merkle_root(proofs: &[ProofVkAndPubInputs]) -> [u8; 32] {
     let mut leaves: Vec<[u8; 32]> = proofs
         .chunks(2)
         .map(|chunk| match chunk {
@@ -41,9 +41,9 @@ pub fn main() {
     let input = sp1_zkvm::io::read::<Input>();
 
     // Verify the proofs.
-    for proof in input.proofs_data.iter() {
+    for proof in input.proofs_vk_and_pub_inputs.iter() {
         match proof {
-            ProofDataInput::SP1Compressed(proof) => {
+            ProofVkAndPubInputs::SP1Compressed(proof) => {
                 let vkey = proof.vk;
                 let public_values = &proof.public_inputs;
                 let public_values_digest = Sha256::digest(public_values);
@@ -52,7 +52,7 @@ pub fn main() {
         }
     }
 
-    let merkle_root = compute_merkle_root(&input.proofs_data);
+    let merkle_root = compute_merkle_root(&input.proofs_vk_and_pub_inputs);
 
     assert_eq!(merkle_root, input.merkle_root);
 

--- a/aggregation_mode/src/aggregators/sp1_aggregator.rs
+++ b/aggregation_mode/src/aggregators/sp1_aggregator.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
 use alloy::primitives::Keccak256;
-use sp1_aggregation_program::{ProofInput, SP1ProofInput};
+use sp1_aggregation_program::{ProofDataInput, SP1VkAndPubInputs};
 use sp1_sdk::{
     EnvProver, HashableKey, Prover, ProverClient, SP1ProofWithPublicValues, SP1Stdin,
     SP1VerifyingKey,
@@ -45,15 +45,15 @@ pub(crate) fn aggregate_proofs(
     let mut stdin = SP1Stdin::new();
 
     let mut program_input = sp1_aggregation_program::Input {
-        proofs: vec![],
+        proofs_data: vec![],
         merkle_root: input.merkle_root,
     };
 
     // write vk + public inputs
     for proof in input.proofs.iter() {
         program_input
-            .proofs
-            .push(ProofInput::SP1Compressed(SP1ProofInput {
+            .proofs_data
+            .push(ProofDataInput::SP1Compressed(SP1VkAndPubInputs {
                 public_inputs: proof.proof_with_pub_values.public_values.to_vec(),
                 vk: proof.vk().hash_u32(),
             }));

--- a/aggregation_mode/src/aggregators/sp1_aggregator.rs
+++ b/aggregation_mode/src/aggregators/sp1_aggregator.rs
@@ -22,9 +22,8 @@ pub struct SP1ProofWithPubValuesAndElf {
 impl SP1ProofWithPubValuesAndElf {
     pub fn hash_vk_and_pub_inputs(&self) -> [u8; 32] {
         let mut hasher = Keccak256::new();
-        for &word in &self.vk().hash_u32() {
-            hasher.update(word.to_le_bytes());
-        }
+        let vk_bytes = &self.vk().hash_bytes();
+        hasher.update(vk_bytes);
         hasher.update(self.proof_with_pub_values.public_values.as_slice());
         hasher.finalize().into()
     }

--- a/aggregation_mode/src/aggregators/sp1_aggregator.rs
+++ b/aggregation_mode/src/aggregators/sp1_aggregator.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
 use alloy::primitives::Keccak256;
-use sp1_aggregation_program::{ProofDataInput, SP1VkAndPubInputs};
+use sp1_aggregation_program::{ProofVkAndPubInputs, SP1VkAndPubInputs};
 use sp1_sdk::{
     EnvProver, HashableKey, Prover, ProverClient, SP1ProofWithPublicValues, SP1Stdin,
     SP1VerifyingKey,
@@ -44,15 +44,15 @@ pub(crate) fn aggregate_proofs(
     let mut stdin = SP1Stdin::new();
 
     let mut program_input = sp1_aggregation_program::Input {
-        proofs_data: vec![],
+        proofs_vk_and_pub_inputs: vec![],
         merkle_root: input.merkle_root,
     };
 
     // write vk + public inputs
     for proof in input.proofs.iter() {
         program_input
-            .proofs_data
-            .push(ProofDataInput::SP1Compressed(SP1VkAndPubInputs {
+            .proofs_vk_and_pub_inputs
+            .push(ProofVkAndPubInputs::SP1Compressed(SP1VkAndPubInputs {
                 public_inputs: proof.proof_with_pub_values.public_values.to_vec(),
                 vk: proof.vk().hash_u32(),
             }));

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -17,8 +17,8 @@ use tracing::{error, info};
 
 #[derive(Debug)]
 pub enum ProofsFetcherError {
-    QueryingLogs,
-    BlockNumber,
+    GetLogs(String),
+    GetBlockNumber(String),
 }
 
 pub struct ProofsFetcher {
@@ -59,7 +59,7 @@ impl ProofsFetcher {
             .from_block(from_block)
             .query()
             .await
-            .map_err(|_| ProofsFetcherError::QueryingLogs)?;
+            .map_err(|e| ProofsFetcherError::GetLogs(e.to_string()))?;
 
         info!("Logs collected {}", logs.len());
 
@@ -124,7 +124,7 @@ impl ProofsFetcher {
             .rpc_provider
             .get_block_number()
             .await
-            .map_err(|_| ProofsFetcherError::BlockNumber)?;
+            .map_err(|e| ProofsFetcherError::GetBlockNumber(e.to_string()))?;
 
         let number_of_blocks_in_the_past = self.fetch_from_secs_ago / self.block_time_secs;
 

--- a/aggregation_mode/src/backend/s3.rs
+++ b/aggregation_mode/src/backend/s3.rs
@@ -2,11 +2,11 @@ use aligned_sdk::core::types::VerificationData;
 
 #[derive(Debug)]
 pub enum GetBatchProofsError {
-    Fetching,
-    Deserialization,
-    EmptyBody,
-    StatusFailed,
-    ReqwestClientFailed,
+    FetchingS3Batch(String),
+    Deserialization(String),
+    EmptyBody(String),
+    StatusFailed(String),
+    ReqwestClientFailed((u16, String)),
 }
 
 // needed to make S3 bucket work
@@ -18,25 +18,28 @@ pub async fn get_aligned_batch_from_s3(
     let client = reqwest::Client::builder()
         .user_agent(DEFAULT_USER_AGENT)
         .build()
-        .map_err(|_| GetBatchProofsError::ReqwestClientFailed)?;
+        .map_err(|e| GetBatchProofsError::ReqwestClientFailed(e.to_string()))?;
 
     let response = client
         .get(url)
         .send()
         .await
-        .map_err(|_| GetBatchProofsError::Fetching)?;
+        .map_err(|e| GetBatchProofsError::FetchingS3Batch(e.to_string()))?;
     if !response.status().is_success() {
-        return Err(GetBatchProofsError::StatusFailed);
+        return Err(GetBatchProofsError::StatusFailed((
+            response.status().as_u16(),
+            response.status().canonical_reason(),
+        )));
     }
 
     let bytes = response
         .bytes()
         .await
-        .map_err(|_| GetBatchProofsError::EmptyBody)?;
+        .map_err(|e| GetBatchProofsError::EmptyBody(e.to_string()))?;
     let bytes: &[u8] = bytes.iter().as_slice();
 
-    let data: Vec<VerificationData> =
-        ciborium::from_reader(bytes).map_err(|_| GetBatchProofsError::Deserialization)?;
+    let data: Vec<VerificationData> = ciborium::from_reader(bytes)
+        .map_err(|e| GetBatchProofsError::Deserialization(e.to_string()))?;
 
     Ok(data)
 }

--- a/aggregation_mode/src/backend/s3.rs
+++ b/aggregation_mode/src/backend/s3.rs
@@ -1,12 +1,13 @@
 use aligned_sdk::core::types::VerificationData;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum GetBatchProofsError {
     FetchingS3Batch(String),
     Deserialization(String),
     EmptyBody(String),
-    StatusFailed(String),
-    ReqwestClientFailed((u16, String)),
+    StatusFailed((u16, String)),
+    ReqwestClientFailed(String),
 }
 
 // needed to make S3 bucket work
@@ -28,7 +29,11 @@ pub async fn get_aligned_batch_from_s3(
     if !response.status().is_success() {
         return Err(GetBatchProofsError::StatusFailed((
             response.status().as_u16(),
-            response.status().canonical_reason(),
+            response
+                .status()
+                .canonical_reason()
+                .unwrap_or("")
+                .to_string(),
         )));
     }
 


### PR DESCRIPTION
## Description

Various refactors for the aggregation:
- Updated error enums to include descriptive error messages.
- Renamed `sp1_aggregator` structs to use more explicit and descriptive names that better reflect their purpose and contents.
- Updated the hash implementation in the to use sp1 built-in `hash_bytes` function. This eliminates the conversion from u32 to u8. This required us to update the hash in the `sp1_aggregator` program to convert `u32` to `u8` in big endian instead of little endian. This change is especially useful for sdk users, as it abstracts away internal details of the vk hashing, which they have to provide when trying to verify proof inclusion in agg mode. 



## Type of change

- [x] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
