### PR TITLE
chore(aggregation_mode): include total proofs to aggregate in logs

### DIFF
--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -103,8 +103,9 @@ impl ProofAggregator {
             warn!("No proofs collected, skipping aggregation...");
             return Ok(());
         }
+        info!("Total proofs to aggregate {}", proofs.len());
 
-        info!("Proofs fetched, constructing merkle root...");
+        info!("Constructing merkle root...");
         let (merkle_tree, leaves) = compute_proofs_merkle_root(&proofs)
             .ok_or(AggregatedProofSubmissionError::BuildingMerkleRoot)?;
         let merkle_root = merkle_tree.root;


### PR DESCRIPTION
## Description

Include total proofs to be aggregated in proof aggregator logs.

## Type of change

- [x] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
