### PR TITLE
fix: explorer aggregated proofs pagination

### DIFF
--- a/explorer/lib/explorer_web/live/pages/agg_proofs/index.ex
+++ b/explorer/lib/explorer_web/live/pages/agg_proofs/index.ex
@@ -6,7 +6,7 @@ defmodule ExplorerWeb.AggProofs.Index do
   @page_size 15
 
   @impl true
-  def mount(_, params, socket) do
+  def mount(params, _, socket) do
     current_page = get_current_page(params)
 
     proofs =

--- a/explorer/lib/explorer_web/live/pages/agg_proofs/index.ex
+++ b/explorer/lib/explorer_web/live/pages/agg_proofs/index.ex
@@ -31,7 +31,7 @@ defmodule ExplorerWeb.AggProofs.Index do
 
   @impl true
   def handle_event("change_page", %{"page" => page}, socket) do
-    {:noreply, push_navigate(socket, to: ~p"/batches?page=#{page}")}
+    {:noreply, push_navigate(socket, to: ~p"/aggregated_proofs?page=#{page}")}
   end
 
   defp get_current_page(params) do

--- a/explorer/lib/explorer_web/live/pages/agg_proofs/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/agg_proofs/index.html.heex
@@ -54,7 +54,7 @@
           <span class="sr-only">Next Page</span>
         </.button>
       </.link>
-      <.link navigate={~p"/batches?page=#{@last_page}"}>
+      <.link navigate={~p"/aggregated_proofs?page=#{@last_page}"}>
         <.button class="text-muted-foreground group">
           Last
         </.button>

--- a/explorer/lib/explorer_web/live/pages/agg_proofs/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/agg_proofs/index.html.heex
@@ -9,7 +9,7 @@
   <% end %>
   <div class="flex gap-x-2 items-center justify-center w-full">
     <%= if @current_page >= 2 do %>
-      <.link navigate={~p"/batches?page=#{1}"}>
+      <.link navigate={~p"/aggregated_proofs?page=#{1}"}>
         <.button class="text-muted-foreground group">
           First
         </.button>


### PR DESCRIPTION
## Description

The [aggregated proofs page](https://holesky.explorer.alignedlayer.com/aggregated_proofs) pagination is not working as expected because we were redirecting to the wrong links.

**Test**

- Run the explorer with the `ENVIRONMENT` set to `testnet`

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
