### PR TITLE
fix(ci): run workflows on pushes to testnet/staging

### DIFF
--- a/.github/workflows/build-and-test-go.yml
+++ b/.github/workflows/build-and-test-go.yml
@@ -2,7 +2,9 @@ name: build-go-projects
 
 on:
   push:
-    branches: [main]
+    branches:
+      - testnet
+      - staging
   pull_request:
     branches: ["*"]
     paths:

--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -2,7 +2,9 @@ name: build-and-test-rust-projects
 
 on:
   push:
-    branches: [main]
+    branches:
+      - testnet
+      - staging
   pull_request:
     branches: ["*"]
     paths:

--- a/.github/workflows/build-contracts.yml
+++ b/.github/workflows/build-contracts.yml
@@ -1,7 +1,9 @@
 name: Build contracts
 on:
   push:
-    branches: [main]
+    branches:
+      - testnet
+      - staging
   pull_request:
     branches: ["*"]
     paths:

--- a/.github/workflows/foundry-gas-diff.yml
+++ b/.github/workflows/foundry-gas-diff.yml
@@ -3,7 +3,8 @@ name: Report gas diff
 on:
   push:
     branches:
-      - main
+      - testnet
+      - staging
   pull_request:
     # Run only for changes in specific files.
      paths:

--- a/.github/workflows/lint-contracts.yml
+++ b/.github/workflows/lint-contracts.yml
@@ -1,7 +1,9 @@
 name: Lint contracts
 on:
   push:
-    branches: [main]
+    branches:
+      - testnet
+      - staging
   pull_request:
     branches: ["*"]
     paths:

--- a/.github/workflows/test-merkle-tree.yml
+++ b/.github/workflows/test-merkle-tree.yml
@@ -2,7 +2,9 @@ name: test-merkle-tree
 
 on:
   push:
-    branches: [main]
+    branches:
+      - testnet
+      - staging
   pull_request:
     branches: ["*"]
     paths:

--- a/.github/workflows/test-risc-zero.yml
+++ b/.github/workflows/test-risc-zero.yml
@@ -2,7 +2,9 @@ name: test-risc-zero
 
 on:
   push:
-    branches: [main]
+    branches:
+      - testnet
+      - staging
   pull_request:
     branches: ["*"]
     paths:

--- a/.github/workflows/test-sp1.yml
+++ b/.github/workflows/test-sp1.yml
@@ -2,7 +2,9 @@ name: test-sp1
 
 on:
   push:
-    branches: [main]
+    branches:
+      - testnet
+      - staging
   pull_request:
     branches: ["*"]
     paths:


### PR DESCRIPTION
# Run workflows on pushes to testnet/staging

## Description

Previously, workflows were set to run on pushes to 'main' branch, but we have branches 'testnet' and 'staging'

Closes #1980 

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
