### PR TITLE
fix(aggregation_mode): unused import: `Prover` in `src/aggregators/sp1_aggregator.rs:6:29`

### DIFF
--- a/aggregation_mode/src/aggregators/sp1_aggregator.rs
+++ b/aggregation_mode/src/aggregators/sp1_aggregator.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use alloy::primitives::Keccak256;
 use sp1_aggregation_program::SP1VkAndPubInputs;
 use sp1_sdk::{
-    EnvProver, HashableKey, Prover, ProverClient, SP1ProofWithPublicValues, SP1Stdin,
+    EnvProver, HashableKey, ProverClient, SP1ProofWithPublicValues, SP1Stdin,
     SP1VerifyingKey,
 };
 


### PR DESCRIPTION
# Unused import: `Prover` in `src/aggregators/sp1_aggregator.rs:6:29`

## Description

Remove unused import to avoid warnings 

## How to test

1. Run anvil

```
make anvil_start
```

2. Run batcher

```
make batcher_start_local
```

3. Send some proofs

```
make batcher_send_risc0_burst BURST_SIZE=8
make batcher_send_so1_burst BURST_SIZE=8 
```

4. Run aggregation mode

```
make start_proof_aggregator_dev AGGREGATOR=sp1
make start_proof_aggregator_dev AGGREGATOR=risc0
```

5. You should not see warnings during compilation process

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
