### PR TITLE
feat(aggregation_mode): use deterministic build for SP1

### DIFF
--- a/aggregation_mode/build.rs
+++ b/aggregation_mode/build.rs
@@ -5,7 +5,7 @@ fn main() {
             output_directory: Some("./aggregation_programs/sp1/elf".to_string()),
             // We use Docker to generate a reproducible ELF that will be identical across all platforms
             // (https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#production-builds)
-            docker: true,  
+            docker: true,
             ..Default::default()
         }
     });

--- a/aggregation_mode/build.rs
+++ b/aggregation_mode/build.rs
@@ -1,7 +1,11 @@
+// Reference: https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#advanced-build-options-1
 fn main() {
     sp1_build::build_program_with_args("./aggregation_programs/sp1", {
         sp1_build::BuildArgs {
             output_directory: Some("./aggregation_programs/sp1/elf".to_string()),
+            // We use Docker to generate a reproducible ELF that will be identical across all platforms
+            // (https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#production-builds)
+            docker: true,  
             ..Default::default()
         }
     });


### PR DESCRIPTION
# Use deterministic build for SP1

## Description

This PR adds deterministic build for SP1 aggregation mode

## How to test

1. Run anvil

```
make anvil_start
```

2. Run aggregation mode

```
make start_proof_aggregator_dev AGGREGATOR=sp1
```
 
3. Get the `sp1_aggregator_program` sha-512

```
shasum -a 512 aggregation_mode/aggregation_programs/sp1/elf/sp1_aggregator_program
```

4. The output should be the following

```
c43c6203554e0776e4926afdf12c07507068fb1da12d5678b8ea32007e0601a1728c730f3cb6e194dbf359797265081cce57ecabfed09b6ec52c6b634e10b5ac  aggregation_mode/aggregation_programs/sp1/elf/sp1_aggregator_program
```



## Type of change

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
