### PR TITLE
feat(aggregation_mode): save last processed block in a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ batcher/aligned/batch_inclusion_responses/*
 **/broadcast
 volume
 config-files/*.last_processed_batch.json
+config-files/*.last_processed_block.json
 
 nonce_*.bin
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ batcher/aligned/batch_inclusion_responses/*
 **/broadcast
 volume
 config-files/*.last_processed_batch.json
-config-files/*.last_processed_block.json
+config-files/*.last_aggregated_block.json
 
 nonce_*.bin
 

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -52,7 +52,7 @@ impl Config {
         last_processed_block: u64,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let last_processed_block_struct = LastProcessedBlock {
-            last_processed_block: last_processed_block,
+            last_processed_block,
         };
 
         let mut file = OpenOptions::new()

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -8,8 +8,8 @@ pub struct ECDSAConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct LastProcessedBlock {
-    pub last_processed_block: u64,
+pub struct LastAggregatedBlock {
+    pub last_aggregated_block: u64,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -19,7 +19,7 @@ pub struct Config {
     pub max_proofs_in_queue: u16,
     pub proof_aggregation_service_address: String,
     pub aligned_service_manager_address: String,
-    pub last_processed_block_filepath: String,
+    pub last_aggregated_block_filepath: String,
     pub ecdsa: ECDSAConfig,
 }
 
@@ -32,8 +32,8 @@ impl Config {
         Ok(config)
     }
 
-    pub fn get_last_processed_block(&self) -> Result<u64, Box<dyn std::error::Error>> {
-        match File::open(&self.last_processed_block_filepath) {
+    pub fn get_last_aggregated_block(&self) -> Result<u64, Box<dyn std::error::Error>> {
+        match File::open(&self.last_aggregated_block_filepath) {
             Err(_) => {
                 // if file doesn't exist, default 0
                 Ok(0)
@@ -41,25 +41,25 @@ impl Config {
             Ok(mut file) => {
                 let mut contents = String::new();
                 file.read_to_string(&mut contents)?;
-                let lpb: LastProcessedBlock = serde_json::from_str(&contents)?;
-                Ok(lpb.last_processed_block)
+                let lpb: LastAggregatedBlock = serde_json::from_str(&contents)?;
+                Ok(lpb.last_aggregated_block)
             }
         }
     }
 
-    pub fn update_last_processed_block(
+    pub fn update_last_aggregated_block(
         &self,
-        last_processed_block: u64,
+        last_aggregated_block: u64,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let last_processed_block_struct = LastProcessedBlock {
-            last_processed_block,
+        let last_processed_block_struct = LastAggregatedBlock {
+            last_aggregated_block,
         };
 
         let mut file = OpenOptions::new()
             .write(true)
             .truncate(true)
             .create(true)
-            .open(&self.last_processed_block_filepath)?;
+            .open(&self.last_aggregated_block_filepath)?;
 
         let content = serde_json::to_string(&last_processed_block_struct)?;
         file.write_all(content.as_bytes())?;

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -1,21 +1,21 @@
-use serde::Deserialize;
-use std::{fs::File, io::Read};
+use serde::{Deserialize, Serialize};
+use std::{fs::File, fs::OpenOptions, io::Read, io::Write};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ECDSAConfig {
     pub private_key_store_path: String,
     pub private_key_store_password: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub eth_rpc_url: String,
     pub eth_ws_url: String,
     pub max_proofs_in_queue: u16,
     pub proof_aggregation_service_address: String,
     pub aligned_service_manager_address: String,
+    pub last_processed_block: u64,
     pub ecdsa: ECDSAConfig,
-    pub last_processed_block: u64
 }
 
 impl Config {
@@ -25,5 +25,12 @@ impl Config {
         file.read_to_string(&mut contents)?;
         let config: Config = serde_yaml::from_str(&contents)?;
         Ok(config)
+    }
+
+    pub fn save_to_file(&self, file_path: &str) -> Result<(), Box<dyn std::error::Error>>  {
+        let mut file = OpenOptions::new().write(true).truncate(true).open(file_path)?;
+        let content = serde_yaml::to_string(&self)?;
+        file.write_all(content.as_bytes())?;
+        Ok(())
     }
 }

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -33,18 +33,11 @@ impl Config {
     }
 
     pub fn get_last_aggregated_block(&self) -> Result<u64, Box<dyn std::error::Error>> {
-        match File::open(&self.last_aggregated_block_filepath) {
-            Err(_) => {
-                // if file doesn't exist, default 0
-                Ok(0)
-            }
-            Ok(mut file) => {
-                let mut contents = String::new();
-                file.read_to_string(&mut contents)?;
-                let lpb: LastAggregatedBlock = serde_json::from_str(&contents)?;
-                Ok(lpb.last_aggregated_block)
-            }
-        }
+        let mut file = File::open(&self.last_aggregated_block_filepath)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let lpb: LastAggregatedBlock = serde_json::from_str(&contents)?;
+        Ok(lpb.last_aggregated_block)
     }
 
     pub fn update_last_aggregated_block(

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -8,13 +8,18 @@ pub struct ECDSAConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct LastProcessedBlock {
+    pub last_processed_block: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub eth_rpc_url: String,
     pub eth_ws_url: String,
     pub max_proofs_in_queue: u16,
     pub proof_aggregation_service_address: String,
     pub aligned_service_manager_address: String,
-    pub last_processed_block: u64,
+    pub last_processed_block_filepath: String,
     pub ecdsa: ECDSAConfig,
 }
 
@@ -27,13 +32,30 @@ impl Config {
         Ok(config)
     }
 
-    pub fn save_to_file(&self, file_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn get_last_processed_block(&self) -> Result<u64, Box<dyn std::error::Error>> {
+        let mut file = File::open(&self.last_processed_block_filepath)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let lpb: LastProcessedBlock = serde_json::from_str(&contents)?;
+        Ok(lpb.last_processed_block)
+    }
+
+    pub fn update_last_processed_block(
+        &self,
+        last_processed_block: u64,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let last_processed_block_struct = LastProcessedBlock {
+            last_processed_block: last_processed_block,
+        };
+
         let mut file = OpenOptions::new()
             .write(true)
             .truncate(true)
-            .open(file_path)?;
-        let content = serde_yaml::to_string(&self)?;
+            .open(&self.last_processed_block_filepath)?;
+
+        let content = serde_json::to_string(&last_processed_block_struct)?;
         file.write_all(content.as_bytes())?;
+
         Ok(())
     }
 }

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -36,15 +36,15 @@ impl Config {
         let mut file = File::open(&self.last_aggregated_block_filepath)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        let lpb: LastAggregatedBlock = serde_json::from_str(&contents)?;
-        Ok(lpb.last_aggregated_block)
+        let lab: LastAggregatedBlock = serde_json::from_str(&contents)?;
+        Ok(lab.last_aggregated_block)
     }
 
     pub fn update_last_aggregated_block(
         &self,
         last_aggregated_block: u64,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let last_processed_block_struct = LastAggregatedBlock {
+        let last_aggregated_block_struct = LastAggregatedBlock {
             last_aggregated_block,
         };
 
@@ -54,7 +54,7 @@ impl Config {
             .create(true)
             .open(&self.last_aggregated_block_filepath)?;
 
-        let content = serde_json::to_string(&last_processed_block_struct)?;
+        let content = serde_json::to_string(&last_aggregated_block_struct)?;
         file.write_all(content.as_bytes())?;
 
         Ok(())

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -33,11 +33,18 @@ impl Config {
     }
 
     pub fn get_last_processed_block(&self) -> Result<u64, Box<dyn std::error::Error>> {
-        let mut file = File::open(&self.last_processed_block_filepath)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-        let lpb: LastProcessedBlock = serde_json::from_str(&contents)?;
-        Ok(lpb.last_processed_block)
+        match File::open(&self.last_processed_block_filepath) {
+            Err(_) =>{
+                // if file doesn't exist, default 0
+                Ok(0)
+            }
+            Ok(mut file) => {
+                let mut contents = String::new();
+                file.read_to_string(&mut contents)?;
+                let lpb: LastProcessedBlock = serde_json::from_str(&contents)?;
+                Ok(lpb.last_processed_block)
+            }
+        } 
     }
 
     pub fn update_last_processed_block(
@@ -51,6 +58,7 @@ impl Config {
         let mut file = OpenOptions::new()
             .write(true)
             .truncate(true)
+            .create(true)
             .open(&self.last_processed_block_filepath)?;
 
         let content = serde_json::to_string(&last_processed_block_struct)?;

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -34,7 +34,7 @@ impl Config {
 
     pub fn get_last_processed_block(&self) -> Result<u64, Box<dyn std::error::Error>> {
         match File::open(&self.last_processed_block_filepath) {
-            Err(_) =>{
+            Err(_) => {
                 // if file doesn't exist, default 0
                 Ok(0)
             }
@@ -44,7 +44,7 @@ impl Config {
                 let lpb: LastProcessedBlock = serde_json::from_str(&contents)?;
                 Ok(lpb.last_processed_block)
             }
-        } 
+        }
     }
 
     pub fn update_last_processed_block(

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -27,8 +27,11 @@ impl Config {
         Ok(config)
     }
 
-    pub fn save_to_file(&self, file_path: &str) -> Result<(), Box<dyn std::error::Error>>  {
-        let mut file = OpenOptions::new().write(true).truncate(true).open(file_path)?;
+    pub fn save_to_file(&self, file_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(file_path)?;
         let content = serde_yaml::to_string(&self)?;
         file.write_all(content.as_bytes())?;
         Ok(())

--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -15,8 +15,7 @@ pub struct Config {
     pub proof_aggregation_service_address: String,
     pub aligned_service_manager_address: String,
     pub ecdsa: ECDSAConfig,
-    pub fetch_logs_from_secs_ago: u64,
-    pub block_time_secs: u64,
+    pub last_processed_block: u64
 }
 
 impl Config {

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -24,8 +24,7 @@ pub enum ProofsFetcherError {
 pub struct ProofsFetcher {
     rpc_provider: RPCProvider,
     aligned_service_manager: AlignedLayerServiceManagerContract,
-    fetch_from_secs_ago: u64,
-    block_time_secs: u64,
+    last_processed_block: u64
 }
 
 impl ProofsFetcher {
@@ -41,27 +40,37 @@ impl ProofsFetcher {
         Self {
             rpc_provider,
             aligned_service_manager,
-            fetch_from_secs_ago: config.fetch_logs_from_secs_ago,
-            block_time_secs: config.block_time_secs,
+            last_processed_block: config.last_processed_block,
         }
     }
 
     pub async fn fetch(&self) -> Result<Vec<AlignedProof>, ProofsFetcherError> {
-        let from_block = self.get_block_number_to_fetch_from().await?;
         info!(
             "Fetching proofs from batch logs starting from block number {}",
-            from_block
+            self.last_processed_block
         );
         // Subscribe to NewBatch event from AlignedServiceManager
         let logs = self
             .aligned_service_manager
             .NewBatchV3_filter()
-            .from_block(from_block)
+            .from_block(self.last_processed_block)
             .query()
             .await
             .map_err(|_| ProofsFetcherError::QueryingLogs)?;
 
         info!("Logs collected {}", logs.len());
+
+        // Get current block
+        self.last_processed_block = self
+            .rpc_provider
+            .get_block_number()
+            .await
+            .map_err(|_| ProofsFetcherError::BlockNumber)?;
+
+        info!(
+            "Fetched proofs from batch logs upto  block number {}",
+            self.last_processed_block
+        );
 
         let mut proofs = vec![];
 
@@ -126,8 +135,6 @@ impl ProofsFetcher {
             .await
             .map_err(|_| ProofsFetcherError::BlockNumber)?;
 
-        let number_of_blocks_in_the_past = self.fetch_from_secs_ago / self.block_time_secs;
-
-        Ok(block_number.saturating_sub(number_of_blocks_in_the_past))
+        Ok(block_number.saturating_sub(self.last_processed_block))
     }
 }

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -42,7 +42,7 @@ impl ProofsFetcher {
         Self {
             rpc_provider,
             aligned_service_manager,
-            last_processed_block: last_processed_block,
+            last_processed_block,
         }
     }
 

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -37,10 +37,12 @@ impl ProofsFetcher {
             rpc_provider.clone(),
         );
 
+        let last_processed_block = config.get_last_processed_block().unwrap();
+
         Self {
             rpc_provider,
             aligned_service_manager,
-            last_processed_block: config.last_processed_block,
+            last_processed_block: last_processed_block,
         }
     }
 

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -128,4 +128,8 @@ impl ProofsFetcher {
 
         Ok(proofs)
     }
+
+    pub fn get_last_processed_block(&self) -> u64 {
+        self.last_processed_block
+    }
 }

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -52,10 +52,10 @@ impl ProofsFetcher {
             .rpc_provider
             .get_block_number()
             .await
-            .map_err(|_| ProofsFetcherError::BlockNumber)?;
+            .map_err(|e| ProofsFetcherError::GetBlockNumber(e.to_string()))?;
 
         if current_block < self.last_processed_block {
-            return Err(ProofsFetcherError::BlockNumber);
+            return Err(ProofsFetcherError::GetBlockNumber("Invalid last processed block".to_string()));
         }
 
         info!(

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -24,7 +24,7 @@ pub enum ProofsFetcherError {
 pub struct ProofsFetcher {
     rpc_provider: RPCProvider,
     aligned_service_manager: AlignedLayerServiceManagerContract,
-    last_processed_block: u64,
+    last_aggregated_block: u64,
 }
 
 impl ProofsFetcher {
@@ -37,12 +37,12 @@ impl ProofsFetcher {
             rpc_provider.clone(),
         );
 
-        let last_processed_block = config.get_last_processed_block().unwrap();
+        let last_aggregated_block = config.get_last_aggregated_block().unwrap();
 
         Self {
             rpc_provider,
             aligned_service_manager,
-            last_processed_block,
+            last_aggregated_block,
         }
     }
 
@@ -54,7 +54,7 @@ impl ProofsFetcher {
             .await
             .map_err(|e| ProofsFetcherError::GetBlockNumber(e.to_string()))?;
 
-        if current_block < self.last_processed_block {
+        if current_block < self.last_aggregated_block {
             return Err(ProofsFetcherError::GetBlockNumber(
                 "Invalid last processed block".to_string(),
             ));
@@ -62,14 +62,14 @@ impl ProofsFetcher {
 
         info!(
             "Fetching proofs from batch logs starting from block number {} upto {}",
-            self.last_processed_block, current_block
+            self.last_aggregated_block, current_block
         );
 
         // Subscribe to NewBatch event from AlignedServiceManager
         let logs = self
             .aligned_service_manager
             .NewBatchV3_filter()
-            .from_block(self.last_processed_block)
+            .from_block(self.last_aggregated_block)
             .to_block(current_block)
             .query()
             .await
@@ -78,7 +78,7 @@ impl ProofsFetcher {
         info!("Logs collected {}", logs.len());
 
         // Update last processed block after collecting logs
-        self.last_processed_block = current_block;
+        self.last_aggregated_block = current_block;
 
         let mut proofs = vec![];
 
@@ -136,7 +136,7 @@ impl ProofsFetcher {
         Ok(proofs)
     }
 
-    pub fn get_last_processed_block(&self) -> u64 {
-        self.last_processed_block
+    pub fn get_last_aggregated_block(&self) -> u64 {
+        self.last_aggregated_block
     }
 }

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -44,33 +44,34 @@ impl ProofsFetcher {
         }
     }
 
-    pub async fn fetch(&self) -> Result<Vec<AlignedProof>, ProofsFetcherError> {
-        info!(
-            "Fetching proofs from batch logs starting from block number {}",
-            self.last_processed_block
-        );
-        // Subscribe to NewBatch event from AlignedServiceManager
-        let logs = self
-            .aligned_service_manager
-            .NewBatchV3_filter()
-            .from_block(self.last_processed_block)
-            .query()
-            .await
-            .map_err(|_| ProofsFetcherError::QueryingLogs)?;
-
-        info!("Logs collected {}", logs.len());
-
+    pub async fn fetch(&mut self) -> Result<Vec<AlignedProof>, ProofsFetcherError> {
         // Get current block
-        self.last_processed_block = self
+        let current_block = self
             .rpc_provider
             .get_block_number()
             .await
             .map_err(|_| ProofsFetcherError::BlockNumber)?;
 
         info!(
-            "Fetched proofs from batch logs upto  block number {}",
-            self.last_processed_block
+            "Fetching proofs from batch logs starting from block number {} upto {}",
+            self.last_processed_block,
+            current_block
         );
+            
+        // Subscribe to NewBatch event from AlignedServiceManager
+        let logs = self
+            .aligned_service_manager
+            .NewBatchV3_filter()
+            .from_block(self.last_processed_block)
+            .to_block(current_block)        
+            .query()
+            .await
+            .map_err(|_| ProofsFetcherError::QueryingLogs)?;
+
+        info!("Logs collected {}", logs.len());
+
+        // Update last processed block after collecting logs
+        self.last_processed_block = current_block;
 
         let mut proofs = vec![];
 
@@ -126,15 +127,5 @@ impl ProofsFetcher {
         }
 
         Ok(proofs)
-    }
-
-    async fn get_block_number_to_fetch_from(&self) -> Result<u64, ProofsFetcherError> {
-        let block_number = self
-            .rpc_provider
-            .get_block_number()
-            .await
-            .map_err(|_| ProofsFetcherError::BlockNumber)?;
-
-        Ok(block_number.saturating_sub(self.last_processed_block))
     }
 }

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -24,7 +24,7 @@ pub enum ProofsFetcherError {
 pub struct ProofsFetcher {
     rpc_provider: RPCProvider,
     aligned_service_manager: AlignedLayerServiceManagerContract,
-    last_processed_block: u64
+    last_processed_block: u64,
 }
 
 impl ProofsFetcher {
@@ -58,16 +58,15 @@ impl ProofsFetcher {
 
         info!(
             "Fetching proofs from batch logs starting from block number {} upto {}",
-            self.last_processed_block,
-            current_block
+            self.last_processed_block, current_block
         );
-            
+
         // Subscribe to NewBatch event from AlignedServiceManager
         let logs = self
             .aligned_service_manager
             .NewBatchV3_filter()
             .from_block(self.last_processed_block)
-            .to_block(current_block)        
+            .to_block(current_block)
             .query()
             .await
             .map_err(|_| ProofsFetcherError::QueryingLogs)?;

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -55,7 +55,9 @@ impl ProofsFetcher {
             .map_err(|e| ProofsFetcherError::GetBlockNumber(e.to_string()))?;
 
         if current_block < self.last_processed_block {
-            return Err(ProofsFetcherError::GetBlockNumber("Invalid last processed block".to_string()));
+            return Err(ProofsFetcherError::GetBlockNumber(
+                "Invalid last processed block".to_string(),
+            ));
         }
 
         info!(

--- a/aggregation_mode/src/backend/fetcher.rs
+++ b/aggregation_mode/src/backend/fetcher.rs
@@ -52,6 +52,10 @@ impl ProofsFetcher {
             .await
             .map_err(|_| ProofsFetcherError::BlockNumber)?;
 
+        if current_block < self.last_processed_block {
+            return Err(ProofsFetcherError::BlockNumber);
+        }
+
         info!(
             "Fetching proofs from batch logs starting from block number {} upto {}",
             self.last_processed_block,

--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -78,7 +78,7 @@ impl ProofAggregator {
         match res {
             Ok(()) => {
                 config
-                    .update_last_processed_block(self.fetcher.get_last_processed_block())
+                    .update_last_aggregated_block(self.fetcher.get_last_aggregated_block())
                     .unwrap();
                 info!("Process finished successfully");
             }

--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -69,7 +69,7 @@ impl ProofAggregator {
         }
     }
 
-    pub async fn start(&mut self, config: &mut Config) {
+    pub async fn start(&mut self, config: &Config) {
         info!("Starting proof aggregator service",);
 
         info!("About to aggregate and submit proof to be verified on chain");
@@ -77,7 +77,9 @@ impl ProofAggregator {
 
         match res {
             Ok(()) => {
-                config.last_processed_block = self.fetcher.get_last_processed_block();
+                config
+                    .update_last_processed_block(self.fetcher.get_last_processed_block())
+                    .unwrap();
                 info!("Process finished successfully");
             }
             Err(err) => {

--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -69,7 +69,7 @@ impl ProofAggregator {
         }
     }
 
-    pub async fn start(&mut self) {
+    pub async fn start(&mut self, config: &mut Config) {
         info!("Starting proof aggregator service",);
 
         info!("About to aggregate and submit proof to be verified on chain");
@@ -77,6 +77,7 @@ impl ProofAggregator {
 
         match res {
             Ok(()) => {
+                config.last_processed_block = self.fetcher.get_last_processed_block();
                 info!("Process finished successfully");
             }
             Err(err) => {

--- a/aggregation_mode/src/main.rs
+++ b/aggregation_mode/src/main.rs
@@ -28,4 +28,6 @@ async fn main() {
 
     let mut proof_aggregator = ProofAggregator::new(&config);
     proof_aggregator.start().await;
+
+    config.save_to_file(&config_file_path).unwrap();   
 }

--- a/aggregation_mode/src/main.rs
+++ b/aggregation_mode/src/main.rs
@@ -28,6 +28,4 @@ async fn main() {
 
     let mut proof_aggregator = ProofAggregator::new(&config);
     proof_aggregator.start(&mut config).await;
-
-    config.save_to_file(&config_file_path).unwrap();
 }

--- a/aggregation_mode/src/main.rs
+++ b/aggregation_mode/src/main.rs
@@ -23,9 +23,9 @@ async fn main() {
     // load config
     let config_file_path = read_config_filepath_from_args();
     tracing::info!("Loading config from {}...", config_file_path);
-    let mut config = Config::from_file(&config_file_path).expect("Config is valid");
+    let config = Config::from_file(&config_file_path).expect("Config is valid");
     tracing::info!("Config loaded");
 
     let mut proof_aggregator = ProofAggregator::new(&config);
-    proof_aggregator.start(&mut config).await;
+    proof_aggregator.start(&config).await;
 }

--- a/aggregation_mode/src/main.rs
+++ b/aggregation_mode/src/main.rs
@@ -23,11 +23,11 @@ async fn main() {
     // load config
     let config_file_path = read_config_filepath_from_args();
     tracing::info!("Loading config from {}...", config_file_path);
-    let config = Config::from_file(&config_file_path).expect("Config is valid");
+    let mut config = Config::from_file(&config_file_path).expect("Config is valid");
     tracing::info!("Config loaded");
 
     let mut proof_aggregator = ProofAggregator::new(&config);
-    proof_aggregator.start().await;
+    proof_aggregator.start(&mut config).await;
 
-    config.save_to_file(&config_file_path).unwrap();   
+    config.save_to_file(&config_file_path).unwrap();
 }

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -3,7 +3,7 @@ eth_ws_url: ws://localhost:8545
 max_proofs_in_queue: 1000
 proof_aggregation_service_address: 0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07
 aligned_service_manager_address: 0x851356ae760d987E095750cCeb3bC6014560891C
-last_processed_block_filepath: config-files/proof-aggregator2.last_processed_block.json
+last_processed_block_filepath: config-files/proof-aggregator.last_processed_block.json
 ecdsa:
   private_key_store_path: config-files/anvil.proof-aggregator.ecdsa.key.json
   private_key_store_password: ''

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -3,7 +3,7 @@ eth_ws_url: ws://localhost:8545
 max_proofs_in_queue: 1000
 proof_aggregation_service_address: 0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07
 aligned_service_manager_address: 0x851356ae760d987E095750cCeb3bC6014560891C
-last_processed_block_filepath: config-files/proof-aggregator.last_processed_block.json
+last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_block.json
 ecdsa:
   private_key_store_path: config-files/anvil.proof-aggregator.ecdsa.key.json
   private_key_store_password: ''

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -1,10 +1,9 @@
-aligned_service_manager_address: "0x851356ae760d987E095750cCeb3bC6014560891C"
-proof_aggregation_service_address: "0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07"
-eth_rpc_url: "http://localhost:8545"
-eth_ws_url: "ws://localhost:8545"
+eth_rpc_url: http://localhost:8545
+eth_ws_url: ws://localhost:8545
 max_proofs_in_queue: 1000
+proof_aggregation_service_address: 0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07
+aligned_service_manager_address: 0x851356ae760d987E095750cCeb3bC6014560891C
 last_processed_block: 0
-
 ecdsa:
-  private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"
-  private_key_store_password: ""
+  private_key_store_path: config-files/anvil.proof-aggregator.ecdsa.key.json
+  private_key_store_password: ''

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -3,7 +3,7 @@ eth_ws_url: ws://localhost:8545
 max_proofs_in_queue: 1000
 proof_aggregation_service_address: 0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07
 aligned_service_manager_address: 0x851356ae760d987E095750cCeb3bC6014560891C
-last_processed_block: 662
+last_processed_block: 0
 ecdsa:
   private_key_store_path: config-files/anvil.proof-aggregator.ecdsa.key.json
   private_key_store_password: ''

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -3,7 +3,7 @@ eth_ws_url: ws://localhost:8545
 max_proofs_in_queue: 1000
 proof_aggregation_service_address: 0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07
 aligned_service_manager_address: 0x851356ae760d987E095750cCeb3bC6014560891C
-last_processed_block_filepath: config-files/proof-aggregator.last_processed_block.json
+last_processed_block_filepath: config-files/proof-aggregator2.last_processed_block.json
 ecdsa:
   private_key_store_path: config-files/anvil.proof-aggregator.ecdsa.key.json
   private_key_store_password: ''

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -3,7 +3,7 @@ eth_ws_url: ws://localhost:8545
 max_proofs_in_queue: 1000
 proof_aggregation_service_address: 0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07
 aligned_service_manager_address: 0x851356ae760d987E095750cCeb3bC6014560891C
-last_processed_block: 626
+last_processed_block: 662
 ecdsa:
   private_key_store_path: config-files/anvil.proof-aggregator.ecdsa.key.json
   private_key_store_password: ''

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -3,7 +3,7 @@ eth_ws_url: ws://localhost:8545
 max_proofs_in_queue: 1000
 proof_aggregation_service_address: 0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07
 aligned_service_manager_address: 0x851356ae760d987E095750cCeb3bC6014560891C
-last_processed_block: 0
+last_processed_block_filepath: config-files/proof-aggregator.last_processed_block.json
 ecdsa:
   private_key_store_path: config-files/anvil.proof-aggregator.ecdsa.key.json
   private_key_store_password: ''

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -3,7 +3,7 @@ eth_ws_url: ws://localhost:8545
 max_proofs_in_queue: 1000
 proof_aggregation_service_address: 0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07
 aligned_service_manager_address: 0x851356ae760d987E095750cCeb3bC6014560891C
-last_processed_block: 0
+last_processed_block: 626
 ecdsa:
   private_key_store_path: config-files/anvil.proof-aggregator.ecdsa.key.json
   private_key_store_password: ''

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -3,10 +3,7 @@ proof_aggregation_service_address: "0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07"
 eth_rpc_url: "http://localhost:8545"
 eth_ws_url: "ws://localhost:8545"
 max_proofs_in_queue: 1000
-# How far in the past should the service go to fetch batch logs
-fetch_logs_from_secs_ago: 86400 # 24hs
-# Anvil start with block time is 7 seconds
-block_time_secs: 7
+last_processed_block: 0
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -3,10 +3,7 @@ proof_aggregation_service_address: "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
 eth_rpc_url: "http://localhost:8545"
 eth_ws_url: "ws://localhost:8545"
 max_proofs_in_queue: 1000
-# How far in the past should the service go to fetch batch logs
-fetch_logs_from_secs_ago: 86400 # 24hs
-# Anvil start with block time is 7 seconds
-block_time_secs: 7
+last_processed_block: 0
 
 ecdsa:
     private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -3,7 +3,7 @@ proof_aggregation_service_address: "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
 eth_rpc_url: "http://localhost:8545"
 eth_ws_url: "ws://localhost:8545"
 max_proofs_in_queue: 1000
-last_processed_block: 0
+last_processed_block_filepath: config-files/proof-aggregator.last_processed_block.json
 
 ecdsa:
     private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -3,7 +3,7 @@ proof_aggregation_service_address: "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
 eth_rpc_url: "http://localhost:8545"
 eth_ws_url: "ws://localhost:8545"
 max_proofs_in_queue: 1000
-last_processed_block_filepath: config-files/proof-aggregator.last_processed_block.json
+last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_block.json
 
 ecdsa:
     private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/proof-aggregator.last_aggregated_block.json
+++ b/config-files/proof-aggregator.last_aggregated_block.json
@@ -1,0 +1,1 @@
+{"last_aggregated_block":0}

--- a/config-files/proof-aggregator.last_processed_block.json
+++ b/config-files/proof-aggregator.last_processed_block.json
@@ -1,1 +1,1 @@
-{"last_processed_block":1305}
+{"last_processed_block":1346}

--- a/config-files/proof-aggregator.last_processed_block.json
+++ b/config-files/proof-aggregator.last_processed_block.json
@@ -1,1 +1,0 @@
-{"last_processed_block":0}

--- a/config-files/proof-aggregator.last_processed_block.json
+++ b/config-files/proof-aggregator.last_processed_block.json
@@ -1,1 +1,1 @@
-{"last_processed_block":1346}
+{"last_processed_block":0}

--- a/config-files/proof-aggregator.last_processed_block.json
+++ b/config-files/proof-aggregator.last_processed_block.json
@@ -1,0 +1,1 @@
+{"last_processed_block":1305}


### PR DESCRIPTION
# Feat (aggregation mode) save last processed block in a file

## Description

From Issue #1870 

Save the last processed block in a json file which path is indicated in the argument config file.

Check if the last_processed_block is lower than the current block of the chain.

Add a method to the config to save the current last_processed_block (discarding the previous file)

## Type of change

Please delete options that are not relevant.

- [ ] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
