### PR TITLE
fix(explorer): redesign aggregator badges design

### DIFF
--- a/explorer/lib/explorer_web/components/agg_proofs_table.ex
+++ b/explorer/lib/explorer_web/components/agg_proofs_table.ex
@@ -48,30 +48,14 @@ defmodule ExplorerWeb.AggProofsTable do
       <:col :let={proof} label="Aggregator">
         <%= case proof.aggregator do %>
           <% :sp1 -> %>
-            <.sp1_badge />
+            SP1
           <% :risc0 -> %>
-            <.risc0_badge />
+            RISC0
           <% _ -> %>
-            <span>Unknown</span>
+            Unknown
         <% end %>
       </:col>
     </.table>
-    """
-  end
-
-  defp sp1_badge(assigns) do
-    ~H"""
-    <div class="rounded-full p-1 px-5 border w-fit" style="border-color: #FE11C5">
-        <p style="color: #FE11C5">SP1</p>
-    </div>
-    """
-  end
-
-  defp risc0_badge(assigns) do
-    ~H"""
-    <div class="rounded-full p-1 px-5 w-fit" style="background-color: #FEFF9D">
-        <p class="text-black">RISC0</p>
-    </div>
     """
   end
 end


### PR DESCRIPTION
## Description

Trying to be a designer goes wrong. This undoes the artistic touch I wanted to give in the aggregated proofs table. 

Now it is more simple:

![image](https://github.com/user-attachments/assets/4a82c0d8-4437-4cd9-9577-78cb27176ecf)

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
