### PR TITLE
fix(CI): set rust version to 1.86.0

### DIFF
--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - "batcher/**"
       - "aggregation_mode/**"
-      - ".github/workflows/build-rust.yml"
+      - ".github/workflows/build-and-test-rust.yml"
 
 jobs:
   build:

--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.86.0
           components: rustfmt, clippy
           override: true
 


### PR DESCRIPTION
# Set rust version to 1.86.0

## Description

Set the version to 1.86.0 to avoid breaking changes using latest versions of Rust

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
