### PR TITLE
feat(explorer): show aggregation mode componentes on testnet only

### DIFF
--- a/explorer/lib/explorer_web/components/contracts.ex
+++ b/explorer/lib/explorer_web/components/contracts.ex
@@ -8,42 +8,54 @@ defmodule ContractsComponent do
   def mount(socket) do
     addresses = Helpers.get_aligned_contracts_addresses()
 
+    proof_aggregator_service =
+      case Helpers.is_mainnet() do
+        true ->
+          []
+
+        false ->
+          [
+            %{
+              contract_name: "AlignedProofAggregationService",
+              address: addresses["alignedProofAggregationService"]
+            }
+          ]
+      end
+
     {:ok,
      assign(socket,
-       contracts: [
-         %{
-           contract_name: "AlignedProofAggregationService",
-           address: addresses["alignedProofAggregationService"]
-         },
-         %{
-           contract_name: "AlignedServiceManager",
-           address: addresses["alignedLayerServiceManager"]
-         },
-         %{
-           contract_name: "BatcherPaymentService",
-           address: addresses["batcherPaymentService"]
-         },
-         %{
-           contract_name: "BlsApkRegistry",
-           address: addresses["blsApkRegistry"]
-         },
-         %{
-           contract_name: "IndexRegistry",
-           address: addresses["indexRegistry"]
-         },
-         %{
-           contract_name: "OperatorStateRetriever",
-           address: addresses["operatorStateRetriever"]
-         },
-         %{
-           contract_name: "RegistryCoordinator",
-           address: addresses["registryCoordinator"]
-         },
-         %{
-           contract_name: "StakeRegistry",
-           address: addresses["stakeRegistry"]
-         }
-       ]
+       contracts:
+         proof_aggregator_service ++
+           [
+             %{
+               contract_name: "AlignedServiceManager",
+               address: addresses["alignedLayerServiceManager"]
+             },
+             %{
+               contract_name: "BatcherPaymentService",
+               address: addresses["batcherPaymentService"]
+             },
+             %{
+               contract_name: "BlsApkRegistry",
+               address: addresses["blsApkRegistry"]
+             },
+             %{
+               contract_name: "IndexRegistry",
+               address: addresses["indexRegistry"]
+             },
+             %{
+               contract_name: "OperatorStateRetriever",
+               address: addresses["operatorStateRetriever"]
+             },
+             %{
+               contract_name: "RegistryCoordinator",
+               address: addresses["registryCoordinator"]
+             },
+             %{
+               contract_name: "StakeRegistry",
+               address: addresses["stakeRegistry"]
+             }
+           ]
      )}
   end
 

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -59,17 +59,19 @@ defmodule NavComponent do
             >
               Batches
             </.link>
-            <.link
-              class={
-                active_view_class(assigns.socket.view, [
-                  ExplorerWeb.AggProofs.Index,
-                  ExplorerWeb.AggProof.Index
-                ])
-              }
-              navigate={~p"/aggregated_proofs"}
-            >
-              Aggregation
-            </.link>
+            <%= if !ExplorerWeb.Helpers.is_mainnet() do %>
+                <.link
+                class={
+                  active_view_class(@socket.view, [
+                    ExplorerWeb.AggProofs.Index,
+                    ExplorerWeb.AggProof.Index
+                  ])
+                }
+                navigate={~p"/aggregated_proofs"}
+                >
+                Aggregation
+                </.link>
+             <% end %>
             <.nav_links_dropdown
               title="Restaking"
               class={
@@ -154,20 +156,22 @@ defmodule NavComponent do
               >
                 Batches
               </.link>
-              <.link
-                class={
-                  classes([
-                    active_view_class(assigns.socket.view, [
-                      ExplorerWeb.AggregatedProofs.Index,
-                      ExplorerWeb.AggregatedProof.Index
-                    ]),
-                    "text-foreground/80 hover:text-foreground font-semibold"
-                  ])
-                }
-                navigate={~p"/aggregated_proofs"}
-              >
-                Aggregation
-              </.link>
+              <%= if !ExplorerWeb.Helpers.is_mainnet() do %>
+                <.link
+                  class={
+                    classes([
+                      active_view_class(assigns.socket.view, [
+                        ExplorerWeb.AggregatedProofs.Index,
+                        ExplorerWeb.AggregatedProof.Index
+                      ]),
+                      "text-foreground/80 hover:text-foreground font-semibold"
+                    ])
+                  }
+                  navigate={~p"/aggregated_proofs"}
+                >
+                  Aggregation
+                </.link>
+              <% end %>
               <.link
                 class="hover:text-foreground"
                 target="_blank"

--- a/explorer/lib/explorer_web/live/pages/home/index.ex
+++ b/explorer/lib/explorer_web/live/pages/home/index.ex
@@ -39,6 +39,21 @@ defmodule ExplorerWeb.Home.Index do
 
     operator_latest_release = ReleasesHelper.get_latest_release()
 
+    # Only show aggregated proof stat for testnet
+    aggregated_proof_stat =
+      if !ExplorerWeb.Helpers.is_mainnet() do
+        [
+          %{
+            title: "Aggregated proofs",
+            value: aggregated_proofs,
+            tooltip_text: nil,
+            link: "/aggregated_proofs"
+          }
+        ]
+      else
+        []
+      end
+
     [
       %{
         title: "Proofs verified",
@@ -59,36 +74,33 @@ defmodule ExplorerWeb.Home.Index do
             _ -> nil
           end,
         link: nil
-      },
-      %{
-        title: "Aggregated proofs",
-        value: aggregated_proofs,
-        tooltip_text: nil,
-        link: "/aggregated_proofs"
-      },
-      %{
-        title: "AVG proof cost",
-        value: "#{avg_fee_per_proof_usd} USD",
-        tooltip_text: "~= #{avg_fee_per_proof_eth} ETH",
-        link: nil
-      },
-      %{
-        title: "Operators",
-        value: operators_registered,
-        tooltip_text: "Current version #{operator_latest_release}",
-        link: "/operators"
-      },
-      %{
-        title: "Total restaked",
-        value: "#{restaked_amount_usd_shorthand} USD",
-        # Using HTML.raw to break paragraph line with <br>
-        tooltip_text:
-          Phoenix.HTML.raw(
-            "= #{Helpers.format_number(restaked_amount_usd)} USD<br>~= #{restaked_amount_eth} ETH"
-          ),
-        link: "/restaked"
       }
-    ]
+    ] ++
+      aggregated_proof_stat ++
+      [
+        %{
+          title: "AVG proof cost",
+          value: "#{avg_fee_per_proof_usd} USD",
+          tooltip_text: "~= #{avg_fee_per_proof_eth} ETH",
+          link: nil
+        },
+        %{
+          title: "Operators",
+          value: operators_registered,
+          tooltip_text: "Current version #{operator_latest_release}",
+          link: "/operators"
+        },
+        %{
+          title: "Total restaked",
+          value: "#{restaked_amount_usd_shorthand} USD",
+          # Using HTML.raw to break paragraph line with <br>
+          tooltip_text:
+            Phoenix.HTML.raw(
+              "= #{Helpers.format_number(restaked_amount_usd)} USD<br>~= #{restaked_amount_eth} ETH"
+            ),
+          link: "/restaked"
+        }
+      ]
   end
 
   def get_cost_per_proof_chart_data(amount) do

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -102,6 +102,15 @@ defmodule ExplorerWeb.Helpers do
     Integer.to_string(value) |> String.pad_leading(2, "0")
   end
 
+  def is_mainnet() do
+    prefix = System.get_env("ENVIRONMENT")
+
+    case prefix do
+      "mainnet" -> true
+      _ -> false
+    end
+  end
+
   @doc """
   Get the EigenLayer Explorer URL based on the environment.
   - `holesky` -> https://holesky.eigenlayer.xyz


### PR DESCRIPTION
## Description

Adds a conditional rendering for aggregation mode components. If the `ENVIRONMENT` is set to `mainnet` then we don't render any of the aggregation-mode related components.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
