### PR TITLE
docs: add metrics references for operators

### DIFF
--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -153,15 +153,15 @@ Then you must register as an Operator on AlignedLayer. To do this, you must run:
 
 - Mainnet:
 
-```bash
-make operator_register_with_aligned_layer CONFIG_FILE=./config-files/config-operator-mainnet.yaml
-```
+    ```bash
+    make operator_register_with_aligned_layer CONFIG_FILE=./config-files/config-operator-mainnet.yaml
+    ```
 
 - Holesky:
 
-```bash
-make operator_register_with_aligned_layer CONFIG_FILE=./config-files/config-operator-holesky.yaml
-```
+    ```bash
+    make operator_register_with_aligned_layer CONFIG_FILE=./config-files/config-operator-holesky.yaml
+    ```
 
 {% hint style="danger" %}
 If you are going to run the server in this machine, 
@@ -172,15 +172,15 @@ delete the operator key
 
 - Mainnet:
 
-```bash
-./operator/build/aligned-operator start --config ./config-files/config-operator-mainnet.yaml
-```
+    ```bash
+    ./operator/build/aligned-operator start --config ./config-files/config-operator-mainnet.yaml
+    ```
 
 - Holesky:
 
-```bash
-./operator/build/aligned-operator start --config ./config-files/config-operator-holesky.yaml
-```
+    ```bash
+    ./operator/build/aligned-operator start --config ./config-files/config-operator-holesky.yaml
+    ```
 
 ### Run Operator using Systemd
 
@@ -242,21 +242,39 @@ Once you are running your operator using systemd, you can get its logs using jou
 journalctl -xfeu aligned-operator.service
 ```
 
+## Operator Metrics
+
+Metrics are exposed by default at `localhost:9092/metrics` in Prometheus format. To change the endpoint, update the following line in the configuration file:
+
+```yaml
+metrics_ip_port_address: localhost:9092
+```
+
+Example of exposed metrics:
+
+```yaml
+# HELP aligned_operator_responses_count Number of proof verified by the operator and sent to the Aligned Service Manager
+# TYPE aligned_operator_responses_count counter
+aligned_operator_responses_count x
+```
+
+You can scrape these metrics using Prometheus and visualize them in Grafana or configure alerts based on the data.
+
 ## Unregistering the operator
 
 To unregister the Aligned operator, run:
 
 - Mainnet:
 
-```bash
-cast send --rpc-url https://ethereum-rpc.publicnode.com --private-key <private_key> 0xA8CC0749b4409c3c47012323E625aEcBA92f64b9 'deregisterOperator(bytes)' 0x00
- ```
+    ```bash
+    cast send --rpc-url https://ethereum-rpc.publicnode.com --private-key <private_key> 0xA8CC0749b4409c3c47012323E625aEcBA92f64b9 'deregisterOperator(bytes)' 0x00
+    ```
 
 - Holesky:
 
-```bash
-cast send --rpc-url https://ethereum-holesky-rpc.publicnode.com --private-key <private_key> 0x3aD77134c986193c9ef98e55e800B71e72835b62 'deregisterOperator(bytes)' 0x00
- ```
+    ```bash
+    cast send --rpc-url https://ethereum-holesky-rpc.publicnode.com --private-key <private_key> 0x3aD77134c986193c9ef98e55e800B71e72835b62 'deregisterOperator(bytes)' 0x00
+    ```
 
  `<private_key>` is the one specified in the output when generating your keys with the EigenLayer CLI.
 

--- a/docs/operator_guides/1_operator_FAQ.md
+++ b/docs/operator_guides/1_operator_FAQ.md
@@ -43,13 +43,24 @@ You can check the latest version available on the [releases' page](https://githu
 
 You can get the registered version of your operator by running the following command:
 
-```bash
-curl https://holesky.tracker.alignedlayer.com/versions/<operator_address>
-```
+- Mainnet:
+
+    ```bash
+    curl https://mainnet.telemetry.alignedlayer.com/versions/<operator_address>
+    ```
+
+- Holesky:
+
+    ```bash
+    curl https://holesky.telemetry.alignedlayer.com/versions/<operator_address>
+    ```
 
 Replace `<operator_address>` with your operator address.
 
-In future releases, the explorer will show the operator version and the latest available version.
+Also, you can check the operator version in the Explorer:
+
+- [Mainnet Operators Explorer](https://explorer.alignedlayer.com/operators)
+- [Holesky Operators Explorer](https://holesky.explorer.alignedlayer.com/operators)
 
 ### How do I check the operator version locally?
 
@@ -67,12 +78,23 @@ This will show the version of the operator you have built in your filesystem.
 
 You can get the ID of the operator by running the following command:
 
-```bash
-cast call \
-	--rpc-url https://ethereum-holesky-rpc.publicnode.com \
-	0xD0A725d82649f9e4155D7A60B638Fe33b3F25e3b \
-	"getOperatorId(address operator)(bytes32)" <operator_address>
-```
+- Mainnet: 
+
+    ```bash
+    cast call \
+        --rpc-url https://ethereum-rpc.publicnode.com \
+        0x3CcfB7e6e8fe2A8d941a8Ce4C69A944a770E8228 \
+        "getOperatorId(address operator)(bytes32)" <operator_address>
+    ```
+
+- Holesky
+
+    ```bash
+    cast call \
+        --rpc-url https://ethereum-holesky-rpc.publicnode.com \
+        0xD0A725d82649f9e4155D7A60B638Fe33b3F25e3b \
+        "getOperatorId(address operator)(bytes32)" <operator_address>
+    ```
 
 > Note: You need to have installed [Foundry](https://book.getfoundry.sh/)
 


### PR DESCRIPTION
# Add metrics references for operators

## Description

This PR adds information about exposed metrics by operators

Also, it updates the FAQ section

## Type of change

- [x] Documentation

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [x] This change requires new documentation.
  - [x] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
