### PR TITLE
fix(operator): set channel stable on risc0 and merkle tree ffi

### DIFF
--- a/operator/merkle_tree/lib/rust-toolchain
+++ b/operator/merkle_tree/lib/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-04-17"
+channel = "stable"
 components = ["llvm-tools", "rustc-dev", "rustfmt", "rust-src"]

--- a/operator/risc_zero/lib/rust-toolchain
+++ b/operator/risc_zero/lib/rust-toolchain
@@ -1,2 +1,3 @@
 [toolchain]
+channel = "stable"
 components = ["llvm-tools", "rustc-dev", "rustfmt", "rust-src"]


### PR DESCRIPTION
# Set channel stable on risc0 and merkle tree ffi

## Description

This fix solves the error 

```
The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo
```

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
