### PR TITLE
fix: bump ethereum-genesis-generator image version in network_params.yaml

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -21,7 +21,7 @@ port_publisher:
 
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:4.1.1
+  image: ethpandaops/ethereum-genesis-generator:4.1.19
 
 # Default configuration parameters for the network
 network_params:


### PR DESCRIPTION
#  Bump genesis-generator image version in `network_params.yaml`

## Description

The following error is thrown when trying to start ethereum-package after pruning all previous images:
```
Caused by: Unexpected error occurred starting service 'cl-1-lighthouse-reth'
  Caused by: An error occurred waiting for all TCP and UDP ports to be open for service 'cl-1-lighthouse-reth' with private IP '172.16.0.14'; this is usually due to a misconfiguration in the service itself, so here are the logs:
  == SERVICE 'cl-1-lighthouse-reth' LOGS ===================================
  Jul 30 18:33:11.710 INFO  Lighthouse started                            version: "Lighthouse/v7.1.0-cfb1f73"
  Jul 30 18:33:11.710 INFO  Configured network                            network_name: "custom (/network-configs)"
  Jul 30 18:33:11.717 INFO  Data directory initialised                    datadir: /data/lighthouse/beacon-data
  Jul 30 18:33:11.717 WARN  Discv5 packet filter is disabled
  Jul 30 18:33:11.722 INFO  Deposit contract                              deploy_block: 0, address: 0x00000000219ab540356cbb839cbe05303d7705fa
  Jul 30 18:33:11.735 INFO  Blob DB initialized                           path: "/data/lighthouse/beacon-data/beacon/blobs_db", oldest_blob_slot: Some(Slot(0)), oldest_data_column_slot: None
  Jul 30 18:33:13.893 INFO  Starting from known genesis state
  Jul 30 18:33:13.897 INFO  Block production enabled
  Jul 30 18:33:13.899 CRIT  Failed to start beacon node                   reason: "Failed to build beacon chain: Head block not found in store"
  Jul 30 18:33:13.899 INFO  Internal shutdown received
  Jul 30 18:33:13.899 INFO  Shutting down..                               reason: Failure("Failed to start beacon node")
  Failed to start beacon node
  ```
  This PR bumps the ethereum-genesis-generator image version to the latest. See: https://github.com/ethpandaops/ethereum-package/blob/3d2c71c72a4ed32c94c3334e41f7821b124aab3e/network_params.yaml#L209 and https://github.com/ethpandaops/ethereum-genesis-generator/releases/tag/v4.1.19.
  
  ## How to test
  
  1. Clean all cached Kurtosis images
  2. Run `make ethereum_package_start` with and without this change.

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
