### PR TITLE
feat(aggregation mode): add retry logic to batches download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ verify_aggregated_proof_risc0:
 		--rpc_url $(RPC_URL)
 
 proof_aggregator_install: ## Install the aggregation mode with proving enabled
-	cargo install --path aggregation_mode --features prove,gpu --bin proof_aggregator --locked
+	cargo install --path aggregation_mode --features prove,gpu --bin proof_aggregator_gpu --locked
 
 proof_aggregator_write_program_ids: ## Write proof aggregator zkvm programs ids
 	@cd aggregation_mode && ./scripts/build_programs.sh

--- a/aggregation_mode/Cargo.lock
+++ b/aggregation_mode/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 1.0.22",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1715,6 +1715,17 @@ dependencies = [
  "instant",
  "pin-project-lite",
  "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
+name = "backon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+dependencies = [
+ "fastrand",
+ "gloo-timers 0.3.0",
  "tokio",
 ]
 
@@ -3805,7 +3816,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "send_wrapper 0.4.0",
 ]
 
@@ -3938,6 +3949,18 @@ name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -6305,6 +6328,7 @@ version = "0.1.0"
 dependencies = [
  "aligned-sdk",
  "alloy 0.15.11",
+ "backon",
  "bincode",
  "c-kzg",
  "ciborium",

--- a/aggregation_mode/Cargo.toml
+++ b/aggregation_mode/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.12" }
 ciborium = "=0.2.2"
 lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks.git", rev = "5f8f2cfcc8a1a22f77e8dff2d581f1166eefb80b", features = ["serde"]}
 rayon = "1.10.0"
+backon = "1.2.0"
 # Necessary for the VerificationData type
 aligned-sdk = { path = "../crates/sdk/" }
 # zkvms

--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -1,9 +1,9 @@
 pub mod config;
 pub mod fetcher;
 mod merkle_tree;
+mod retry;
 mod s3;
 mod types;
-mod retry;
 
 use crate::aggregators::{AlignedProof, ProofAggregationError, ZKVMEngine};
 

--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -3,6 +3,7 @@ pub mod fetcher;
 mod merkle_tree;
 mod s3;
 mod types;
+mod retry;
 
 use crate::aggregators::{AlignedProof, ProofAggregationError, ZKVMEngine};
 

--- a/aggregation_mode/src/backend/retry.rs
+++ b/aggregation_mode/src/backend/retry.rs
@@ -1,0 +1,62 @@
+use backon::ExponentialBuilder;
+use backon::Retryable;
+use std::{future::Future, time::Duration};
+
+#[derive(Debug)]
+pub enum RetryError<E> {
+    Transient(E),
+    Permanent(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for RetryError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            RetryError::Transient(e) => write!(f, "{}", e),
+            RetryError::Permanent(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl<E> RetryError<E> {
+    pub fn inner(self) -> E {
+        match self {
+            RetryError::Transient(e) => e,
+            RetryError::Permanent(e) => e,
+        }
+    }
+}
+
+impl<E: std::fmt::Display> std::error::Error for RetryError<E> where E: std::fmt::Debug {}
+
+/// Supports retries only on async functions. See: https://docs.rs/backon/latest/backon/#retry-an-async-function
+/// Runs with `jitter: false`.
+/// 
+/// # Parameters
+/// * `function` - The async function to retry
+/// * `min_delay_millis` - Initial delay before first retry attempt (in milliseconds)
+/// * `factor` - Exponential backoff multiplier for retry delays
+/// * `max_times` - Maximum number of retry attempts
+/// * `max_delay_seconds` - Maximum delay between retry attempts (in seconds)
+pub async fn retry_function<FutureFn, Fut, T, E>(
+    function: FutureFn,
+    min_delay_millis: u64,
+    factor: f32,
+    max_times: usize,
+    max_delay_seconds: u64,
+) -> Result<T, RetryError<E>>
+    where
+        Fut: Future<Output = Result<T, RetryError<E>>>,
+        FutureFn: FnMut() -> Fut,
+{
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(min_delay_millis))
+        .with_max_times(max_times)
+        .with_factor(factor)
+        .with_max_delay(Duration::from_secs(max_delay_seconds));
+
+    function
+        .retry(backoff)
+        .sleep(tokio::time::sleep)
+        .when(|e| matches!(e, RetryError::Transient(_)))
+        .await
+}

--- a/aggregation_mode/src/backend/retry.rs
+++ b/aggregation_mode/src/backend/retry.rs
@@ -30,7 +30,7 @@ impl<E: std::fmt::Display> std::error::Error for RetryError<E> where E: std::fmt
 
 /// Supports retries only on async functions. See: https://docs.rs/backon/latest/backon/#retry-an-async-function
 /// Runs with `jitter: false`.
-/// 
+///
 /// # Parameters
 /// * `function` - The async function to retry
 /// * `min_delay_millis` - Initial delay before first retry attempt (in milliseconds)
@@ -44,9 +44,9 @@ pub async fn retry_function<FutureFn, Fut, T, E>(
     max_times: usize,
     max_delay_seconds: u64,
 ) -> Result<T, RetryError<E>>
-    where
-        Fut: Future<Output = Result<T, RetryError<E>>>,
-        FutureFn: FnMut() -> Fut,
+where
+    Fut: Future<Output = Result<T, RetryError<E>>>,
+    FutureFn: FnMut() -> Fut,
 {
     let backoff = ExponentialBuilder::default()
         .with_min_delay(Duration::from_millis(min_delay_millis))

--- a/aggregation_mode/src/backend/s3.rs
+++ b/aggregation_mode/src/backend/s3.rs
@@ -1,7 +1,7 @@
-use std::time::Duration;
-use aligned_sdk::common::types::VerificationData;
-use tracing::{info, warn};
 use crate::backend::retry::{retry_function, RetryError};
+use aligned_sdk::common::types::VerificationData;
+use std::time::Duration;
+use tracing::{info, warn};
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -40,20 +40,22 @@ async fn get_aligned_batch_from_s3_retryable(
         .connect_timeout(CONNECT_TIMEOUT_SECONDS)
         .timeout(BATCH_DOWNLOAD_TIMEOUT_SECONDS)
         .build()
-        .map_err(|e| RetryError::Permanent(GetBatchProofsError::ReqwestClientFailed(e.to_string())))?;
-
-    let response = client
-        .get(&url)
-        .send()
-        .await
         .map_err(|e| {
-            warn!("Failed to send request to {}: {}", url, e);
-            RetryError::Transient(GetBatchProofsError::FetchingS3Batch(e.to_string()))
+            RetryError::Permanent(GetBatchProofsError::ReqwestClientFailed(e.to_string()))
         })?;
+
+    let response = client.get(&url).send().await.map_err(|e| {
+        warn!("Failed to send request to {}: {}", url, e);
+        RetryError::Transient(GetBatchProofsError::FetchingS3Batch(e.to_string()))
+    })?;
 
     if !response.status().is_success() {
         let status_code = response.status().as_u16();
-        let reason = response.status().canonical_reason().unwrap_or("").to_string();
+        let reason = response
+            .status()
+            .canonical_reason()
+            .unwrap_or("")
+            .to_string();
 
         // Determine if the error is retryable based on status code
         let error = GetBatchProofsError::StatusFailed((status_code, reason));
@@ -69,20 +71,16 @@ async fn get_aligned_batch_from_s3_retryable(
         };
     }
 
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| {
-            warn!("Failed to read response body from {}: {}", url, e);
-            RetryError::Transient(GetBatchProofsError::EmptyBody(e.to_string()))
-        })?;
+    let bytes = response.bytes().await.map_err(|e| {
+        warn!("Failed to read response body from {}: {}", url, e);
+        RetryError::Transient(GetBatchProofsError::EmptyBody(e.to_string()))
+    })?;
     let bytes: &[u8] = bytes.iter().as_slice();
 
-    let data: Vec<VerificationData> = ciborium::from_reader(bytes)
-        .map_err(|e| {
-            warn!("Failed to deserialize batch data from {}: {}", url, e);
-            RetryError::Permanent(GetBatchProofsError::Deserialization(e.to_string()))
-        })?;
+    let data: Vec<VerificationData> = ciborium::from_reader(bytes).map_err(|e| {
+        warn!("Failed to deserialize batch data from {}: {}", url, e);
+        RetryError::Permanent(GetBatchProofsError::Deserialization(e.to_string()))
+    })?;
 
     Ok(data)
 }

--- a/aggregation_mode/src/backend/s3.rs
+++ b/aggregation_mode/src/backend/s3.rs
@@ -26,8 +26,10 @@ const RETRY_MAX_TIMES: usize = 5;
 /// Maximum delay between retry attempts (in seconds)
 const RETRY_MAX_DELAY_SECONDS: u64 = 10;
 
-/// Timeout for Reqwest Client
-const REQWEST_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
+/// Timeout for establishing a connection to S3
+const CONNECT_TIMEOUT_SECONDS: Duration = Duration::from_secs(10);
+/// Timeout for Batch Download Requests
+const BATCH_DOWNLOAD_TIMEOUT_SECONDS: Duration = Duration::from_secs(5 * 60);
 
 async fn get_aligned_batch_from_s3_retryable(
     url: String,
@@ -35,7 +37,8 @@ async fn get_aligned_batch_from_s3_retryable(
     info!("Fetching batch from S3 URL: {}", url);
     let client = reqwest::Client::builder()
         .user_agent(DEFAULT_USER_AGENT)
-        .timeout(REQWEST_TIMEOUT_SECONDS)
+        .connect_timeout(CONNECT_TIMEOUT_SECONDS)
+        .timeout(BATCH_DOWNLOAD_TIMEOUT_SECONDS)
         .build()
         .map_err(|e| RetryError::Permanent(GetBatchProofsError::ReqwestClientFailed(e.to_string())))?;
 

--- a/aggregation_mode/src/backend/s3.rs
+++ b/aggregation_mode/src/backend/s3.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
 use aligned_sdk::common::types::VerificationData;
+use tracing::{info, warn};
+use crate::backend::retry::{retry_function, RetryError};
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -13,38 +16,92 @@ pub enum GetBatchProofsError {
 // needed to make S3 bucket work
 const DEFAULT_USER_AGENT: &str = "proof-aggregator/aligned-layer";
 
-pub async fn get_aligned_batch_from_s3(
+// Retry parameters for S3 requests
+/// Initial delay before first retry attempt (in milliseconds)
+const RETRY_MIN_DELAY_MILLIS: u64 = 500;
+/// Exponential backoff multiplier for retry delays
+const RETRY_FACTOR: f32 = 2.0;
+/// Maximum number of retry attempts
+const RETRY_MAX_TIMES: usize = 5;
+/// Maximum delay between retry attempts (in seconds)
+const RETRY_MAX_DELAY_SECONDS: u64 = 10;
+
+/// Timeout for Reqwest Client
+const REQWEST_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
+
+async fn get_aligned_batch_from_s3_retryable(
     url: String,
-) -> Result<Vec<VerificationData>, GetBatchProofsError> {
+) -> Result<Vec<VerificationData>, RetryError<GetBatchProofsError>> {
+    info!("Fetching batch from S3 URL: {}", url);
     let client = reqwest::Client::builder()
         .user_agent(DEFAULT_USER_AGENT)
+        .timeout(REQWEST_TIMEOUT_SECONDS)
         .build()
-        .map_err(|e| GetBatchProofsError::ReqwestClientFailed(e.to_string()))?;
+        .map_err(|e| RetryError::Permanent(GetBatchProofsError::ReqwestClientFailed(e.to_string())))?;
 
     let response = client
-        .get(url)
+        .get(&url)
         .send()
         .await
-        .map_err(|e| GetBatchProofsError::FetchingS3Batch(e.to_string()))?;
+        .map_err(|e| {
+            warn!("Failed to send request to {}: {}", url, e);
+            RetryError::Transient(GetBatchProofsError::FetchingS3Batch(e.to_string()))
+        })?;
+
     if !response.status().is_success() {
-        return Err(GetBatchProofsError::StatusFailed((
-            response.status().as_u16(),
-            response
-                .status()
-                .canonical_reason()
-                .unwrap_or("")
-                .to_string(),
-        )));
+        let status_code = response.status().as_u16();
+        let reason = response.status().canonical_reason().unwrap_or("").to_string();
+
+        // Determine if the error is retryable based on status code
+        let error = GetBatchProofsError::StatusFailed((status_code, reason));
+        return match status_code {
+            // Client errors (4xx) are generally permanent, except for specific cases
+            400..=499 => match status_code {
+                408 | 429 => Err(RetryError::Transient(error)), // Request Timeout, Too Many Requests
+                _ => Err(RetryError::Permanent(error)),
+            },
+            // Server errors (5xx) are generally transient
+            500..=599 => Err(RetryError::Transient(error)),
+            _ => Err(RetryError::Permanent(error)),
+        };
     }
 
     let bytes = response
         .bytes()
         .await
-        .map_err(|e| GetBatchProofsError::EmptyBody(e.to_string()))?;
+        .map_err(|e| {
+            warn!("Failed to read response body from {}: {}", url, e);
+            RetryError::Transient(GetBatchProofsError::EmptyBody(e.to_string()))
+        })?;
     let bytes: &[u8] = bytes.iter().as_slice();
 
     let data: Vec<VerificationData> = ciborium::from_reader(bytes)
-        .map_err(|e| GetBatchProofsError::Deserialization(e.to_string()))?;
+        .map_err(|e| {
+            warn!("Failed to deserialize batch data from {}: {}", url, e);
+            RetryError::Permanent(GetBatchProofsError::Deserialization(e.to_string()))
+        })?;
 
     Ok(data)
+}
+
+/// Download batch from Storage Service using the provided URL.
+///
+/// Retries on recoverable errors using exponential backoff up to `RETRY_MAX_TIMES` times:
+/// (0,5 secs - 1 secs - 2 secs - 4 secs - 8 secs).
+pub async fn get_aligned_batch_from_s3(
+    url: String,
+) -> Result<Vec<VerificationData>, GetBatchProofsError> {
+    let url_clone = url.clone();
+    retry_function(
+        move || {
+            let url = url_clone.clone();
+            get_aligned_batch_from_s3_retryable(url)
+        },
+        RETRY_MIN_DELAY_MILLIS,
+        RETRY_FACTOR,
+        RETRY_MAX_TIMES,
+        RETRY_MAX_DELAY_SECONDS,
+    )
+    .await
+    .map_err(|retry_err| retry_err.inner())
 }


### PR DESCRIPTION
# feat(aggregation mode): add retry logic to batches download

## Description

This PR adds retry logic to the download of batches on the aggregation mode

The retry parameters are 

```rust
// Retry parameters for S3 requests
/// Initial delay before first retry attempt (in milliseconds)
const RETRY_MIN_DELAY_MILLIS: u64 = 500;
/// Exponential backoff multiplier for retry delays
const RETRY_FACTOR: f32 = 2.0;
/// Maximum number of retry attempts
const RETRY_MAX_TIMES: usize = 5;
/// Maximum delay between retry attempts (in seconds)
const RETRY_MAX_DELAY_SECONDS: u64 = 10;
```

## How to Test

1. Run Ethereum Package

```
make ethereum_package_start
```

2. Run batcher

```
make batcher_start_ethereum_package
```

3.  Send tasks

```
make batcher_send_proof_with_random_address
```

4. Run aggregation mode

```
make proof_aggregator_start_ethereum_package AGGREGATOR=sp1
```

In this case, the aggregation mode should be able to fetch the batch from Localstack.

5. Stop Localstack

6. Run aggregation mode

```
make proof_aggregator_start_ethereum_package AGGREGATOR=sp1
```

In this case, you should see the process tries to fetch the batch, waiting before doing a retry using exponential backoff,

```
2025-08-05T18:22:09.684662Z  INFO proof_aggregator::backend::s3: Fetching batch from S3 URL: http://localhost:4566/aligned.storage/628809ec4e40fd964766a0fe33e47d6779816b411a8310e1c6202fe00f2d7675.json
2025-08-05T18:22:09.685407Z  WARN proof_aggregator::backend::s3: Failed to send request to http://localhost:4566/aligned.storage/628809ec4e40fd964766a0fe33e47d6779816b411a8310e1c6202fe00f2d7675.json: error sending request for url (http://localhost:4566/aligned.storage/628809ec4e40fd964766a0fe33e47d6779816b411a8310e1c6202fe00f2d7675.json)
2025-08-05T18:22:10.187615Z  INFO proof_aggregator::backend::s3: Fetching batch from S3 URL: http://localhost:4566/aligned.storage/628809ec4e40fd964766a0fe33e47d6779816b411a8310e1c6202fe00f2d7675.json
2025-08-05T18:22:10.189572Z  WARN proof_aggregator::backend::s3: Failed to send request to http://localhost:4566/aligned.storage/628809ec4e40fd964766a0fe33e47d6779816b411a8310e1c6202fe00f2d7675.json: error sending request for url (http://localhost:4566/aligned.storage/628809ec4e40fd964766a0fe33e47d6779816b411a8310e1c6202fe00f2d7675.json)
```

7. Start Localstack again. In this case, the storage will be available, but the batch will not exist. This is a permanent error.

8. Run aggregation mode

```
make proof_aggregator_start_ethereum_package AGGREGATOR=sp1
```

In this case, the error is permanent, so the process will not retry. You should see the following logs:

```
2025-08-05T18:27:32.397180Z ERROR proof_aggregator::backend::fetcher: Error while downloading proofs from s3. Err StatusFailed((404, "Not Found"))
```


## Type of change

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
