### PR TITLE
Sp1 task sender

### DIFF
--- a/crates/task-sender/README.md
+++ b/crates/task-sender/README.md
@@ -1,4 +1,5 @@
 # Task Sender
+
 This CLI is made to stress-test the network.
 
 It has the following commands:
@@ -8,6 +9,7 @@ It has the following commands:
 This command is to generate N Groth16 proofs.
 
 To run it, you can:
+
 ```bash
 cargo run --release -- generate-proofs \
         --number-of-proofs <NUMBER_OF_PROOFS> --proof-type groth16 \
@@ -15,14 +17,17 @@ cargo run --release -- generate-proofs \
 ```
 
 We also have a make target:
+
 ```bash
 NUMBER_OF_PROOFS=15 make task_sender_generate_groth16_proofs
 ```
+
 ## GenerateAndFundWallets
 
 This command is to generate N wallets, and fund them in the BatcherPaymentService.
 
 To run it, you can:
+
 ```bash
 cargo run --release -- generate-and-fund-wallets \
         --eth-rpc-url <RPC_URL> \
@@ -35,17 +40,20 @@ cargo run --release -- generate-and-fund-wallets \
 ```
 
 ### In Testnet
+
 ```bash
 NUM_WALLETS=<N> make task_sender_generate_and_fund_wallets_holesky_stage
 ```
 
 ### In Devnet:
 Run anvil with more prefunded accounts, using the following make target:
+
 ```bash
 make anvil_start_with_more_prefunded_accounts
 ```
 
 Then run the following make target, with `NUM_WALLETS` being the amount of wallets you want to deposit funds to aligned payment service, up to 1000.
+
 ```bash
 NUM_WALLETS=<N> make task_sender_generate_and_fund_wallets_devnet
 ```
@@ -56,20 +64,55 @@ This command sends `BURST_SIZE` proofs from each private key in `PATH_TO_PRIVATE
 
 To vary the amount of senders, it is recommended to have a backup with all private keys, and add/remove keys from the file being used.
 
-To run it, you can:
+Note: The `--random-address` flag is optional and will use the address a salt to avoid the repetitions of batches.
+
+### RISC Zero Proofs
+
 ```bash
 cargo run --release -- send-infinite-proofs \
-        --burst-size <BURST_SIZE> --burst-time-secs <BURST_TIME_SECS> \
-        --eth-rpc-url <RPC_URL> \
-        --network <network> \
-        --proofs-dirpath $(PWD)/scripts/test_files/task_sender/proofs \
-        --private-keys-filepath <PATH_TO_PRIVATE_KEYS_FILE>
+        --private-keys-filepath <PATH_TO_PRIVATE_KEYS_FILE> \
+        --random-address \
+        --burst-size <BURST_SIZE> \
+        --burst-time-secs <BURST_TIME_SECS> \
+        --network <NETWORK> \
+        risc0 \
+            --proof-path ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci_2_2_0.proof \
+            --bin-path ./scripts/test_files/risc_zero/fibonacci_proof_generator/fibonacci_id_2_2_0.bin \
+            --pub-path ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci_2_2_0.pub
 ```
 
-We also have the following related make targets
+### Gnark Groth16 Proofs
+
+```bash
+cargo run --release -- send-infinite-proofs \
+        --private-keys-filepath <PATH_TO_PRIVATE_KEYS_FILE> \
+        --random-address \
+        --burst-size <BURST_SIZE> \
+        --burst-time-secs <BURST_TIME_SECS> \
+        --network <NETWORK> \
+        gnark-groth16 --proofs-dir ./scripts/test_files/gnark_groth16_bn254_script
+```
+
+### SP1 Proofs
+
+```bash
+cargo run --release --manifest-path ./crates/task-sender/Cargo.toml -- send-infinite-proofs \
+        --private-keys-filepath <PATH_TO_PRIVATE_KEYS_FILE> \
+        --burst-size <BURST_SIZE> \
+        --burst-time-secs <BURST_TIME_SECS> \
+        --random-address \
+        sp1 \
+        --proof-path ./scripts/test_files/sp1/sp1_fibonacci_5_0_0.proof \
+        --elf-path ./scripts/test_files/sp1/sp1_fibonacci_5_0_0.elf \
+        --pub-path ./scripts/test_files/sp1/sp1_fibonacci_5_0_0.pub
+```
+
+We also have the following related make targets:
+
 ```bash
 BURST_SIZE=<N> BURST_TIME_SECS=<N> make task_sender_send_infinite_proofs_devnet
 ```
+
 ```bash
 BURST_SIZE=<N> BURST_TIME_SECS=<N> make task_sender_send_infinite_proofs_holesky_stage
 ```
@@ -79,15 +122,18 @@ BURST_SIZE=<N> BURST_TIME_SECS=<N> make task_sender_send_infinite_proofs_holesky
 This command enables and hangs N connections with the Batcher.
 
 To run it, you can:
-```
-cargo run --release -- test-connections \
+
+```bash
+cargo run --release --manifest-path ./crates/task-sender/Cargo.toml -- test-connections \
         --num-senders <NUM_SENDERS>
 ```
 
 We also have the following related make targets:
+
 ```bash
 NUM_SENDERS=<N> make task_sender_test_connections_devnet
 ```
+
 ```bash
 NUM_SENDERS=<N> make task_sender_test_connections_holesky_stage
 ```

--- a/crates/task-sender/src/commands.rs
+++ b/crates/task-sender/src/commands.rs
@@ -436,6 +436,36 @@ pub async fn send_infinite_proofs(args: SendInfiniteProofsArgs) {
                 proof_generator_addr: Address::zero(), // Will be set randomly in the loop
             }]
         }
+        InfiniteProofType::SP1 {
+            proof_path,
+            elf_path,
+            pub_path,
+        } => {
+            info!("Loading SP1 proof files");
+            let Ok(proof) = std::fs::read(proof_path) else {
+                error!("Could not read proof file: {}", proof_path);
+                return;
+            };
+            let Ok(vm_program) = std::fs::read(elf_path) else {
+                error!("Could not read ELF file: {}", elf_path);
+                return;
+            };
+            let pub_input = if let Some(pub_path) = pub_path {
+                std::fs::read(pub_path).ok()
+            } else {
+                None
+            };
+
+            // Create template verification data (without proof_generator_addr)
+            vec![VerificationData {
+                proving_system: ProvingSystemId::SP1,
+                proof,
+                pub_input,
+                verification_key: None,
+                vm_program_code: Some(vm_program),
+                proof_generator_addr: Address::zero(), // Will be set randomly in the loop
+            }]
+        }
     };
 
     info!("Proofs loaded!");

--- a/crates/task-sender/src/commands.rs
+++ b/crates/task-sender/src/commands.rs
@@ -412,29 +412,13 @@ pub async fn send_infinite_proofs(args: SendInfiniteProofsArgs) {
             pub_path,
         } => {
             info!("Loading RISC Zero proof files");
-            let Ok(proof) = std::fs::read(proof_path) else {
-                error!("Could not read proof file: {}", proof_path);
-                return;
-            };
-            let Ok(vm_program) = std::fs::read(bin_path) else {
-                error!("Could not read bin file: {}", bin_path);
-                return;
-            };
-            let pub_input = if let Some(pub_path) = pub_path {
-                std::fs::read(pub_path).ok()
-            } else {
-                None
-            };
-
-            // Create template verification data (without proof_generator_addr)
-            vec![VerificationData {
-                proving_system: ProvingSystemId::Risc0,
-                proof,
-                pub_input,
-                verification_key: None,
-                vm_program_code: Some(vm_program),
-                proof_generator_addr: Address::zero(), // Will be set randomly in the loop
-            }]
+            match load_risc0_verification_data(proof_path, bin_path, pub_path) {
+                Ok(data) => data,
+                Err(err) => {
+                    error!("Failed to load RISC Zero files: {}", err);
+                    return;
+                }
+            }
         }
         InfiniteProofType::SP1 {
             proof_path,
@@ -442,29 +426,13 @@ pub async fn send_infinite_proofs(args: SendInfiniteProofsArgs) {
             pub_path,
         } => {
             info!("Loading SP1 proof files");
-            let Ok(proof) = std::fs::read(proof_path) else {
-                error!("Could not read proof file: {}", proof_path);
-                return;
-            };
-            let Ok(vm_program) = std::fs::read(elf_path) else {
-                error!("Could not read ELF file: {}", elf_path);
-                return;
-            };
-            let pub_input = if let Some(pub_path) = pub_path {
-                std::fs::read(pub_path).ok()
-            } else {
-                None
-            };
-
-            // Create template verification data (without proof_generator_addr)
-            vec![VerificationData {
-                proving_system: ProvingSystemId::SP1,
-                proof,
-                pub_input,
-                verification_key: None,
-                vm_program_code: Some(vm_program),
-                proof_generator_addr: Address::zero(), // Will be set randomly in the loop
-            }]
+            match load_sp1_verification_data(proof_path, elf_path, pub_path) {
+                Ok(data) => data,
+                Err(err) => {
+                    error!("Failed to load SP1 files: {}", err);
+                    return;
+                }
+            }
         }
     };
 
@@ -589,4 +557,50 @@ fn get_verification_data_from_proofs_folder(
     }
 
     verifications_data
+}
+
+fn load_risc0_verification_data(
+    proof_path: &str,
+    bin_path: &str,
+    pub_path: &Option<String>,
+) -> Result<Vec<VerificationData>, std::io::Error> {
+    let proof = std::fs::read(proof_path)?;
+    let vm_program = std::fs::read(bin_path)?;
+    let pub_input = if let Some(pub_path) = pub_path {
+        std::fs::read(pub_path).ok()
+    } else {
+        None
+    };
+
+    Ok(vec![VerificationData {
+        proving_system: ProvingSystemId::Risc0,
+        proof,
+        pub_input,
+        verification_key: None,
+        vm_program_code: Some(vm_program),
+        proof_generator_addr: Address::zero(),
+    }])
+}
+
+fn load_sp1_verification_data(
+    proof_path: &str,
+    elf_path: &str,
+    pub_path: &Option<String>,
+) -> Result<Vec<VerificationData>, std::io::Error> {
+    let proof = std::fs::read(proof_path)?;
+    let vm_program = std::fs::read(elf_path)?;
+    let pub_input = if let Some(pub_path) = pub_path {
+        std::fs::read(pub_path).ok()
+    } else {
+        None
+    };
+
+    Ok(vec![VerificationData {
+        proving_system: ProvingSystemId::SP1,
+        proof,
+        pub_input,
+        verification_key: None,
+        vm_program_code: Some(vm_program),
+        proof_generator_addr: Address::zero(),
+    }])
 }

--- a/crates/task-sender/src/structs.rs
+++ b/crates/task-sender/src/structs.rs
@@ -158,6 +158,18 @@ pub enum InfiniteProofType {
         )]
         pub_path: Option<String>,
     },
+    #[clap(about = "Send infinite SP1 proofs from file paths")]
+    SP1 {
+        #[arg(name = "Path to SP1 proof file (.proof)", long = "proof-path")]
+        proof_path: String,
+        #[arg(name = "Path to SP1 ELF file (.elf)", long = "elf-path")]
+        elf_path: String,
+        #[arg(
+            name = "Path to SP1 public input file (.pub) - optional",
+            long = "pub-path"
+        )]
+        pub_path: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
# Sp1 task sender

# Aligned Payment Service Testing Guide

This guide walks you through testing the Aligned payment service with different proof systems. You'll need to set up wallets, fund them, and then choose from three different proof verification options.

## Prerequisites

Make sure you have a local Anvil node running on `http://localhost:8545`

## Setup Steps

### 1. Create Wallets File

First, create a file with test wallet private keys:

```sh
echo "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba" > wallets.txt
```

### 2. Fund Wallets

Fund the wallets in the Aligned payment service:

```sh
cargo run --release --manifest-path ./crates/task-sender/Cargo.toml -- generate-and-fund-wallets \
    --eth-rpc-url http://localhost:8545 \
    --network devnet \
    --funding-wallet-private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
    --number-wallets 5 \
    --amount-to-deposit 1.0 \
    --amount-to-deposit-to-aligned 0.1 \
    --private-keys-filepath ./wallets.txt
```

## Testing Options

After completing the setup steps above, choose **one** of the following proof systems to test:

### Option A: RISC Zero Proofs

```sh
cargo run --release --manifest-path ./crates/task-sender/Cargo.toml -- send-infinite-proofs \
    --private-keys-filepath ./wallets.txt \
    --random-address \
    --burst-size 5 \
    --burst-time-secs 10 \
    --network devnet \
    risc0 \
        --proof-path ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci_2_2_0.proof \
        --bin-path ./scripts/test_files/risc_zero/fibonacci_proof_generator/fibonacci_id_2_2_0.bin \
        --pub-path ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci_2_2_0.pub
```

### Option B: Gnark Groth16 Proofs

```sh
cargo run --release --manifest-path ./crates/task-sender/Cargo.toml -- send-infinite-proofs \
    --private-keys-filepath ./wallets.txt \
    --random-address \
    --burst-size 5 \
    --burst-time-secs 10 \
    --network devnet \
    gnark-groth16 --proofs-dir ./scripts/test_files/gnark_groth16_bn254_script
```

### Option C: SP1 Proofs

```sh
cargo run --release --manifest-path ./crates/task-sender/Cargo.toml -- send-infinite-proofs \
    --private-keys-filepath wallets.txt \
    --burst-size 5 \
    --burst-time-secs 10 \
    --random-address \
    sp1 \
    --proof-path ./scripts/test_files/sp1/sp1_fibonacci_5_0_0.proof \
    --elf-path ./scripts/test_files/sp1/sp1_fibonacci_5_0_0.elf \
    --pub-path ./scripts/test_files/sp1/sp1_fibonacci_5_0_0.pub
```

## What Each Option Does

- **RISC Zero**: Tests with RISC Zero fibonacci proofs using a burst size of 5 proofs every 10 seconds
- **Gnark Groth16**: Tests with Gnark Groth16 BN254 proofs using a burst size of 5 proofs every 10 seconds  
- **SP1**: Tests with SP1 fibonacci proofs using a burst size of 5 proof every 10 seconds

Each test will continuously send proofs to random addresses using the funded wallets until manually stopped.