### PR TITLE
docs: add missing proof aggregator address

### DIFF
--- a/docs/3_guides/7_contract_addresses.md
+++ b/docs/3_guides/7_contract_addresses.md
@@ -39,6 +39,7 @@ For additional details, refer to the [official EigenLayer documentation](https:/
 
 | Contract                   | Address                                                                                                                       |
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| AlignedProofAggregationService | [0xe84CD4084d8131841CE6DC265361f81F4C59a1d4](https://holesky.etherscan.io/address/0xe84CD4084d8131841CE6DC265361f81F4C59a1d4) |
 | AlignedLayerServiceManager | [0x58F280BeBE9B34c9939C3C39e0890C81f163B623](https://holesky.etherscan.io/address/0x58F280BeBE9B34c9939C3C39e0890C81f163B623) |
 | BlsApkRegistry             | [0xD0A725d82649f9e4155D7A60B638Fe33b3F25e3b](https://holesky.etherscan.io/address/0xD0A725d82649f9e4155D7A60B638Fe33b3F25e3b) |
 | IndexRegistry              | [0x4A7DE0a9fBBAa4fF0270d31852B363592F68B81F](https://holesky.etherscan.io/address/0x4A7DE0a9fBBAa4fF0270d31852B363592F68B81F) |


### PR DESCRIPTION
## Description

Adds missing proof aggregator address in docs for holesky network.

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
