### PR TITLE
fix(aggregation_mode): invert variables order and add setter for risc0 contract

### DIFF
--- a/contracts/src/core/AlignedProofAggregationService.sol
+++ b/contracts/src/core/AlignedProofAggregationService.sol
@@ -113,7 +113,6 @@ contract AlignedProofAggregationService is
     /// @notice Sets the address of the Risc0 verifier contract
     /// @param _risc0VerifierAddress The new address for the Risc0 verifier contract
     function setRisc0VerifierAddress(address _risc0VerifierAddress) external onlyOwner {
-        require(_risc0VerifierAddress != address(0), "Invalid verifier address");
         risc0VerifierAddress = _risc0VerifierAddress;
     }
 }

--- a/contracts/src/core/AlignedProofAggregationService.sol
+++ b/contracts/src/core/AlignedProofAggregationService.sol
@@ -24,13 +24,13 @@ contract AlignedProofAggregationService is
     ///      https://docs.succinct.xyz/onchain-verification/contract-addresses
     address public sp1VerifierAddress;
 
+    /// @notice The address of the Wallet that is allowed to call the verify function.
+    address public alignedAggregatorAddress;
+
     /// @notice The address of the Risc0 verifier contract
     /// @dev See supported verifier here:
     /// https://dev.risczero.com/api/blockchain-integration/contracts/verifier#contract-addresses
     address public risc0VerifierAddress;
-
-    /// @notice The address of the Wallet that is allowed to call the verify function.
-    address public alignedAggregatorAddress;
 
     /// @notice whether we are in dev mode or not
     /// if the sp1 verifier address is set to this address, then we skip verification
@@ -108,5 +108,12 @@ contract AlignedProofAggregationService is
             revert OnlyAlignedAggregator(msg.sender);
         }
         _;
+    }
+
+    /// @notice Sets the address of the Risc0 verifier contract
+    /// @param _risc0VerifierAddress The new address for the Risc0 verifier contract
+    function setRisc0VerifierAddress(address _risc0VerifierAddress) external onlyOwner {
+        require(_risc0VerifierAddress != address(0), "Invalid verifier address");
+        risc0VerifierAddress = _risc0VerifierAddress;
     }
 }


### PR DESCRIPTION
# Invert variables order and add setter for risc0 contract

## Description

Variable declaration in AlignedProofAggregation contract was

```solidity
    /// @notice The address of the SP1 verifier contract.
    /// @dev This can either be a specific SP1Verifier for a specific version, or the
    ///      SP1VerifierGateway which can be used to verify proofs for any version of SP1.
    ///      For the list of supported verifiers on each chain, see:
    ///      https://docs.succinct.xyz/onchain-verification/contract-addresses
    address public sp1VerifierAddress;

    /// @notice The address of the Wallet that is allowed to call the verify function.
    address public alignedAggregatorAddress;
```

In PR #1874, it was changed to

```solidity
    /// @notice The address of the SP1 verifier contract.
    /// @dev This can either be a specific SP1Verifier for a specific version, or the
    ///      SP1VerifierGateway which can be used to verify proofs for any version of SP1.
    ///      For the list of supported verifiers on each chain, see:
    ///      https://docs.succinct.xyz/onchain-verification/contract-addresses
    address public sp1VerifierAddress;

    /// @notice The address of the Risc0 verifier contract
    /// @dev See supported verifier here:
    /// https://dev.risczero.com/api/blockchain-integration/contracts/verifier#contract-addresses
    address public risc0VerifierAddress;

    /// @notice The address of the Wallet that is allowed to call the verify function.
    address public alignedAggregatorAddress;
```

Setting the `risc0VerifierAddress` to `alignedAggregatorAddress`, and setting `alignedAggregatorAddress` to `0x0...0`

## How to Test

## Contracts upgrade

Once upgraded the contract, the `risc0VerifierAddress` will be set to `0x0...0`

You can set the `risc0VerifierAddress` address with 

For STAGE

```
cast send 0x7Eace34A8d4C4CacE633946C6F7CF4BeF3F33513 "setRisc0VerifierAddress(address)" 0xf70aBAb028Eb6F4100A24B203E113D94E87DE93C --rpc-url https://ethereum-holesky-rpc.publicnode.com --interactive
```

For TESTNET

```
cast send 0xe84CD4084d8131841CE6DC265361f81F4C59a1d4 "setRisc0VerifierAddress(address)" 0xf70aBAb028Eb6F4100A24B203E113D94E87DE93C --rpc-url https://ethereum-holesky-rpc.publicnode.com --interactive
```

In both cases you must be the owner

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
