### PR TITLE
Avoid recompilation of Aggregation Mode by using receipts on the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ reset_last_aggregated_block:
 	@echo "Resetting last aggregated block..."
 	@echo '{"last_aggregated_block":0}' > config-files/proof-aggregator.last_aggregated_block.json
 
-AGGREGATION_MODE_SOURCES = $(wildcard ./aggregation_mode/src/**) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/**) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/**)
+AGGREGATION_MODE_SOURCES = $(wildcard ./aggregation_mode/Cargo.toml) $(wildcard ./aggregation_mode/src/**) $(wildcard ./aggregation_mode/aggregation_programs/risc0/Cargo.toml) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/**) $(wildcard ./aggregation_mode/aggregation_programs/sp1/Cargo.toml) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/**)
 
 ### All Dev proof aggregator receipts with no real proving
 ./aggregation_mode/target/release/proof_aggregator_dev: $(AGGREGATION_MODE_SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -172,14 +172,21 @@ reset_last_aggregated_block:
 	@echo "Resetting last aggregated block..."
 	@echo '{"last_aggregated_block":0}' > config-files/proof-aggregator.last_aggregated_block.json
 
-start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode)
-	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator -- config-files/config-proof-aggregator-mock.yaml
+
+### Dev targets with no real proving
+./aggregation_mode/target/release/proof_aggregator_dev:
+		AGGREGATOR=$(AGGREGATOR) cargo build --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_dev
 
 
-./aggregation_mode/target/release/proof_aggregator: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
-	AGGREGATOR=$(AGGREGATOR) cargo build --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator
+start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode)
+	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator_dev -- config-files/config-proof-aggregator-mock.yaml
 
-start_proof_aggregator: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set ## Starts proof aggregator with proving activated
+### All CPU proof aggregator receipts
+
+./aggregation_mode/target/release/proof_aggregator_cpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
+	AGGREGATOR=$(AGGREGATOR) cargo build --features prove --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_cpu
+
+start_proof_aggregator: ./aggregation_mode/target/release/proof_aggregator_cpu is_aggregator_set ## Starts proof aggregator with proving activated
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator.yaml
 
 start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode) in ethereum package
@@ -188,11 +195,17 @@ start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggreg
 start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set ## Starts proof aggregator with proving activated in ethereum package
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator-ethereum-package.yaml
 
-start_proof_aggregator_gpu: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)
-	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator.yaml
+### All GPU proof aggregator receipts
 
-start_proof_aggregator_gpu_ethereum_package: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
-	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator-ethereum-package.yaml
+./aggregation_mode/target/release/proof_aggregator_gpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
+	AGGREGATOR=$(AGGREGATOR) cargo build --features "prove,gpu" --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_gpu 
+
+start_proof_aggregator_gpu: ./aggregation_mode/target/release/proof_aggregator_gpu is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)
+	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator_gpu config-files/config-proof-aggregator.yaml
+
+start_proof_aggregator_gpu_ethereum_package: ./aggregation_mode/target/release/proof_aggregator_gpu is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
+	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator_gpu config-files/config-proof-aggregator-ethereum-package.yaml
+
 
 verify_aggregated_proof_sp1_holesky_stage: 
 	@echo "Verifying SP1 in aggregated proofs on holesky..."

--- a/Makefile
+++ b/Makefile
@@ -175,14 +175,18 @@ reset_last_aggregated_block:
 start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode)
 	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator -- config-files/config-proof-aggregator-mock.yaml
 
-start_proof_aggregator: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated
-	AGGREGATOR=$(AGGREGATOR) cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove --bin proof_aggregator -- config-files/config-proof-aggregator.yaml
+
+./aggregation_mode/target/release/proof_aggregator: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
+	AGGREGATOR=$(AGGREGATOR) cargo build --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator
+
+start_proof_aggregator: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set ## Starts proof aggregator with proving activated
+	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator.yaml
 
 start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode) in ethereum package
 	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator -- config-files/config-proof-aggregator-mock-ethereum-package.yaml
 
-start_proof_aggregator_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
-	AGGREGATOR=$(AGGREGATOR) cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove --bin proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
+start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set ## Starts proof aggregator with proving activated in ethereum package
+	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator-ethereum-package.yaml
 
 start_proof_aggregator_gpu: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)
 	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove,gpu --bin proof_aggregator -- config-files/config-proof-aggregator.yaml

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ reset_last_aggregated_block:
 	@echo '{"last_aggregated_block":0}' > config-files/proof-aggregator.last_aggregated_block.json
 
 
-### Dev targets with no real proving
+### All Dev proof aggregator receipts with no real proving
 ./aggregation_mode/target/release/proof_aggregator_dev:
 		AGGREGATOR=$(AGGREGATOR) cargo build --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_dev
 

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator_cpu config-files/config-proof-aggregator-ethereum-package.yaml
 
 ### All GPU proof aggregator receipts
-./aggregation_mode/target/release/proof_aggregator_gpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
+./aggregation_mode/target/release/proof_aggregator_gpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/*) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/*)
 	AGGREGATOR=$(AGGREGATOR) cargo build --features "prove,gpu" --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_gpu 
 
 start_proof_aggregator_gpu: ./aggregation_mode/target/release/proof_aggregator_gpu is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,10 @@ reset_last_aggregated_block:
 
 
 start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode)
-	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator_dev -- config-files/config-proof-aggregator-mock.yaml
+	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator_dev config-files/config-proof-aggregator-mock.yaml
+
+start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode) in ethereum package
+	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator_dev config-files/config-proof-aggregator-mock-ethereum-package.yaml
 
 ### All CPU proof aggregator receipts
 
@@ -189,8 +192,6 @@ start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ./aggr
 start_proof_aggregator: ./aggregation_mode/target/release/proof_aggregator_cpu is_aggregator_set ## Starts proof aggregator with proving activated
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator.yaml
 
-start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with mock proofs (DEV mode) in ethereum package
-	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator -- config-files/config-proof-aggregator-mock-ethereum-package.yaml
 
 start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set ## Starts proof aggregator with proving activated in ethereum package
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator-ethereum-package.yaml

--- a/Makefile
+++ b/Makefile
@@ -172,11 +172,9 @@ reset_last_aggregated_block:
 	@echo "Resetting last aggregated block..."
 	@echo '{"last_aggregated_block":0}' > config-files/proof-aggregator.last_aggregated_block.json
 
-
 ### All Dev proof aggregator receipts with no real proving
 ./aggregation_mode/target/release/proof_aggregator_dev:
 		AGGREGATOR=$(AGGREGATOR) cargo build --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_dev
-
 
 start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode)
 	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator_dev config-files/config-proof-aggregator-mock.yaml
@@ -185,19 +183,16 @@ start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggreg
 	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator_dev config-files/config-proof-aggregator-mock-ethereum-package.yaml
 
 ### All CPU proof aggregator receipts
-
 ./aggregation_mode/target/release/proof_aggregator_cpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
 	AGGREGATOR=$(AGGREGATOR) cargo build --features prove --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_cpu
 
 start_proof_aggregator: ./aggregation_mode/target/release/proof_aggregator_cpu is_aggregator_set ## Starts proof aggregator with proving activated
-	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator.yaml
+	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator_cpu config-files/config-proof-aggregator.yaml
 
-
-start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set ## Starts proof aggregator with proving activated in ethereum package
-	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator-ethereum-package.yaml
+start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof_aggregator_cpu is_aggregator_set ## Starts proof aggregator with proving activated in ethereum package
+	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator_cpu config-files/config-proof-aggregator-ethereum-package.yaml
 
 ### All GPU proof aggregator receipts
-
 ./aggregation_mode/target/release/proof_aggregator_gpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
 	AGGREGATOR=$(AGGREGATOR) cargo build --features "prove,gpu" --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_gpu 
 
@@ -206,7 +201,6 @@ start_proof_aggregator_gpu: ./aggregation_mode/target/release/proof_aggregator_g
 
 start_proof_aggregator_gpu_ethereum_package: ./aggregation_mode/target/release/proof_aggregator_gpu is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
 	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator_gpu config-files/config-proof-aggregator-ethereum-package.yaml
-
 
 verify_aggregated_proof_sp1_holesky_stage: 
 	@echo "Verifying SP1 in aggregated proofs on holesky..."

--- a/Makefile
+++ b/Makefile
@@ -188,11 +188,11 @@ start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggreg
 start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set ## Starts proof aggregator with proving activated in ethereum package
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator-ethereum-package.yaml
 
-start_proof_aggregator_gpu: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)
-	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove,gpu --bin proof_aggregator -- config-files/config-proof-aggregator.yaml
+start_proof_aggregator_gpu: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)
+	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator.yaml
 
-start_proof_aggregator_gpu_ethereum_package: is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
-	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda cargo run --manifest-path ./aggregation_mode/Cargo.toml --release --features prove,gpu --bin proof_aggregator -- config-files/config-proof-aggregator-ethereum-package.yaml
+start_proof_aggregator_gpu_ethereum_package: ./aggregation_mode/target/release/proof_aggregator is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
+	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator config-files/config-proof-aggregator-ethereum-package.yaml
 
 verify_aggregated_proof_sp1_holesky_stage: 
 	@echo "Verifying SP1 in aggregated proofs on holesky..."

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ reset_last_aggregated_block:
 	@echo '{"last_aggregated_block":0}' > config-files/proof-aggregator.last_aggregated_block.json
 
 ### All Dev proof aggregator receipts with no real proving
-./aggregation_mode/target/release/proof_aggregator_dev: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
+./aggregation_mode/target/release/proof_aggregator_dev: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/*) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/*)
 		AGGREGATOR=$(AGGREGATOR) cargo build --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_dev
 
 start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode)

--- a/Makefile
+++ b/Makefile
@@ -188,20 +188,20 @@ start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggreg
 ./aggregation_mode/target/release/proof_aggregator_cpu: $(AGGREGATION_MODE_SOURCES)
 	AGGREGATOR=$(AGGREGATOR) cargo build --features prove --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_cpu
 
-start_proof_aggregator: ./aggregation_mode/target/release/proof_aggregator_cpu is_aggregator_set ## Starts proof aggregator with proving activated
+start_proof_aggregator: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_cpu ## Starts proof aggregator with proving activated
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator_cpu config-files/config-proof-aggregator.yaml
 
-start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof_aggregator_cpu is_aggregator_set ## Starts proof aggregator with proving activated in ethereum package
+start_proof_aggregator_ethereum_package: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_cpu ## Starts proof aggregator with proving activated in ethereum package
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator_cpu config-files/config-proof-aggregator-ethereum-package.yaml
 
 ### All GPU proof aggregator receipts
 ./aggregation_mode/target/release/proof_aggregator_gpu: $(AGGREGATION_MODE_SOURCES)
 	AGGREGATOR=$(AGGREGATOR) cargo build --features "prove,gpu" --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_gpu 
 
-start_proof_aggregator_gpu: ./aggregation_mode/target/release/proof_aggregator_gpu is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)
+start_proof_aggregator_gpu: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_gpu ## Starts proof aggregator with proving + GPU acceleration (CUDA)
 	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator_gpu config-files/config-proof-aggregator.yaml
 
-start_proof_aggregator_gpu_ethereum_package: ./aggregation_mode/target/release/proof_aggregator_gpu is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving activated in ethereum package
+start_proof_aggregator_gpu_ethereum_package: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_gpu ## Starts proof aggregator with proving activated in ethereum package
 	AGGREGATOR=$(AGGREGATOR) SP1_PROVER=cuda ./aggregation_mode/target/release/proof_aggregator_gpu config-files/config-proof-aggregator-ethereum-package.yaml
 
 verify_aggregated_proof_sp1_holesky_stage: 

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggreg
 	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator_dev config-files/config-proof-aggregator-mock-ethereum-package.yaml
 
 ### All CPU proof aggregator receipts
-./aggregation_mode/target/release/proof_aggregator_cpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
+./aggregation_mode/target/release/proof_aggregator_cpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/*) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/*)
 	AGGREGATOR=$(AGGREGATOR) cargo build --features prove --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_cpu
 
 start_proof_aggregator: ./aggregation_mode/target/release/proof_aggregator_cpu is_aggregator_set ## Starts proof aggregator with proving activated

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ reset_last_aggregated_block:
 
 
 ### All Dev proof aggregator receipts with no real proving
-./aggregation_mode/target/release/proof_aggregator_dev:
+./aggregation_mode/target/release/proof_aggregator_dev: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_programs/risc0/src/*) $(wildcard ./aggregation_programs/sp1/src/*)
 		AGGREGATOR=$(AGGREGATOR) cargo build --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_dev
 
 

--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,10 @@ reset_last_aggregated_block:
 	@echo "Resetting last aggregated block..."
 	@echo '{"last_aggregated_block":0}' > config-files/proof-aggregator.last_aggregated_block.json
 
+AGGREGATION_MODE_SOURCES = $(wildcard ./aggregation_mode/src/**) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/**) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/**)
+
 ### All Dev proof aggregator receipts with no real proving
-./aggregation_mode/target/release/proof_aggregator_dev: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/*) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/*)
+./aggregation_mode/target/release/proof_aggregator_dev: $(AGGREGATION_MODE_SOURCES)
 		AGGREGATOR=$(AGGREGATOR) cargo build --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_dev
 
 start_proof_aggregator_dev: is_aggregator_set reset_last_aggregated_block ./aggregation_mode/target/release/proof_aggregator_dev ## Starts proof aggregator with mock proofs (DEV mode)
@@ -183,7 +185,7 @@ start_proof_aggregator_dev_ethereum_package: is_aggregator_set reset_last_aggreg
 	AGGREGATOR=$(AGGREGATOR) RISC0_DEV_MODE=1 ./aggregation_mode/target/release/proof_aggregator_dev config-files/config-proof-aggregator-mock-ethereum-package.yaml
 
 ### All CPU proof aggregator receipts
-./aggregation_mode/target/release/proof_aggregator_cpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/*) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/*)
+./aggregation_mode/target/release/proof_aggregator_cpu: $(AGGREGATION_MODE_SOURCES)
 	AGGREGATOR=$(AGGREGATOR) cargo build --features prove --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_cpu
 
 start_proof_aggregator: ./aggregation_mode/target/release/proof_aggregator_cpu is_aggregator_set ## Starts proof aggregator with proving activated
@@ -193,7 +195,7 @@ start_proof_aggregator_ethereum_package: ./aggregation_mode/target/release/proof
 	AGGREGATOR=$(AGGREGATOR) ./aggregation_mode/target/release/proof_aggregator_cpu config-files/config-proof-aggregator-ethereum-package.yaml
 
 ### All GPU proof aggregator receipts
-./aggregation_mode/target/release/proof_aggregator_gpu: $(wildcard ./aggregation_mode/src/*) $(wildcard ./aggregation_mode/aggregation_programs/risc0/src/*) $(wildcard ./aggregation_mode/aggregation_programs/sp1/src/*)
+./aggregation_mode/target/release/proof_aggregator_gpu: $(AGGREGATION_MODE_SOURCES)
 	AGGREGATOR=$(AGGREGATOR) cargo build --features "prove,gpu" --manifest-path ./aggregation_mode/Cargo.toml --release --bin proof_aggregator_gpu 
 
 start_proof_aggregator_gpu: ./aggregation_mode/target/release/proof_aggregator_gpu is_aggregator_set reset_last_aggregated_block ## Starts proof aggregator with proving + GPU acceleration (CUDA)

--- a/aggregation_mode/Cargo.toml
+++ b/aggregation_mode/Cargo.toml
@@ -43,7 +43,17 @@ prove = []
 gpu = ["risc0-zkvm/cuda"]
 
 [[bin]]
-name = "proof_aggregator"
+name = "proof_aggregator_cpu"
+path = "./src/main.rs"
+required-features = ["prove"]
+
+[[bin]]
+name = "proof_aggregator_gpu"
+path = "./src/main.rs"
+required-features = ["prove", "gpu"]
+
+[[bin]]
+name = "proof_aggregator_dev"
 path = "./src/main.rs"
 
 [[bin]]


### PR DESCRIPTION
# Avoid recompilation of Aggregation Mode by using receipts on the Makefile

## Description

Avoid recompilation of Aggregation Mode by using receipts on the Makefile. Notice this doesn't include DEV mode

## Type of change

Please delete options that are not relevant.

- [x] New feature
