### PR TITLE
build: update cache action to v4

### DIFF
--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -32,7 +32,7 @@ jobs:
            ~/.sp1/bin/sp1up
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -90,7 +90,7 @@ jobs:
            ~/.sp1/bin/sp1up
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
GitHub runners now default to Node 20; actions/cache@v4 is the recommended version. Only workflow files changed—no functional impact.