### PR TITLE
CI: migrate workflows to golangci-lint-action v8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: '1.22'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v8
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.


### PR DESCRIPTION
Bumps golangci-lint-action to v8 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0