### PR TITLE
fix(ci): pin eigenlayer cli version to v0.11.3

### DIFF
--- a/docker/aligned_base.Dockerfile
+++ b/docker/aligned_base.Dockerfile
@@ -26,7 +26,7 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Install go deps
 RUN go install github.com/maoueh/zap-pretty@v0.3.0
 RUN go install github.com/ethereum/go-ethereum/cmd/abigen@latest
-RUN go install github.com/Layr-Labs/eigenlayer-cli/cmd/eigenlayer@latest
+RUN go install github.com/Layr-Labs/eigenlayer-cli/cmd/eigenlayer@v0.11.3
 
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/docker/eigenlayer-cli.Dockerfile
+++ b/docker/eigenlayer-cli.Dockerfile
@@ -2,4 +2,4 @@ FROM golang:1.22.2-bookworm
 
 COPY config-files/ ./config-files
 
-RUN go install github.com/Layr-Labs/eigenlayer-cli/cmd/eigenlayer@latest
+RUN go install github.com/Layr-Labs/eigenlayer-cli/cmd/eigenlayer@v0.11.3


### PR DESCRIPTION
# Pin eigenlayer cli version to v0.11.3

## Description

This PR pins the eingelayer CLI to v0.11.3

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
