### PR TITLE
fix(operator): pin go-ethereum and eigenlayer-cli version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ deps: submodules go_deps build_all_ffi ## Install deps
 go_deps:
 	@echo "Installing Go dependencies..."
 	go install github.com/maoueh/zap-pretty@v0.3.0
-	go install github.com/ethereum/go-ethereum/cmd/abigen@latest
-	go install github.com/Layr-Labs/eigenlayer-cli/cmd/eigenlayer@latest
+	go install github.com/ethereum/go-ethereum/cmd/abigen@v1.14.0
+	go install github.com/Layr-Labs/eigenlayer-cli/cmd/eigenlayer@v0.13.0
 
 foundry_install:
 	curl -L https://foundry.paradigm.xyz | bash


### PR DESCRIPTION
# Pin go-ethereum and eigenlayer-cli version


## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change batcher/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
