### PR TITLE
docs: fix operator upgrade guide

### DIFF
--- a/docs/operator_guides/0_running_an_operator.md
+++ b/docs/operator_guides/0_running_an_operator.md
@@ -72,13 +72,13 @@ make operator_build ENVIRONMENT=mainnet
 If you want to upgrade the operator in **Testnet**, run:
 
 ```bash
-make operator_start ENVIRONMENT=testnet
+make operator_update ENVIRONMENT=testnet
 ```
 
 If you want to upgrade the operator in **Mainnet**, run:
 
 ```bash
-make operator_start ENVIRONMENT=mainnet
+make operator_update ENVIRONMENT=mainnet
 ```
 
 This will recreate the binaries. You can then proceed to restart the operator.


### PR DESCRIPTION
# Fix operator upgrade guide

## Description

Docs were using incorrect target to update the operator.

Closes #2025 

## Type of change

- [x] Documentation

## Checklist

- [x] “Hotfix” to `testnet`, everything else to `staging`
- [x] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
