### PR TITLE
fix(explorer): show unknown if no aggregator set in aggregated proof view

### DIFF
--- a/explorer/lib/explorer_web/live/pages/agg_proof/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/agg_proof/index.html.heex
@@ -31,6 +31,8 @@
             <p>SP1</p>
           <% :risc0 ->  %>
             <p>RISC0</p>
+          <% _ -> %>
+            <p>Unknown</p>
         <% end %>
       </div>
 


### PR DESCRIPTION
# Show unknown if no aggregator set in aggregated proof view

## Description

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/dbc2816b-2b8a-4cef-a46f-b8750f55b1ee" />

Closes #1921 

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
