### PR TITLE
fix: default variable assignment and `tar` command syntax

### DIFF
--- a/scripts/install_node_exporter.sh
+++ b/scripts/install_node_exporter.sh
@@ -11,7 +11,7 @@ if [[ "$ARCH" == "x86_64" ]]; then
 fi
 
 BASE_DIR="$HOME"
-NODE_EXPORTER_DIR="${NODE_EXPORTER_DIR-"$BASE_DIR/.node_exporter"}"
+NODE_EXPORTER_DIR="${NODE_EXPORTER_DIR:-"$BASE_DIR/.node_exporter"}"
 NODE_EXPORTER_BIN_DIR="$NODE_EXPORTER_DIR/bin"
 NODE_EXPORTER_BIN_PATH="$NODE_EXPORTER_BIN_DIR/node_exporter"
 
@@ -29,7 +29,7 @@ else
 fi
 
 echo "Extracting Node Exporter..."
-if tar xvfz $FILE; then
+if tar -xvzf $FILE; then
     mv "node_exporter-$VERSION.$OS-$ARCH/node_exporter" "$NODE_EXPORTER_BIN_PATH"
     chmod +x "$NODE_EXPORTER_BIN_PATH"
     rm -rf "node_exporter-$VERSION.$OS-$ARCH" $FILE


### PR DESCRIPTION
# TITLE

## Description

I’ve corrected two issues in the script:

1. The syntax for setting the default value for the `NODE_EXPORTER_DIR` variable was wrong. The corrected version now properly uses `:-` for default assignment in Bash:
   ```bash
   NODE_EXPORTER_DIR="${NODE_EXPORTER_DIR:-"$BASE_DIR/.node_exporter"}"
   ```
   This ensures that if `NODE_EXPORTER_DIR` isn’t set, it defaults to `$BASE_DIR/.node_exporter`.

2. Fixed the incorrect order of flags in the `tar` command. The `-z` flag for gzip compression should follow `-x` and precede `-v`. The corrected command is:
   ```bash
   if tar -xvzf $FILE; then
   ```

Both changes ensure the script runs without errors in these areas.

## Type of change

Please delete options that are not relevant.

- [x] Optimization

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
