### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/build-and-test-go.yml
+++ b/.github/workflows/build-and-test-go.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: aligned-runner
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -86,7 +86,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: foundry-toolchain
         uses: foundry-rs/foundry-toolchain@v1.2.0

--- a/.github/workflows/build-contracts.yml
+++ b/.github/workflows/build-contracts.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -24,7 +24,7 @@ jobs:
           version: 1.70.0
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Display Branch Name
         env:

--- a/.github/workflows/foundry-gas-diff.yml
+++ b/.github/workflows/foundry-gas-diff.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: ./contracts
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Build batcher client
         run: make build_batcher_client

--- a/.github/workflows/send-proofs-docker.yml
+++ b/.github/workflows/send-proofs-docker.yml
@@ -31,7 +31,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
 

--- a/.github/workflows/test-merkle-tree.yml
+++ b/.github/workflows/test-merkle-tree.yml
@@ -24,7 +24,7 @@ jobs:
             sudo rm -rf /usr/share/dotnet
             sudo rm -rf /opt/ghc
             sudo rm -rf "/usr/local/share/boost"
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: actions/setup-go@v5
           with:
             go-version: '1.22'

--- a/.github/workflows/test-risc-zero.yml
+++ b/.github/workflows/test-risc-zero.yml
@@ -24,7 +24,7 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: "1.23"

--- a/.github/workflows/test-sp1.yml
+++ b/.github/workflows/test-sp1.yml
@@ -15,7 +15,7 @@ jobs:
     test:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: actions/setup-go@v5
           with:
             go-version: '1.22'

--- a/contracts/.github/workflows/test.yml
+++ b/contracts/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0