### PR TITLE
fix(batcher): stop listening to blocks when one of the rpcs disconnects

### DIFF
--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -322,38 +322,70 @@ impl Batcher {
     pub async fn listen_new_blocks_retryable(
         self: Arc<Self>,
     ) -> Result<(), RetryError<BatcherError>> {
-        let eth_ws_provider = Provider::connect(&self.eth_ws_url).await.map_err(|e| {
-            warn!("Failed to instantiate Ethereum websocket provider");
-            RetryError::Transient(BatcherError::EthereumSubscriptionError(e.to_string()))
-        })?;
+        // Try to connect at least to one of the nodes (main or fallback)
+        let eth_ws_provider = Provider::connect(&self.eth_ws_url).await.ok();
+        let eth_ws_provider_fallback = Provider::connect(&self.eth_ws_url_fallback).await.ok();
+        if eth_ws_provider.is_none() {
+            warn!("Failed to instantiate Ethereum main websocket provider");
+        }
+        if eth_ws_provider_fallback.is_none() {
+            warn!("Failed to instantiate fallback Ethereum websocket provider");
+        }
+        if eth_ws_provider.is_none() && eth_ws_provider_fallback.is_none() {
+            return Err(RetryError::Transient(
+                BatcherError::EthereumSubscriptionError(
+                    "Both Ethereum websocket providers failed to connect".to_string(),
+                ),
+            ));
+        }
 
-        let eth_ws_provider_fallback =
-            Provider::connect(&self.eth_ws_url_fallback)
-                .await
-                .map_err(|e| {
-                    warn!("Failed to instantiate fallback Ethereum websocket provider");
-                    RetryError::Transient(BatcherError::EthereumSubscriptionError(e.to_string()))
-                })?;
-
-        let mut stream = eth_ws_provider.subscribe_blocks().await.map_err(|e| {
-            warn!("Error subscribing to blocks.");
-            RetryError::Transient(BatcherError::EthereumSubscriptionError(e.to_string()))
-        })?;
-
-        let mut stream_fallback =
-            eth_ws_provider_fallback
-                .subscribe_blocks()
-                .await
-                .map_err(|e| {
-                    warn!("Error subscribing to blocks.");
-                    RetryError::Transient(BatcherError::EthereumSubscriptionError(e.to_string()))
-                })?;
+        // Tru to connect to one stream (main or fallback)
+        let mut stream = match &eth_ws_provider {
+            Some(provider) => match provider.subscribe_blocks().await {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    warn!("Error subscribing to blocks on primary provider: {:?}", e);
+                    None
+                }
+            },
+            None => None,
+        };
+        let mut stream_fallback = match &eth_ws_provider_fallback {
+            Some(provider) => match provider.subscribe_blocks().await {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    warn!("Error subscribing to blocks on fallback provider: {:?}", e);
+                    None
+                }
+            },
+            None => None,
+        };
+        if stream.is_none() && stream_fallback.is_none() {
+            return Err(RetryError::Transient(
+                BatcherError::EthereumSubscriptionError(
+                    "Both Ethereum block subscriptions failed".to_string(),
+                ),
+            ));
+        }
 
         let last_seen_block = Mutex::<u64>::new(0);
 
         loop {
             // Wait for both responses
-            let (block_main, block_fallback) = join!(stream.next(), stream_fallback.next());
+            let (block_main, block_fallback) = join!(
+                async {
+                    match stream.as_mut() {
+                        Some(s) => s.next().await,
+                        None => None,
+                    }
+                },
+                async {
+                    match stream_fallback.as_mut() {
+                        Some(s) => s.next().await,
+                        None => None,
+                    }
+                }
+            );
 
             let block = if let Some(block) = block_main {
                 block

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -415,7 +415,7 @@ impl Batcher {
                 }
             });
         }
-        error!("Failed to fetch blocks");
+        error!("Both main and fallback Ethereum WS clients subscriptions have disconnected, will try to reconnect...");
 
         Err(RetryError::Transient(
             BatcherError::EthereumSubscriptionError("Could not get new blocks".to_string()),

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -41,7 +41,7 @@ use aws_sdk_s3::client::Client as S3Client;
 use eth::payment_service::{BatcherPaymentService, CreateNewTaskFeeParams, SignerMiddlewareT};
 use ethers::prelude::{Middleware, Provider};
 use ethers::types::{Address, Signature, TransactionReceipt, U256};
-use futures_util::{future, SinkExt, StreamExt, TryStreamExt};
+use futures_util::{future, join, SinkExt, StreamExt, TryStreamExt};
 use lambdaworks_crypto::merkle_tree::merkle::MerkleTree;
 use lambdaworks_crypto::merkle_tree::traits::IsMerkleTreeBackend;
 use log::{debug, error, info, warn};
@@ -351,10 +351,19 @@ impl Batcher {
 
         let last_seen_block = Mutex::<u64>::new(0);
 
-        while let Some(block) = tokio::select! {
-            block = stream.next() => block,
-            block = stream_fallback.next() => block,
-        } {
+        loop {
+            // Wait for both responses
+            let (block_main, block_fallback) = join!(stream.next(), stream_fallback.next());
+
+            let block = if let Some(block) = block_main {
+                block
+            } else if let Some(block) = block_fallback {
+                block
+            } else {
+                // Both rpc failed to respond, break and try to reconnect
+                break;
+            };
+
             let batcher = self.clone();
             let block_number = block.number.unwrap_or_default();
             let block_number = u64::try_from(block_number).unwrap_or_default();
@@ -371,7 +380,7 @@ impl Batcher {
             tokio::spawn(async move {
                 if let Err(e) = batcher.handle_new_block(block_number).await {
                     error!("Error when handling new block: {:?}", e);
-                };
+                }
             });
         }
         error!("Failed to fetch blocks");

--- a/batcher/aligned-batcher/src/lib.rs
+++ b/batcher/aligned-batcher/src/lib.rs
@@ -339,7 +339,7 @@ impl Batcher {
             ));
         }
 
-        // Tru to connect to one stream (main or fallback)
+        // Try to connect to one stream (main or fallback)
         let mut stream = match &eth_ws_provider {
             Some(provider) => match provider.subscribe_blocks().await {
                 Ok(s) => Some(s),

--- a/batcher/aligned-sdk/src/common/constants.rs
+++ b/batcher/aligned-sdk/src/common/constants.rs
@@ -41,7 +41,7 @@ pub const DEFAULT_MAX_FEE_BATCH_SIZE: usize = 10;
 pub const ETHEREUM_CALL_MIN_RETRY_DELAY: u64 = 500; // milliseconds
 pub const ETHEREUM_CALL_MAX_RETRIES: usize = 5;
 pub const ETHEREUM_CALL_BACKOFF_FACTOR: f32 = 2.0;
-pub const ETHEREUM_CALL_MAX_RETRY_DELAY: u64 = 3600; // seconds
+pub const ETHEREUM_CALL_MAX_RETRY_DELAY: u64 = 60; // seconds
 
 /// Ethereum transaction retry constants
 pub const BUMP_MIN_RETRY_DELAY: u64 = 500; // milliseconds


### PR DESCRIPTION
## Description

This PR improves the batcher's ws connection. The batcher maintains two ws connections: a primary and a fallback. Previously, if either connection failed during `listen_to_new_blocks`, the entire process would fail. 

With this pr now:
- The batcher only returns an error if both connections fail. If at least one succeeds, the process continues.
- Previously, a select call would return immediately on the first event, when one disconnected then it would be the first one to return making it fail. The new logic listens to both connections and only exits if both fail.

The process now is the following:
1. Attempts to connect to both nodes.
2. Listens for new blocks from both connections.
3. If one connection fails, it continues listening on the other.
4. If both fail, it retries the connection process from step 1.

Note: when one fails then the connection we don't try to reconnect until both have failed. Adding this logic is not trivial at all as we would need to create s new process that handles it in the background and deal with mutex, etc.

**How to test**
1. Start `ethereum-pacakge`:
```shell
make ethereum_package_start
```
2. Start batcher:
```shell
make batcher_start_ethereum_package
```
3. Locate the rpcs container ids in docker handled by ethereum-package:
```shell
docker ps

# You should be looking for:
5ae8707b5dbf   ghcr.io/paradigmxyz/reth:latest                       "/usr/local/bin/reth…"   24 minutes ago   Up 15 minutes   0.0.0.0:8549->8549/tcp, 0.0.0.0:8549->8549/udp, 30303/tcp, 30303/udp, 0.0.0.0:8552->8545/tcp, 0.0.0.0:8553->8546/tcp, 0.0.0.0:8550->8551/tcp, 0.0.0.0:8551->9001/tcp   el-2-reth-lighthouse--3e21610d756d4ef588441314a9733ca1
180a0bcae8c2   ghcr.io/paradigmxyz/reth:latest                       "/usr/local/bin/reth…"   24 minutes ago   Up 19 minutes   0.0.0.0:8542->8542/tcp, 0.0.0.0:8545-8546->8545-8546/tcp, 0.0.0.0:8542->8542/udp, 30303/tcp, 30303/udp, 0.0.0.0:8543->8551/tcp, 0.0.0.0:8544->9001/tcp                 el-1-reth-lighthouse--9b08863b6524476092e0770690968857
```
4. Play around with starting and stopping the containers you should see the behavior explained above. 

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
