### PR TITLE
fix: missing target build_batcher_client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,7 @@ aligned_install_compiling: ## Install Aligned CLI by compiling from source
 	@cargo install --path crates/cli
 
 build_batcher_client:
-	@cd crates/cli && cargo b --release
+	@cd crates/cli && cargo build --release
 
 __SEND_PROOFS__: ## ____
 

--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,9 @@ aligned_uninstall: ## Uninstall Aligned CLI
 aligned_install_compiling: ## Install Aligned CLI by compiling from source
 	@cargo install --path crates/cli
 
+build_batcher_client:
+	@cd crates/cli && cargo b --release
+
 __SEND_PROOFS__: ## ____
 
 crates/target/release/aligned:


### PR DESCRIPTION
# missing target build_batcher_client

## Description

This target is using by release workflow

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
