### PR TITLE
fix: update explorer URL printed after proof submission

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -622,9 +622,14 @@ async fn main() -> Result<(), AlignedError> {
             }
 
             for batch_merkle_root in unique_batch_merkle_roots {
+                let base_url = match submit_args.network.clone().into() {
+                    Network::Holesky => "https://holesky.explorer.alignedlayer.com/batches/0x",
+                    _ => "https://explorer.alignedlayer.com/batches/0x",
+                };
+
                 info!(
-                    "https://explorer.alignedlayer.com/batches/0x{}",
-                    hex::encode(batch_merkle_root)
+                    "{}",
+                    base_url.to_string() + hex::encode(batch_merkle_root).as_str()
                 );
             }
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -584,7 +584,7 @@ async fn main() -> Result<(), AlignedError> {
             info!("Submitting proofs to the Aligned batcher...");
 
             let aligned_verification_data_vec = submit_multiple(
-                submit_args.network.into(),
+                submit_args.network.clone().into(),
                 &verification_data_arr,
                 max_fee_wei,
                 wallet.clone(),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -623,6 +623,8 @@ async fn main() -> Result<(), AlignedError> {
 
             for batch_merkle_root in unique_batch_merkle_roots {
                 let base_url = match submit_args.network.clone().into() {
+                    // Note: in case the explorer address changes for other networks, we should add an arm to this
+                    // match with that network since the default URL used here is the mainnet one
                     Network::Holesky => "https://holesky.explorer.alignedlayer.com/batches/0x",
                     _ => "https://explorer.alignedlayer.com/batches/0x",
                 };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -624,9 +624,11 @@ async fn main() -> Result<(), AlignedError> {
             for batch_merkle_root in unique_batch_merkle_roots {
                 let base_url = match submit_args.network.clone().into() {
                     Network::Holesky => "https://holesky.explorer.alignedlayer.com/batches/0x",
-                    Network::HoleskyStage => "https://holesky.explorer.alignedlayer.com/batches/0x",
+                    Network::HoleskyStage => "https://stage.explorer.alignedlayer.com/batches/0x",
                     Network::Mainnet => "https://explorer.alignedlayer.com/batches/0x",
-                    Network::MainnetStage => "https://explorer.alignedlayer.com/batches/0x",
+                    Network::MainnetStage => {
+                        "https://mainnetstage.explorer.alignedlayer.com/batches/0x"
+                    }
                     Network::Devnet => "http://localhost:4000/batches/0x",
                     _ => "http://localhost:4000/batches/0x",
                 };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -623,10 +623,12 @@ async fn main() -> Result<(), AlignedError> {
 
             for batch_merkle_root in unique_batch_merkle_roots {
                 let base_url = match submit_args.network.clone().into() {
-                    // Note: in case the explorer address changes for other networks, we should add an arm to this
-                    // match with that network since the default URL used here is the mainnet one
                     Network::Holesky => "https://holesky.explorer.alignedlayer.com/batches/0x",
-                    _ => "https://explorer.alignedlayer.com/batches/0x",
+                    Network::HoleskyStage => "https://holesky.explorer.alignedlayer.com/batches/0x",
+                    Network::Mainnet => "https://explorer.alignedlayer.com/batches/0x",
+                    Network::MainnetStage => "https://explorer.alignedlayer.com/batches/0x",
+                    Network::Devnet => "http://localhost:4000/batches/0x",
+                    _ => "http://localhost:4000/batches/0x",
                 };
 
                 info!(


### PR DESCRIPTION
## Description

This PR updates the explorer URL printed after a proof submission. Also left a comment explaining that the default URL used is the one for mainnet, and in case the explorer's URL changes for another network, it should change here too.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
