### PR TITLE
infra(aggregation_mode): add Risc0 setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ start_proof_aggregator_gpu: is_aggregator_set ## Starts proof aggregator with pr
 	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove,gpu -- config-files/config-proof-aggregator.yaml
 
 install_aggregation_mode: ## Install the aggregation mode with proving enabled
-	cargo install --path aggregation_mode --features prove
+	cargo install --path aggregation_mode --features prove,gpu
 
 _AGGREGATOR_:
 

--- a/infra/aggregation_mode/aggregation_mode.service
+++ b/infra/aggregation_mode/aggregation_mode.service
@@ -6,8 +6,7 @@ After=network.target
 Type=oneshot
 WorkingDirectory=/home/user
 ExecStartPre=sleep 60
-ExecStart=/home/user/.cargo/bin/proof_aggregator /home/user/config/config-proof-aggregator.yaml
-Environment="SP1_PROVER=cuda"
+ExecStart=/home/user/run.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/infra/aggregation_mode/aggregation_mode.sh
+++ b/infra/aggregation_mode/aggregation_mode.sh
@@ -82,6 +82,11 @@ curl -L https://sp1.succinct.xyz | bash
 source $HOME/.bashrc
 sp1up
 
+# Install Risc0
+curl -L https://risczero.com/install | bash
+source $HOME/.bashrc
+rzup install
+
 # Install cast
 curl -L https://foundry.paradigm.xyz | bash
 source $HOME/.bashrc
@@ -95,13 +100,19 @@ mkdir -p ~/.keystores
 # Create keystore
 cast wallet import proof_aggregation.keystore -k $HOME/.keystores -i
 
-# Create config file interactively
-./infra/aggregation_mode/config_file.sh ./infra/aggregation_mode/config-proof-aggregator.template.yaml
-touch $HOME/config/proof-aggregator.last_aggregated_block.json
-read -p "Enter a number (last_aggregated_block): " num && echo "{\"last_aggregated_block\":$num}" > $HOME/config/proof-aggregator.last_aggregated_block.json
+# Create config file for SP1
+./infra/aggregation_mode/config_file.sh ./infra/aggregation_mode/config-proof-aggregator-sp1.template.yaml $HOME/config/config-proof-aggregator-sp1.yaml
+read -p "Enter a block number for SP1 (last_aggregated_block): " num && echo "{\"last_aggregated_block\":$num}" > $HOME/config/proof-aggregator-sp1.last_aggregated_block.json
+
+# Create config file for Risc0
+./infra/aggregation_mode/config_file.sh ./infra/aggregation_mode/config-proof-aggregator-risc0.template.yaml $HOME/config/config-proof-aggregator-risc0.yaml
+read -p "Enter a block number for Risc0 (last_aggregated_block): " num && echo "{\"last_aggregated_block\":$num}" > $HOME/config/proof-aggregator-risc0.last_aggregated_block.json
 
 # Build the proof_aggregator
 make install_aggregation_mode
+
+# Copy run script
+cp ./infra/aggregation_mode/run.sh $HOME/run.sh
 
 # Setup systemd service
 cp ./infra/aggregation_mode/aggregation_mode.service $HOME/.config/systemd/user/aggregation_mode.service

--- a/infra/aggregation_mode/aggregation_mode.sh
+++ b/infra/aggregation_mode/aggregation_mode.sh
@@ -113,6 +113,7 @@ make install_aggregation_mode
 
 # Copy run script
 cp ./infra/aggregation_mode/run.sh $HOME/run.sh
+chmod 744 $HOME/run.sh
 
 # Setup systemd service
 cp ./infra/aggregation_mode/aggregation_mode.service $HOME/.config/systemd/user/aggregation_mode.service

--- a/infra/aggregation_mode/config-proof-aggregator-risc0.template.yaml
+++ b/infra/aggregation_mode/config-proof-aggregator-risc0.template.yaml
@@ -3,7 +3,7 @@ proof_aggregation_service_address: <proof_aggregation_service_address>
 eth_rpc_url: <eth_rpc_url>
 eth_ws_url: <eth_ws_url>
 max_proofs_in_queue: 1000
-last_aggregated_block_filepath: ~/config/proof-aggregator.last_aggregated_block.json
+last_aggregated_block_filepath: /home/user/config/proof-aggregator-risc0.last_aggregated_block.json
 
 ecdsa:
     private_key_store_path: <private_key_store_path>

--- a/infra/aggregation_mode/config-proof-aggregator-sp1.template.yaml
+++ b/infra/aggregation_mode/config-proof-aggregator-sp1.template.yaml
@@ -1,0 +1,10 @@
+aligned_service_manager_address: <aligned_service_manager_address>
+proof_aggregation_service_address: <proof_aggregation_service_address>
+eth_rpc_url: <eth_rpc_url>
+eth_ws_url: <eth_ws_url>
+max_proofs_in_queue: 1000
+last_aggregated_block_filepath: /home/user/config/proof-aggregator-sp1.last_aggregated_block.json
+
+ecdsa:
+    private_key_store_path: <private_key_store_path>
+    private_key_store_password: <private_key_store_password>

--- a/infra/aggregation_mode/config_file.sh
+++ b/infra/aggregation_mode/config_file.sh
@@ -13,8 +13,8 @@
 #   - Risc0: $HOME/config/config-proof-aggregator-risc0.yaml
 
 # Check if template file path is provided as argument
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <template_file_path>"
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <template_file_path> <output_file>"
     exit 1
 fi
 

--- a/infra/aggregation_mode/config_file.sh
+++ b/infra/aggregation_mode/config_file.sh
@@ -2,7 +2,7 @@
 
 # This script creates a configuration file for the proof aggregator
 
-# ENV VARIABLES
+# PARAMETERS
 #
 # TEMPLATE_FILE: Path to the template file
 #   - SP1: ./infra/aggregation_mode/config-proof-aggregator-sp1.template.yaml
@@ -19,6 +19,7 @@ if [ $# -ne 2 ]; then
 fi
 
 TEMPLATE_FILE="$1"
+OUTPUT_FILE="$2"
 
 # Verify template file exists
 if [ ! -f "$TEMPLATE_FILE" ]; then

--- a/infra/aggregation_mode/config_file.sh
+++ b/infra/aggregation_mode/config_file.sh
@@ -48,7 +48,7 @@ prompt_and_replace "<private_key_store_path>" "ECDSA Private Key Store Path (~/.
 prompt_and_replace "<private_key_store_password>" "ECDSA Private Key Store Password"
 
 # Create destination directory if it doesn't exist
-mkdir -p /home/user/config
+mkdir -p $HOME/config
 
 # Copy the completed file to destination
 cp "$TEMP_FILE" "$OUTPUT_FILE"

--- a/infra/aggregation_mode/config_file.sh
+++ b/infra/aggregation_mode/config_file.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# This script creates a configuration file for the proof aggregator
+
+# ENV VARIABLES
+#
+# TEMPLATE_FILE: Path to the template file
+#   - SP1: ./infra/aggregation_mode/config-proof-aggregator-sp1.template.yaml
+#   - Risc0: ./infra/aggregation_mode/config-proof-aggregator-risc0.template.yaml
+#
+# OUTPUT_FILE: Path to the output file
+#   - SP1: $HOME/config/config-proof-aggregator-sp1.yaml
+#   - Risc0: $HOME/config/config-proof-aggregator-risc0.yaml
+
 # Check if template file path is provided as argument
 if [ $# -ne 1 ]; then
     echo "Usage: $0 <template_file_path>"
@@ -39,9 +51,9 @@ prompt_and_replace "<private_key_store_password>" "ECDSA Private Key Store Passw
 mkdir -p /home/user/config
 
 # Copy the completed file to destination
-cp "$TEMP_FILE" $HOME/config/config-proof-aggregator.yaml
+cp "$TEMP_FILE" "$OUTPUT_FILE"
 
 # Clean up temporary file
 rm "$TEMP_FILE"
 
-echo "Configuration file has been created and copied to $HOME/config/config-proof-aggregator.yaml"
+echo "Configuration file has been created and copied to $OUTPUT_FILE"

--- a/infra/aggregation_mode/run.sh
+++ b/infra/aggregation_mode/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SLEEP=5
+
+echo "Starting Aggregation Mode in $SLEEP seconds..."
+sleep $SLEEP
+
+echo "Starting SP1 Aggregation Mode..."
+AGGREGATOR=sp1 SP1_PROVER=cuda /home/user/.cargo/bin/proof_aggregator /home/user/config/config-proof-aggregator-sp1.yaml
+echo "SP1 Aggregation Mode finished"
+
+echo "Starting Risc0 Aggregation Mode..."
+AGGREGATOR=risc0 /home/user/.cargo/bin/proof_aggregator /home/user/config/config-proof-aggregator-risc0.yaml
+echo "Risc0 Aggregation Mode finished"

--- a/infra/aggregation_mode/run.sh
+++ b/infra/aggregation_mode/run.sh
@@ -7,6 +7,7 @@ sleep $SLEEP
 
 echo "Starting SP1 Aggregation Mode..."
 AGGREGATOR=sp1 SP1_PROVER=cuda /home/user/.cargo/bin/proof_aggregator /home/user/config/config-proof-aggregator-sp1.yaml
+docker stop $(docker ps -a -q) ## stop all containers
 echo "SP1 Aggregation Mode finished"
 
 echo "Starting Risc0 Aggregation Mode..."


### PR DESCRIPTION
# Add Risc0 setup

## Description

This PR adds the setup for running the aggregation mode for Risc0 proving system.

Closes #1897

## Type of change

- [x] Infra

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
