### PR TITLE
feat(aggregation-mode): limit number of proofs to fetch

### DIFF
--- a/aggregation_mode/src/backend/config.rs
+++ b/aggregation_mode/src/backend/config.rs
@@ -22,6 +22,7 @@ pub struct Config {
     pub last_aggregated_block_filepath: String,
     pub ecdsa: ECDSAConfig,
     pub proofs_per_chunk: u16,
+    pub total_proofs_limit: u16,
 }
 
 impl Config {

--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -97,7 +97,7 @@ impl ProofAggregator {
     ) -> Result<(), AggregatedProofSubmissionError> {
         let proofs = self
             .fetcher
-            .fetch(self.engine.clone())
+            .fetch(self.engine.clone(), self.config.total_proofs_limit)
             .await
             .map_err(AggregatedProofSubmissionError::FetchingProofs)?;
 

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -7,9 +7,11 @@ last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_bl
 proofs_per_chunk: 512 # Amount of proofs to process per chunk
 # This number comes from the blob data limit
 # Since each blob has a capacity of (4096 * 32) = 131.072 bytes
-# Since each proof commitments takes 32 bytes hash + 1 byte for padding 
-# We can aggregate as much proofs as 131.072 / 33 ~= 3971 per blob
-total_proofs_limit: 3970
+# But to not surpass the field modulus we pad with a 0xo byte so we have (4096 * 31) = 126.976 bytes
+# of usable data
+# Since each proof commitments takes 32 bytes hash
+# We can aggregate as much proofs as 126.976 / 32 = 3968 per blob
+total_proofs_limit: 3968
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -5,6 +5,11 @@ eth_ws_url: "ws://localhost:8546"
 max_proofs_in_queue: 1000
 last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_block.json
 proofs_per_chunk: 512 # Amount of proofs to process per chunk
+# This number comes from the blob data limit
+# Since each blob has a capacity of (4096 * 32) = 131.072 bytes
+# Since each proof commitments takes 32 bytes hash + 1 byte for padding 
+# We can aggregate as much proofs as 131.072 / 33 ~= 3971 per blob
+total_proofs_limit: 3970
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-mock-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-mock-ethereum-package.yaml
@@ -5,6 +5,11 @@ eth_ws_url: "ws://localhost:8546"
 max_proofs_in_queue: 1000
 last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_block.json
 proofs_per_chunk: 512 # Amount of proofs to process per chunk
+# This number comes from the blob data limit
+# Since each blob has a capacity of (4096 * 32) = 131.072 bytes
+# Since each proof commitments takes 32 bytes hash + 1 byte for padding 
+# We can aggregate as much proofs as 131.072 / 33 ~= 3971 per blob
+total_proofs_limit: 3970
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-mock-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-mock-ethereum-package.yaml
@@ -7,9 +7,12 @@ last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_bl
 proofs_per_chunk: 512 # Amount of proofs to process per chunk
 # This number comes from the blob data limit
 # Since each blob has a capacity of (4096 * 32) = 131.072 bytes
-# Since each proof commitments takes 32 bytes hash + 1 byte for padding 
-# We can aggregate as much proofs as 131.072 / 33 ~= 3971 per blob
-total_proofs_limit: 3970
+# But to not surpass the field modulus we pad with a 0xo byte so we have (4096 * 31) = 126.976 bytes
+# of usable data
+# Since each proof commitments takes 32 bytes hash
+# We can aggregate as much proofs as 126.976 / 32 = 3968 per blob
+total_proofs_limit: 3968
+
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -5,6 +5,11 @@ eth_ws_url: "ws://localhost:8545"
 max_proofs_in_queue: 1000
 last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_block.json
 proofs_per_chunk: 512 # Amount of proofs to process per chunk
+# This number comes from the blob data limit
+# Since each blob has a capacity of (4096 * 32) = 131.072 bytes
+# Since each proof commitments takes 32 bytes hash + 1 byte for padding 
+# We can aggregate as much proofs as 131.072 / 33 ~= 3971 per blob
+total_proofs_limit: 3970
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-mock.yaml
+++ b/config-files/config-proof-aggregator-mock.yaml
@@ -7,9 +7,12 @@ last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_bl
 proofs_per_chunk: 512 # Amount of proofs to process per chunk
 # This number comes from the blob data limit
 # Since each blob has a capacity of (4096 * 32) = 131.072 bytes
-# Since each proof commitments takes 32 bytes hash + 1 byte for padding 
-# We can aggregate as much proofs as 131.072 / 33 ~= 3971 per blob
-total_proofs_limit: 3970
+# But to not surpass the field modulus we pad with a 0xo byte so we have (4096 * 31) = 126.976 bytes
+# of usable data
+# Since each proof commitments takes 32 bytes hash
+# We can aggregate as much proofs as 126.976 / 32 = 3968 per blob
+total_proofs_limit: 3968
+
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -5,6 +5,11 @@ eth_ws_url: "ws://localhost:8545"
 max_proofs_in_queue: 1000
 last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_block.json
 proofs_per_chunk: 512 # Amount of proofs to process per chunk
+# This number comes from the blob data limit
+# Since each blob has a capacity of (4096 * 32) = 131.072 bytes
+# Since each proof commitments takes 32 bytes hash + 1 byte for padding 
+# We can aggregate as much proofs as 131.072 / 33 ~= 3971 per blob
+total_proofs_limit: 3970
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -7,9 +7,12 @@ last_aggregated_block_filepath: config-files/proof-aggregator.last_aggregated_bl
 proofs_per_chunk: 512 # Amount of proofs to process per chunk
 # This number comes from the blob data limit
 # Since each blob has a capacity of (4096 * 32) = 131.072 bytes
-# Since each proof commitments takes 32 bytes hash + 1 byte for padding 
-# We can aggregate as much proofs as 131.072 / 33 ~= 3971 per blob
-total_proofs_limit: 3970
+# But to not surpass the field modulus we pad with a 0xo byte so we have (4096 * 31) = 126.976 bytes
+# of usable data
+# Since each proof commitments takes 32 bytes hash
+# We can aggregate as much proofs as 126.976 / 32 = 3968 per blob
+total_proofs_limit: 3968
+
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"


### PR DESCRIPTION
## Description

Adds a limit for the number of proofs to fetch. When the fetcher reaches that limit or when the proofs for the batch surprass that limit the fetching stops and the last aggregated block us updated to the block number of that log so that the next aggregation starts at that block. 

**Considerations:**

Currently, we are limited by the blob size:
- Each blob has a capacity of (4096 * 32) = 131.072 bytes
- But, since we need to pad it with a 0x0 byte to not surpass the field modulus we are left with (4096 * 31) = 126.976
- Each proof commitments takes 32 bytes hash
 
So we can aggregate as much proofs as 126.976 / 32 = 3968 per blob.

We could increase the capacity by:
- Running the aggregator more frequently
- Adding the logic to send a vector of blobs instead of only one 

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
