### PR TITLE
fix: handling of missing keys by checking for "null" values

### DIFF
--- a/scripts/mint_mock_token.sh
+++ b/scripts/mint_mock_token.sh
@@ -22,7 +22,7 @@ mock_token_address=$(cast call "$mock_strategy_address" "underlyingToken()" --rp
 
 operator_address=$(cat "$1" | yq -r '.operator.address')
 
-if [[ -z  "$mock_token_address" ]]; then
+if [[ -z "$mock_token_address" || "$mock_token_address" == "null" ]]; then
   echo "Mock token address is empty, please deploy the contracts first"
   exit 1
 fi;


### PR DESCRIPTION
# TITLE

## Description

added a check for the string `"null"` in addition to empty strings, since sometimes `cast` or `jq` return `"null"` if a key isn’t there. without this, things could get messed up. this should make the key checking more solid.


## Type of change

Please delete options that are not relevant.

- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
