### PR TITLE
hotfix: use eigenSDK v0.1.13 for devnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ export OPERATOR_ADDRESS ?= $(shell yq -r '.operator.address' $(CONFIG_FILE))
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
 OPERATOR_VERSION=v0.15.2
+EIGEN_SDK_GO_VERSION_DEVNET=v0.1.13
 EIGEN_SDK_GO_VERSION_TESTNET=v0.2.0-beta.1
 EIGEN_SDK_GO_VERSION_MAINNET=v0.2.0-beta.1
 
@@ -70,6 +71,9 @@ go_deps:
 
 install_foundry:
 	curl -L https://foundry.paradigm.xyz | bash
+
+install_eigenlayer_cli_devnet: ## Install Eigenlayer CLI v0.11.3 (Devnet compatible)
+	curl -sSfL https://raw.githubusercontent.com/layr-labs/eigenlayer-cli/master/scripts/install.sh | sh -s -- v0.11.3
 
 anvil_deploy_eigen_contracts:
 	@echo "Deploying Eigen Contracts..."
@@ -190,7 +194,9 @@ operator_set_eigen_sdk_go_version_testnet:
 	@echo "Setting Eigen SDK version to: $(EIGEN_SDK_GO_VERSION_TESTNET)"
 	go get github.com/Layr-Labs/eigensdk-go@$(EIGEN_SDK_GO_VERSION_TESTNET)
 
-operator_set_eigen_sdk_go_version_devnet: operator_set_eigen_sdk_go_version_mainnet
+operator_set_eigen_sdk_go_version_devnet:
+	@echo "Setting Eigen SDK version to: $(EIGEN_SDK_GO_VERSION_DEVNET)"
+	go get github.com/Layr-Labs/eigensdk-go@$(EIGEN_SDK_GO_VERSION_DEVNET)
 
 operator_set_eigen_sdk_go_version_mainnet:
 	@echo "Setting Eigen SDK version to: $(EIGEN_SDK_GO_VERSION_MAINNET)"

--- a/scripts/mint_mock_token.sh
+++ b/scripts/mint_mock_token.sh
@@ -17,7 +17,7 @@ mock_token_address=$(cast call "$mock_strategy_address" "underlyingToken()")
 
 operator_address=$(cat "$1" | yq -r '.operator.address')
 
-if [[-z  "$mock_token_address" ]]; then
+if [[ -z  "$mock_token_address" ]]; then
   echo "Mock token address is empty, please deploy the contracts first"
   exit 1
 fi;


### PR DESCRIPTION
# Use eigenSDK v0.1.13 for devnet

## Description

This PR sets eigenSDK to v0.1.13 for devnet environment. It is needed because the EigenLayer contracts deployed in devnet are not compatible with v0.2.0.

Closes #1893

## How to Test

Note: Make sure you have installed EigenLayer cli version 0.11.3. You can check this with 

```
eigenlayer --version
```

If you have a different version, you can install it with:

```
install_eigenlayer_cli_devnet
```

You may need to remove the Eigenlayer CLI installed via go (rm /Users/<your-user>/go/bin/eigenlayer)

1. `make anvil_start`
2. `make batcher_start_local`
3. `make aggregator_start ENVIRONMENT=devnet`
4. `make operator_full_registration CONFIG_FILE=config-files/config-operator-1.yaml ENVIRONMENT=devnet`
5. `make operator_start CONFIG_FILE=config-files/config-operator-1.yaml ENVIRONMENT=devnet`
6. `make batcher_send_risc0_burst`


## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
