### PR TITLE
Change all addresses in yamls to be quoted, as to avoid them being interpreted as numbers

### DIFF
--- a/config-files/config-aggregator-docker.yaml
+++ b/config-files/config-aggregator-docker.yaml
@@ -22,8 +22,8 @@ bls:
 ## Aggregator Configurations
 aggregator:
   server_ip_port_address: 0.0.0.0:8090
-  bls_public_key_compendium_address: 0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44
-  avs_service_manager_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
+  bls_public_key_compendium_address: '0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44'
+  avs_service_manager_address: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690'
   enable_metrics: true
   metrics_ip_port_address: 0.0.0.0:9091
   telemetry_ip_port_address: localhost:4001

--- a/config-files/config-aggregator-ethereum-package.yaml
+++ b/config-files/config-aggregator-ethereum-package.yaml
@@ -22,8 +22,8 @@ bls:
 ## Aggregator Configurations
 aggregator:
   server_ip_port_address: localhost:8090
-  bls_public_key_compendium_address: 0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44
-  avs_service_manager_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
+  bls_public_key_compendium_address: '0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44'
+  avs_service_manager_address: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690'
   enable_metrics: true
   metrics_ip_port_address: localhost:9091
   telemetry_ip_port_address: localhost:4001

--- a/config-files/config-aggregator.yaml
+++ b/config-files/config-aggregator.yaml
@@ -29,8 +29,8 @@ bls:
 ## Aggregator Configurations
 aggregator:
   server_ip_port_address: localhost:8090
-  bls_public_key_compendium_address: 0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44
-  avs_service_manager_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
+  bls_public_key_compendium_address: '0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44'
+  avs_service_manager_address: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690'
   enable_metrics: true
   metrics_ip_port_address: localhost:9091
   telemetry_ip_port_address: localhost:4001
@@ -49,8 +49,8 @@ aggregator:
 ## Operator Configurations
 # operator:
 #   aggregator_rpc_server_ip_port_address: localhost:8090
-#   address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-#   earnings_receiver_address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+#   address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+#   earnings_receiver_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
 #   delegation_approver_address: "0x0000000000000000000000000000000000000000"
 #   staker_opt_out_window_blocks: 0
 #   metadata_url: "https://yetanotherco.github.io/operator_metadata/metadata.json"

--- a/config-files/config-batcher-docker.yaml
+++ b/config-files/config-batcher-docker.yaml
@@ -29,5 +29,5 @@ batcher:
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
   non_paying:
-    address: 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 # Anvil address 9
+    address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9
     replacement_private_key: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 # Anvil address 1

--- a/config-files/config-batcher-ethereum-package.yaml
+++ b/config-files/config-batcher-ethereum-package.yaml
@@ -27,5 +27,5 @@ batcher:
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
   non_paying:
-    address: 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 # Anvil address 9
+    address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9
     replacement_private_key: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 # Anvil address 1

--- a/config-files/config-batcher.yaml
+++ b/config-files/config-batcher.yaml
@@ -29,5 +29,5 @@ batcher:
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
   non_paying:
-    address: 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 # Anvil address 9
+    address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9
     replacement_private_key: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 # Anvil address 1

--- a/config-files/config-operator-1.yaml
+++ b/config-files/config-operator-1.yaml
@@ -23,8 +23,8 @@ bls:
 operator:
   aggregator_rpc_server_ip_port_address: localhost:8090
   operator_tracker_ip_port_address: http://localhost:4001
-  address: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
-  earnings_receiver_address: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+  address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+  earnings_receiver_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
   delegation_approver_address: '0x0000000000000000000000000000000000000000'
   staker_opt_out_window_blocks: 0
   metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'

--- a/config-files/config-operator-2.yaml
+++ b/config-files/config-operator-2.yaml
@@ -23,8 +23,8 @@ bls:
 operator:
   aggregator_rpc_server_ip_port_address: localhost:8090
   operator_tracker_ip_port_address: http://localhost:4001
-  address: 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
-  earnings_receiver_address: 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
+  address: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'
+  earnings_receiver_address: '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'
   delegation_approver_address: '0x0000000000000000000000000000000000000000'
   staker_opt_out_window_blocks: 0
   metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'

--- a/config-files/config-operator-3.yaml
+++ b/config-files/config-operator-3.yaml
@@ -23,8 +23,8 @@ bls:
 operator:
   aggregator_rpc_server_ip_port_address: localhost:8090
   operator_tracker_ip_port_address: http://localhost:4001
-  address: 0x90F79bf6EB2c4f870365E785982E1f101E93b906
-  earnings_receiver_address: 0x90F79bf6EB2c4f870365E785982E1f101E93b906
+  address: '0x90F79bf6EB2c4f870365E785982E1f101E93b906'
+  earnings_receiver_address: '0x90F79bf6EB2c4f870365E785982E1f101E93b906'
   delegation_approver_address: '0x0000000000000000000000000000000000000000'
   staker_opt_out_window_blocks: 0
   metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'

--- a/config-files/config-operator-docker.yaml
+++ b/config-files/config-operator-docker.yaml
@@ -23,8 +23,8 @@ bls:
 operator:
   aggregator_rpc_server_ip_port_address: aggregator:8090
   operator_tracker_ip_port_address: http://localhost:3030
-  address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-  earnings_receiver_address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+  address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+  earnings_receiver_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
   delegation_approver_address: "0x0000000000000000000000000000000000000000"
   staker_opt_out_window_blocks: 0
   metadata_url: "https://yetanotherco.github.io/operator_metadata/metadata.json"

--- a/config-files/config.yaml
+++ b/config-files/config.yaml
@@ -31,8 +31,8 @@ batcher:
 ## Aggregator Configurations
 aggregator:
   server_ip_port_address: localhost:8090
-  bls_public_key_compendium_address: 0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44
-  avs_service_manager_address: 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690
+  bls_public_key_compendium_address: '0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44'
+  avs_service_manager_address: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690'
   enable_metrics: true
   metrics_ip_port_address: localhost:9091
   bls_service_task_timeout: 168h # The timeout of bls aggregation service tasks. Suggested value for prod '168h' (7 days)
@@ -41,8 +41,8 @@ aggregator:
 operator:
   aggregator_rpc_server_ip_port_address: localhost:8090
   operator_tracker_ip_port_address: http://localhost:4001
-  address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-  earnings_receiver_address: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+  address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+  earnings_receiver_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
   delegation_approver_address: '0x0000000000000000000000000000000000000000'
   staker_opt_out_window_blocks: 0
   metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'


### PR DESCRIPTION
# Fix issues with configs

Change all addresses in yamls to be quoted, as to avoid them being interpreted as numbers

This happened with some versions of yq in server machines

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

