### PR TITLE
fix(operatorsaggregator): update EigenSDK version for mainnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
 OPERATOR_VERSION=v0.15.1
 EIGEN_SDK_GO_VERSION_TESTNET=v0.2.0-beta.1
-EIGEN_SDK_GO_VERSION_MAINNET=v0.1.13
+EIGEN_SDK_GO_VERSION_MAINNET=v0.2.0-beta.1
 
 ifeq ($(OS),Linux)
 	BUILD_ALL_FFI = $(MAKE) build_all_ffi_linux


### PR DESCRIPTION
# Update EigenSDK version for mainnet

## Description

As EigenLayer has deployed Slashing on Mainnet, EigenSDK `v0.1.13` is not compatible anymore.

This PR updates EigenSDK version to `v0.2.0-beta.1`. This version has already been running in testnet in the last months

Could not create AVS reader

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
