### PR TITLE
chore(aggregation-mode): prevent rebuilding programs if not changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,35 +172,23 @@ reset_last_aggregated_block:
 	@echo "Resetting last aggregated block..."
 	@echo '{"last_aggregated_block":0}' > config-files/proof-aggregator.last_aggregated_block.json
 
-build_proof_aggregator_dev:
-	@cd aggregation_mode && \
-	cargo build --release --bin proof_aggregator
-	
-build_proof_aggregator_cpu:
-	@cd aggregation_mode && \
-	cargo build --release --bin proof_aggregator --features prove
+start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode)
+	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator -- config-files/config-proof-aggregator-mock.yaml
 
-build_proof_aggregator_gpu:
-	@cd aggregation_mode && \
-	cargo build --release --bin proof_aggregator --features prove,gpu
+start_proof_aggregator: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated
+	AGGREGATOR=$(AGGREGATOR) cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove --bin proof_aggregator -- config-files/config-proof-aggregator.yaml
 
-start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode)
-	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-mock.yaml
+start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode) in ethereum package
+	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator -- config-files/config-proof-aggregator-mock-ethereum-package.yaml
 
-start_proof_aggregator_cpu: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_cpu ## Starts proof aggregator with proving activated
-	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-mock.yaml
+start_proof_aggregator_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
+	AGGREGATOR=$(AGGREGATOR) cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove --bin proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
 
-start_proof_aggregator_gpu: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_gpu ## Starts proof aggregator with proving + GPU acceleration (CUDA)
-	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator.yaml
+start_proof_aggregator_gpu: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)
+	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove,gpu --bin proof_aggregator -- config-files/config-proof-aggregator.yaml
 
-start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode) in ethereum package
-	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-mock-ethereum-package.yaml
-
-start_proof_aggregator_cpu_ethereum_package: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_cpu ## Starts proof aggregator with proving activated in ethereum package
-	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
-
-start_proof_aggregator_gpu_ethereum_package: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_gpu ## Starts proof aggregator with proving activated in ethereum package
-	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
+start_proof_aggregator_gpu_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
+	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove,gpu --bin proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
 
 verify_aggregated_proof_sp1_holesky_stage: 
 	@echo "Verifying SP1 in aggregated proofs on holesky..."

--- a/Makefile
+++ b/Makefile
@@ -172,23 +172,35 @@ reset_last_aggregated_block:
 	@echo "Resetting last aggregated block..."
 	@echo '{"last_aggregated_block":0}' > config-files/proof-aggregator.last_aggregated_block.json
 
-start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode)
-	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator -- config-files/config-proof-aggregator-mock.yaml
+build_proof_aggregator_dev:
+	@cd aggregation_mode && \
+	cargo build --release --bin proof_aggregator
+	
+build_proof_aggregator_cpu:
+	@cd aggregation_mode && \
+	cargo build --release --bin proof_aggregator --features prove
 
-start_proof_aggregator: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated
-	AGGREGATOR=$(AGGREGATOR) cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove --bin proof_aggregator -- config-files/config-proof-aggregator.yaml
+build_proof_aggregator_gpu:
+	@cd aggregation_mode && \
+	cargo build --release --bin proof_aggregator --features prove,gpu
 
-start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode) in ethereum package
-	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator -- config-files/config-proof-aggregator-mock-ethereum-package.yaml
+start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode)
+	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-mock.yaml
 
-start_proof_aggregator_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
-	AGGREGATOR=$(AGGREGATOR) cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove --bin proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
+start_proof_aggregator_cpu: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_cpu ## Starts proof aggregator with proving activated
+	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-mock.yaml
 
-start_proof_aggregator_gpu: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)
-	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove,gpu --bin proof_aggregator -- config-files/config-proof-aggregator.yaml
+start_proof_aggregator_gpu: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_gpu ## Starts proof aggregator with proving + GPU acceleration (CUDA)
+	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator.yaml
 
-start_proof_aggregator_gpu_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
-	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove,gpu --bin proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
+start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode) in ethereum package
+	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-mock-ethereum-package.yaml
+
+start_proof_aggregator_cpu_ethereum_package: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_cpu ## Starts proof aggregator with proving activated in ethereum package
+	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
+
+start_proof_aggregator_gpu_ethereum_package: is_aggregator_set reset_last_aggregated_block build_proof_aggregator_gpu ## Starts proof aggregator with proving activated in ethereum package
+	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
 
 verify_aggregated_proof_sp1_holesky_stage: 
 	@echo "Verifying SP1 in aggregated proofs on holesky..."

--- a/aggregation_mode/Cargo.toml
+++ b/aggregation_mode/Cargo.toml
@@ -29,6 +29,7 @@ risc0-ethereum-contracts = { git = "https://github.com/risc0/risc0-ethereum/", t
 [build-dependencies]
 sp1-build = { version = "4.1.3" } 
 risc0-build = { version = "2.0.0" }
+sha3 = "0.10.8"
 
 [package.metadata.risc0]
 # Tell risc0 build to find method in ./aggregation_programs/risc0 package

--- a/aggregation_mode/build.rs
+++ b/aggregation_mode/build.rs
@@ -6,7 +6,6 @@ use std::io::Read;
 use std::path::Path;
 use std::{env, fs};
 
-// Hash all inputs
 fn hash_files_and_features<P: AsRef<Path>>(paths: &[P], features: Vec<String>) -> String {
     let mut hasher = Keccak256::new();
     for path in paths {
@@ -61,7 +60,7 @@ fn main() {
                 output_directory: Some("./aggregation_programs/sp1/elf".to_string()),
                 // We use Docker to generate a reproducible ELF that will be identical across all platforms
                 // (https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#production-builds)
-                // docker: true,
+                docker: true,
                 ..Default::default()
             }
         });
@@ -71,7 +70,7 @@ fn main() {
         let docker_options = DockerOptionsBuilder::default().build().unwrap();
         // Reference: https://github.com/risc0/risc0/blob/main/risc0/build/src/config.rs#L73-L90
         let guest_options = GuestOptionsBuilder::default()
-            // .use_docker(docker_options)
+            .use_docker(docker_options)
             .build()
             .unwrap();
         risc0_build::embed_methods_with_options(HashMap::from([(

--- a/aggregation_mode/build.rs
+++ b/aggregation_mode/build.rs
@@ -60,32 +60,32 @@ fn main() {
         true
     };
 
-    if needs_build {
-        sp1_build::build_program_with_args("./aggregation_programs/sp1", {
-            sp1_build::BuildArgs {
-                output_directory: Some("./aggregation_programs/sp1/elf".to_string()),
-                // We use Docker to generate a reproducible ELF that will be identical across all platforms
-                // (https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#production-builds)
-                docker: true,
-                ..Default::default()
-            }
-        });
-
-        // With this containerized build process, we ensure that all builds of the guest code,
-        // regardless of the machine or local environment, will produce the same ImageID
-        let docker_options = DockerOptionsBuilder::default().build().unwrap();
-        // Reference: https://github.com/risc0/risc0/blob/main/risc0/build/src/config.rs#L73-L90
-        let guest_options = GuestOptionsBuilder::default()
-            .use_docker(docker_options)
-            .build()
-            .unwrap();
-        risc0_build::embed_methods_with_options(HashMap::from([(
-            "risc0_aggregation_program",
-            guest_options,
-        )]));
-
-        fs::write(hash_file, hash).unwrap();
-    } else {
-        println!("Programs code unchanged — skipping programs build");
+    if !needs_build {
+        return;
     }
+
+    sp1_build::build_program_with_args("./aggregation_programs/sp1", {
+        sp1_build::BuildArgs {
+            output_directory: Some("./aggregation_programs/sp1/elf".to_string()),
+            // We use Docker to generate a reproducible ELF that will be identical across all platforms
+            // (https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#production-builds)
+            docker: true,
+            ..Default::default()
+        }
+    });
+
+    // With this containerized build process, we ensure that all builds of the guest code,
+    // regardless of the machine or local environment, will produce the same ImageID
+    let docker_options = DockerOptionsBuilder::default().build().unwrap();
+    // Reference: https://github.com/risc0/risc0/blob/main/risc0/build/src/config.rs#L73-L90
+    let guest_options = GuestOptionsBuilder::default()
+        .use_docker(docker_options)
+        .build()
+        .unwrap();
+    risc0_build::embed_methods_with_options(HashMap::from([(
+        "risc0_aggregation_program",
+        guest_options,
+    )]));
+
+    fs::write(hash_file, hash).unwrap();
 }

--- a/aggregation_mode/build.rs
+++ b/aggregation_mode/build.rs
@@ -1,33 +1,86 @@
 use risc0_build::{DockerOptionsBuilder, GuestOptionsBuilder};
+use sha3::{Digest, Keccak256};
+
 use std::collections::HashMap;
+use std::io::Read;
+use std::path::Path;
+use std::{env, fs};
+
+// Hash all inputs
+fn hash_files_and_features<P: AsRef<Path>>(paths: &[P], features: Vec<String>) -> String {
+    let mut hasher = Keccak256::new();
+    for path in paths {
+        let mut f = fs::File::open(path).unwrap();
+        let mut buffer = Vec::new();
+        f.read_to_end(&mut buffer).unwrap();
+        hasher.update(&buffer);
+    }
+
+    for feature in features {
+        hasher.update(&feature);
+    }
+
+    format!("{:x}", hasher.finalize())
+}
 
 // Reference: https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#advanced-build-options-1
 fn main() {
-    sp1_build::build_program_with_args("./aggregation_programs/sp1", {
-        sp1_build::BuildArgs {
-            output_directory: Some("./aggregation_programs/sp1/elf".to_string()),
-            binaries: vec![
-                "sp1_user_proofs_aggregator_program".into(),
-                "sp1_chunk_aggregator_program".into(),
-            ],
-            // We use Docker to generate a reproducible ELF that will be identical across all platforms
-            // (https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#production-builds)
-            docker: true,
-            ..Default::default()
-        }
-    });
+    let programs = [
+        "build.rs",
+        "aggregation_programs/sp1/src/user_proofs_aggregator_main.rs",
+        "aggregation_programs/sp1/src/chunk_aggregator_main.rs",
+        "aggregation_programs/sp1/src/lib.rs",
+        "aggregation_programs/risc0/src/user_proofs_aggregator_main.rs",
+        "aggregation_programs/risc0/src/chunk_aggregator_main.rs",
+        "aggregation_programs/risc0/src/lib.rs",
+    ];
 
-    // With this containerized build process, we ensure that all builds of the guest code,
-    // regardless of the machine or local environment, will produce the same ImageID
-    let docker_options = DockerOptionsBuilder::default().build().unwrap();
-    // Reference: https://github.com/risc0/risc0/blob/main/risc0/build/src/config.rs#L73-L90
-    let guest_options = GuestOptionsBuilder::default()
-        .use_docker(docker_options)
-        .build()
-        .unwrap();
+    for file in &programs {
+        println!("cargo:rerun-if-changed={}", file);
+    }
 
-    risc0_build::embed_methods_with_options(HashMap::from([(
-        "risc0_aggregation_program",
-        guest_options,
-    )]));
+    // Collect and sort features for stable hashing
+    let mut features: Vec<String> = env::vars()
+        .filter(|(k, _)| k.starts_with("CARGO_FEATURE_"))
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect();
+    features.sort(); // Ensure deterministic hash regardless of env var order
+
+    let hash = hash_files_and_features(&programs, features);
+    let hash_file = Path::new("target/programs_hash.txt");
+
+    let needs_build = if let Ok(prev) = fs::read_to_string(hash_file) {
+        prev != hash
+    } else {
+        true
+    };
+
+    if needs_build {
+        sp1_build::build_program_with_args("./aggregation_programs/sp1", {
+            sp1_build::BuildArgs {
+                output_directory: Some("./aggregation_programs/sp1/elf".to_string()),
+                // We use Docker to generate a reproducible ELF that will be identical across all platforms
+                // (https://docs.succinct.xyz/docs/sp1/writing-programs/compiling#production-builds)
+                // docker: true,
+                ..Default::default()
+            }
+        });
+
+        // With this containerized build process, we ensure that all builds of the guest code,
+        // regardless of the machine or local environment, will produce the same ImageID
+        let docker_options = DockerOptionsBuilder::default().build().unwrap();
+        // Reference: https://github.com/risc0/risc0/blob/main/risc0/build/src/config.rs#L73-L90
+        let guest_options = GuestOptionsBuilder::default()
+            // .use_docker(docker_options)
+            .build()
+            .unwrap();
+        risc0_build::embed_methods_with_options(HashMap::from([(
+            "risc0_aggregation_program",
+            guest_options,
+        )]));
+
+        fs::write(hash_file, hash).unwrap();
+    } else {
+        println!("Programs code unchanged — skipping programs build");
+    }
 }

--- a/aggregation_mode/build.rs
+++ b/aggregation_mode/build.rs
@@ -42,7 +42,7 @@ fn main() {
         println!("cargo:rerun-if-changed={}", file);
     }
 
-    // Get all the env vars from rust (RUSTC, CARGO_FEATURES, etc) 
+    // Get all the env vars from rust (RUSTC, CARGO_FEATURES, etc)
     // But filter those that don't affect the build of the program
     let mut flags: Vec<String> = env::vars()
         .filter(|(k, _)| k != "AGGREGATOR" || k != "RISC0_DEV_MODE" || k != "SP1_PROVER")

--- a/aggregation_mode/build.rs
+++ b/aggregation_mode/build.rs
@@ -26,9 +26,13 @@ fn hash_files_and_features<P: AsRef<Path>>(paths: &[P], features: Vec<String>) -
 fn main() {
     let programs = [
         "build.rs",
+        "aggregation_programs/Cargo.toml",
+        "aggregation_programs/Cargo.lock",
+        "aggregation_programs/sp1/Cargo.toml",
+        "aggregation_programs/sp1/src/lib.rs",
         "aggregation_programs/sp1/src/user_proofs_aggregator_main.rs",
         "aggregation_programs/sp1/src/chunk_aggregator_main.rs",
-        "aggregation_programs/sp1/src/lib.rs",
+        "aggregation_programs/risc0/Cargo.toml",
         "aggregation_programs/risc0/src/user_proofs_aggregator_main.rs",
         "aggregation_programs/risc0/src/chunk_aggregator_main.rs",
         "aggregation_programs/risc0/src/lib.rs",
@@ -38,14 +42,16 @@ fn main() {
         println!("cargo:rerun-if-changed={}", file);
     }
 
-    // Collect and sort features for stable hashing
-    let mut features: Vec<String> = env::vars()
-        .filter(|(k, _)| k.starts_with("CARGO_FEATURE_"))
+    // Get all the env vars from rust (RUSTC, CARGO_FEATURES, etc) 
+    // But filter those that don't affect the build of the program
+    let mut flags: Vec<String> = env::vars()
+        .filter(|(k, _)| k != "AGGREGATOR" || k != "RISC0_DEV_MODE" || k != "SP1_PROVER")
         .map(|(k, v)| format!("{k}={v}"))
         .collect();
-    features.sort(); // Ensure deterministic hash regardless of env var order
+    // Sort them to make it deterministic in spite of the order.
+    flags.sort();
 
-    let hash = hash_files_and_features(&programs, features);
+    let hash = hash_files_and_features(&programs, flags);
     let hash_file = Path::new("target/programs_hash.txt");
 
     let needs_build = if let Ok(prev) = fs::read_to_string(hash_file) {


### PR DESCRIPTION
## Description

Since we introduced deterministic buildings with docker for the zkvm programs the proof aggregator started to take too much time to compile. This got even worse after the multilayer feature. This pr, recompiles the programs only if they have changed. For that, we've been orthodox and simply solved it by hashing the files + features.

This means that now the programs have to be compiled only once for each feature (prove, gpu)

To test it I suggest removing the `use_docker` options for faster builds in `build.rs`

## Type of change

- [x] Optimization

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
