### PR TITLE
refactor: use Hashmap instead of Dashmap

### DIFF
--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1430,7 +1430,7 @@ impl Batcher {
 
         // Update metrics
         let queue_len = batch_state_lock.batch_queue.len();
-        let queue_size_bytes: i64= 100;
+        let queue_size_bytes: i64= 0;
         // let queue_size_bytes = calculate_batch_size(&batch_state_lock.batch_queue)?;
         self.metrics
             .update_queue_metrics(queue_len as i64, queue_size_bytes as i64);

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -878,6 +878,7 @@ impl Batcher {
         let is_user_in_state = self.user_states.contains_key(&addr);
 
         if !is_user_in_state {
+            info!("User state for address {addr:?} not found, creating a new one");
             // We add a dummy user state to grab a lock on the user state
             let dummy_user_state = UserState::new(U256::zero());
             self.user_states

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -884,12 +884,12 @@ impl Batcher {
         let is_user_in_state = self.user_states.contains_key(&addr);
 
         if !is_user_in_state {
-            info!("User state for address {addr:?} not found, creating a new one");
+            warn!("User state for address {addr:?} not found, creating a new one");
             // We add a dummy user state to grab a lock on the user state
             let dummy_user_state = UserState::new(U256::zero());
             self.user_states
                 .insert(addr, Arc::new(Mutex::new(dummy_user_state)));
-            info!("Dummy user state for address {addr:?} created");
+            warn!("Dummy user state for address {addr:?} created");
         }
 
         let Some(user_state_ref) = self.user_states.get(&addr) else {

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -794,6 +794,7 @@ impl Batcher {
         client_msg: Box<SubmitProofMessage>,
         ws_conn_sink: WsMessageSink,
     ) -> Result<(), Error> {
+        let start_time = std::time::Instant::now();
         let msg_nonce = client_msg.verification_data.nonce;
         debug!("Received message with nonce: {msg_nonce:?}");
         self.metrics.received_proofs.inc();
@@ -820,6 +821,8 @@ impl Batcher {
         // All check functions sends the error to the metrics server and logs it
         // if they return false
 
+        let validation_start = std::time::Instant::now();
+        
         if !self.msg_chain_id_is_valid(&client_msg, &ws_conn_sink).await {
             return Ok(());
         }
@@ -844,6 +847,8 @@ impl Batcher {
         else {
             return Ok(());
         };
+        
+        warn!("Message validations completed for {:?} in {:?}", addr_in_msg, validation_start.elapsed());
 
         let addr;
         let signature = client_msg.signature;
@@ -870,6 +875,7 @@ impl Batcher {
         }
 
         info!("Handling message, locking user state");
+        let user_state_start = std::time::Instant::now();
 
         // We acquire the lock first only to query if the user is already present and the lock is dropped.
         // If it was not present, then the user nonce is queried to the Aligned contract.
@@ -905,9 +911,12 @@ impl Batcher {
             send_message(ws_conn_sink.clone(), SubmitProofResponseMessage::ServerBusy).await;
             return Ok(());
         };
+        
+        warn!("User lock acquired for {:?} in {:?}", addr, user_state_start.elapsed());
 
         // If the user state was not present, we need to get the nonce from the Ethereum contract and update the dummy user state
         if !is_user_in_state {
+            let nonce_fetch_start = std::time::Instant::now();
             let ethereum_user_nonce = match self.get_user_nonce_from_ethereum(addr).await {
                 Ok(ethereum_user_nonce) => ethereum_user_nonce,
                 Err(e) => {
@@ -923,6 +932,7 @@ impl Batcher {
                     return Ok(());
                 }
             };
+            warn!("Ethereum nonce fetched for {:?} in {:?}", addr, nonce_fetch_start.elapsed());
             // Update the dummy user state with the correct nonce
             user_state_guard.nonce = ethereum_user_nonce;
         }
@@ -931,6 +941,7 @@ impl Batcher {
         // *        Perform validations over user state         *
         // * ---------------------------------------------------*
 
+        let balance_validation_start = std::time::Instant::now();
         let Some(user_balance) = self.get_user_balance(&addr).await else {
             error!("Could not get balance for address {addr:?}");
             send_message(
@@ -1001,7 +1012,10 @@ impl Batcher {
             self.metrics.user_error(&["invalid_max_fee", ""]);
             return Ok(());
         }
+        
+        warn!("Balance and nonce validations completed for {:?} in {:?}", addr, balance_validation_start.elapsed());
 
+        let proof_verification_start = std::time::Instant::now();
         if !self
             .verify_proof_if_enabled(
                 &nonced_verification_data.verification_data,
@@ -1011,11 +1025,13 @@ impl Batcher {
         {
             return Ok(());
         }
+        warn!("Proof verification completed for {:?} in {:?}", addr, proof_verification_start.elapsed());
 
         // * ---------------------------------------------------------------------*
         // *        Perform validation over batcher queue                         *
         // * ---------------------------------------------------------------------*
 
+        let queue_management_start = std::time::Instant::now();
         let Some(mut batch_state_lock) = self
             .try_batch_lock_with_timeout(self.batch_state.lock())
             .await
@@ -1119,11 +1135,14 @@ impl Batcher {
                 return Ok(());
             }
         }
+        
+        warn!("Queue management and eviction logic completed for {:?} in {:?}", addr, queue_management_start.elapsed());
 
         // * ---------------------------------------------------------------------*
         // *        Add message data into the queue and update user state         *
         // * ---------------------------------------------------------------------*
 
+        let add_to_batch_start = std::time::Instant::now();
         if let Err(e) = self
             .add_to_batch(
                 batch_state_lock,
@@ -1147,8 +1166,10 @@ impl Batcher {
         user_state_guard.last_max_fee_limit = max_fee;
         user_state_guard.proofs_in_batch += 1;
         user_state_guard.total_fees_in_queue += max_fee;
+        
+        warn!("Add to batch and user state update completed for {:?} in {:?}", addr, add_to_batch_start.elapsed());
 
-        info!("Verification data message handled");
+        warn!("Verification data message handled for {:?} - total time: {:?}", addr, start_time.elapsed());
         Ok(())
     }
 

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -108,9 +108,9 @@ pub struct Batcher {
     /// Flag to indicate when recovery is in progress
     /// When true, message handlers will return ServerBusy responses
     /// It's used a way to "lock" all the user_states at the same time
-    /// If one needed is taken in the handle message it will timeout
+    /// If one needed is taken in the handle message it will time out
     is_recovering_from_submission_failure: RwLock<bool>,
-    user_states: Arc<tokio::sync::RwLock<HashMap<Address, Arc<Mutex<UserState>>>>>,
+    user_states: Arc<RwLock<HashMap<Address, Arc<Mutex<UserState>>>>>,
 
     last_uploaded_batch_block: Mutex<u64>,
 
@@ -180,7 +180,7 @@ impl Batcher {
         let deployment_output =
             ContractDeploymentOutput::new(config.aligned_layer_deployment_config_file_path);
 
-        log::info!(
+        info!(
             "Starting metrics server on port {}",
             config.batcher.metrics_port
         );
@@ -261,7 +261,7 @@ impl Batcher {
         .await
         .expect("Failed to get fallback Service Manager contract");
 
-        let user_states = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+        let user_states = Arc::new(RwLock::new(HashMap::new()));
         let batch_state = BatchState::new(config.batcher.max_queue_size);
         let non_paying_config = if let Some(non_paying_config) = config.batcher.non_paying {
             warn!("Non-paying address configuration detected. Will replace non-paying address {} with configured address.",
@@ -391,7 +391,7 @@ impl Batcher {
 
     fn calculate_new_user_states_data(
         &self,
-        batch_queue: &types::batch_queue::BatchQueue,
+        batch_queue: &batch_queue::BatchQueue,
     ) -> HashMap<Address, (usize, U256, U256)> {
         let mut updated_user_states = HashMap::new();
         for (entry, _) in batch_queue.iter() {
@@ -847,7 +847,7 @@ impl Batcher {
             return Ok(());
         };
         
-        warn!("Message validations completed for {:?} in {:?}", addr_in_msg, validation_start.elapsed());
+        debug!("Message validations completed for {:?} in {:?}", addr_in_msg, validation_start.elapsed());
 
         let addr;
         let signature = client_msg.signature;
@@ -883,12 +883,12 @@ impl Batcher {
         let is_user_in_state = self.user_states.read().await.contains_key(&addr);
 
         if !is_user_in_state {
-            warn!("User state for address {addr:?} not found, creating a new one");
+            debug!("User state for address {addr:?} not found, creating a new one");
             // We add a dummy user state to grab a lock on the user state
             let dummy_user_state = UserState::new(U256::zero());
             self.user_states
                 .write().await.insert(addr, Arc::new(Mutex::new(dummy_user_state)));
-            warn!("Dummy user state for address {addr:?} created");
+            debug!("Dummy user state for address {addr:?} created");
         }
 
         let Some(user_state_ref) = self.user_states.read().await.get(&addr).cloned() else {
@@ -911,7 +911,7 @@ impl Batcher {
             return Ok(());
         };
         
-        warn!("User lock acquired for {:?} in {:?}", addr, user_state_start.elapsed());
+        debug!("User lock acquired for {:?} in {:?}", addr, user_state_start.elapsed());
 
         // If the user state was not present, we need to get the nonce from the Ethereum contract and update the dummy user state
         if !is_user_in_state {
@@ -1011,8 +1011,8 @@ impl Batcher {
             self.metrics.user_error(&["invalid_max_fee", ""]);
             return Ok(());
         }
-        
-        warn!("Balance and nonce validations completed for {:?} in {:?}", addr, balance_validation_start.elapsed());
+
+        debug!("Balance and nonce validations completed for {:?} in {:?}", addr, balance_validation_start.elapsed());
 
         let proof_verification_start = std::time::Instant::now();
         if !self
@@ -1024,7 +1024,7 @@ impl Batcher {
         {
             return Ok(());
         }
-        warn!("Proof verification completed for {:?} in {:?}", addr, proof_verification_start.elapsed());
+        debug!("Proof verification completed for {:?} in {:?}", addr, proof_verification_start.elapsed());
 
         // * ---------------------------------------------------------------------*
         // *        Perform validation over batcher queue                         *
@@ -1134,8 +1134,8 @@ impl Batcher {
                 return Ok(());
             }
         }
-        
-        warn!("Queue management and eviction logic completed for {:?} in {:?}", addr, queue_management_start.elapsed());
+
+        debug!("Queue management and eviction logic completed for {:?} in {:?}", addr, queue_management_start.elapsed());
 
         // * ---------------------------------------------------------------------*
         // *        Add message data into the queue and update user state         *
@@ -1165,10 +1165,9 @@ impl Batcher {
         user_state_guard.last_max_fee_limit = max_fee;
         user_state_guard.proofs_in_batch += 1;
         user_state_guard.total_fees_in_queue += max_fee;
-        
-        warn!("Add to batch and user state update completed for {:?} in {:?}", addr, add_to_batch_start.elapsed());
+        debug!("Add to batch and user state update completed for {:?} in {:?}", addr, add_to_batch_start.elapsed());
 
-        warn!("Verification data message handled for {:?} - total time: {:?}", addr, start_time.elapsed());
+        debug!("Verification data message handled for {:?} - total time: {:?}", addr, start_time.elapsed());
         Ok(())
     }
 

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -431,7 +431,7 @@ impl Batcher {
     where
         F: std::future::Future<Output = T>,
     {
-        match timeout(Duration::from_secs(150), lock_future).await {
+        match timeout(Duration::from_secs(15), lock_future).await {
             Ok(result) => Some(result),
             Err(_) => {
                 warn!("Batch lock acquisition timed out");

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -793,7 +793,6 @@ impl Batcher {
         client_msg: Box<SubmitProofMessage>,
         ws_conn_sink: WsMessageSink,
     ) -> Result<(), Error> {
-        let start_time = std::time::Instant::now();
         let msg_nonce = client_msg.verification_data.nonce;
         debug!("Received message with nonce: {msg_nonce:?}");
         self.metrics.received_proofs.inc();
@@ -820,8 +819,6 @@ impl Batcher {
         // All check functions sends the error to the metrics server and logs it
         // if they return false
 
-        let validation_start = std::time::Instant::now();
-
         if !self.msg_chain_id_is_valid(&client_msg, &ws_conn_sink).await {
             return Ok(());
         }
@@ -847,11 +844,6 @@ impl Batcher {
             return Ok(());
         };
 
-        debug!(
-            "Message validations completed for {:?} in {:?}",
-            addr_in_msg,
-            validation_start.elapsed()
-        );
 
         let addr;
         let signature = client_msg.signature;
@@ -878,7 +870,6 @@ impl Batcher {
         }
 
         info!("Handling message, locking user state");
-        let user_state_start = std::time::Instant::now();
 
         // We acquire the lock first only to query if the user is already present and the lock is dropped.
         // If it was not present, then the user nonce is queried to the Aligned contract.
@@ -917,15 +908,9 @@ impl Batcher {
             return Ok(());
         };
 
-        debug!(
-            "User lock acquired for {:?} in {:?}",
-            addr,
-            user_state_start.elapsed()
-        );
 
         // If the user state was not present, we need to get the nonce from the Ethereum contract and update the dummy user state
         if !is_user_in_state {
-            let nonce_fetch_start = std::time::Instant::now();
             let ethereum_user_nonce = match self.get_user_nonce_from_ethereum(addr).await {
                 Ok(ethereum_user_nonce) => ethereum_user_nonce,
                 Err(e) => {
@@ -941,11 +926,6 @@ impl Batcher {
                     return Ok(());
                 }
             };
-            warn!(
-                "Ethereum nonce fetched for {:?} in {:?}",
-                addr,
-                nonce_fetch_start.elapsed()
-            );
             // Update the dummy user state with the correct nonce
             user_state_guard.nonce = ethereum_user_nonce;
         }
@@ -954,7 +934,6 @@ impl Batcher {
         // *        Perform validations over user state         *
         // * ---------------------------------------------------*
 
-        let balance_validation_start = std::time::Instant::now();
         let Some(user_balance) = self.get_user_balance(&addr).await else {
             error!("Could not get balance for address {addr:?}");
             send_message(
@@ -1026,13 +1005,7 @@ impl Batcher {
             return Ok(());
         }
 
-        debug!(
-            "Balance and nonce validations completed for {:?} in {:?}",
-            addr,
-            balance_validation_start.elapsed()
-        );
 
-        let proof_verification_start = std::time::Instant::now();
         if !self
             .verify_proof_if_enabled(
                 &nonced_verification_data.verification_data,
@@ -1042,17 +1015,11 @@ impl Batcher {
         {
             return Ok(());
         }
-        debug!(
-            "Proof verification completed for {:?} in {:?}",
-            addr,
-            proof_verification_start.elapsed()
-        );
 
         // * ---------------------------------------------------------------------*
         // *        Perform validation over batcher queue                         *
         // * ---------------------------------------------------------------------*
 
-        let queue_management_start = std::time::Instant::now();
         let Some(mut batch_state_lock) = self
             .try_batch_lock_with_timeout(self.batch_state.lock())
             .await
@@ -1160,17 +1127,11 @@ impl Batcher {
             }
         }
 
-        debug!(
-            "Queue management and eviction logic completed for {:?} in {:?}",
-            addr,
-            queue_management_start.elapsed()
-        );
 
         // * ---------------------------------------------------------------------*
         // *        Add message data into the queue and update user state         *
         // * ---------------------------------------------------------------------*
 
-        let add_to_batch_start = std::time::Instant::now();
         if let Err(e) = self
             .add_to_batch(
                 batch_state_lock,
@@ -1194,17 +1155,6 @@ impl Batcher {
         user_state_guard.last_max_fee_limit = max_fee;
         user_state_guard.proofs_in_batch += 1;
         user_state_guard.total_fees_in_queue += max_fee;
-        debug!(
-            "Add to batch and user state update completed for {:?} in {:?}",
-            addr,
-            add_to_batch_start.elapsed()
-        );
-
-        debug!(
-            "Verification data message handled for {:?} - total time: {:?}",
-            addr,
-            start_time.elapsed()
-        );
         Ok(())
     }
 

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1412,10 +1412,9 @@ impl Batcher {
 
         // Update metrics
         let queue_len = batch_state_lock.batch_queue.len();
-        let queue_size_bytes: i64 = 0;
-        // let queue_size_bytes = calculate_batch_size(&batch_state_lock.batch_queue)?;
+        let queue_size_bytes = calculate_batch_size(&batch_state_lock.batch_queue)?;
         self.metrics
-            .update_queue_metrics(queue_len as i64, queue_size_bytes);
+            .update_queue_metrics(queue_len as i64, queue_size_bytes as i64);
 
         info!("Current batch queue length: {}", queue_len);
 

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1430,9 +1430,9 @@ impl Batcher {
 
         // Update metrics
         let queue_len = batch_state_lock.batch_queue.len();
-        let queue_size_bytes = calculate_batch_size(&batch_state_lock.batch_queue)?;
-        self.metrics
-            .update_queue_metrics(queue_len as i64, queue_size_bytes as i64);
+        // let queue_size_bytes = calculate_batch_size(&batch_state_lock.batch_queue)?;
+        // self.metrics
+        //     .update_queue_metrics(queue_len as i64, queue_size_bytes as i64);
 
         info!("Current batch queue length: {}", queue_len);
 

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -821,7 +821,7 @@ impl Batcher {
         // if they return false
 
         let validation_start = std::time::Instant::now();
-        
+
         if !self.msg_chain_id_is_valid(&client_msg, &ws_conn_sink).await {
             return Ok(());
         }
@@ -846,8 +846,12 @@ impl Batcher {
         else {
             return Ok(());
         };
-        
-        debug!("Message validations completed for {:?} in {:?}", addr_in_msg, validation_start.elapsed());
+
+        debug!(
+            "Message validations completed for {:?} in {:?}",
+            addr_in_msg,
+            validation_start.elapsed()
+        );
 
         let addr;
         let signature = client_msg.signature;
@@ -887,7 +891,9 @@ impl Batcher {
             // We add a dummy user state to grab a lock on the user state
             let dummy_user_state = UserState::new(U256::zero());
             self.user_states
-                .write().await.insert(addr, Arc::new(Mutex::new(dummy_user_state)));
+                .write()
+                .await
+                .insert(addr, Arc::new(Mutex::new(dummy_user_state)));
             debug!("Dummy user state for address {addr:?} created");
         }
 
@@ -910,8 +916,12 @@ impl Batcher {
             send_message(ws_conn_sink.clone(), SubmitProofResponseMessage::ServerBusy).await;
             return Ok(());
         };
-        
-        debug!("User lock acquired for {:?} in {:?}", addr, user_state_start.elapsed());
+
+        debug!(
+            "User lock acquired for {:?} in {:?}",
+            addr,
+            user_state_start.elapsed()
+        );
 
         // If the user state was not present, we need to get the nonce from the Ethereum contract and update the dummy user state
         if !is_user_in_state {
@@ -931,7 +941,11 @@ impl Batcher {
                     return Ok(());
                 }
             };
-            warn!("Ethereum nonce fetched for {:?} in {:?}", addr, nonce_fetch_start.elapsed());
+            warn!(
+                "Ethereum nonce fetched for {:?} in {:?}",
+                addr,
+                nonce_fetch_start.elapsed()
+            );
             // Update the dummy user state with the correct nonce
             user_state_guard.nonce = ethereum_user_nonce;
         }
@@ -1012,7 +1026,11 @@ impl Batcher {
             return Ok(());
         }
 
-        debug!("Balance and nonce validations completed for {:?} in {:?}", addr, balance_validation_start.elapsed());
+        debug!(
+            "Balance and nonce validations completed for {:?} in {:?}",
+            addr,
+            balance_validation_start.elapsed()
+        );
 
         let proof_verification_start = std::time::Instant::now();
         if !self
@@ -1024,7 +1042,11 @@ impl Batcher {
         {
             return Ok(());
         }
-        debug!("Proof verification completed for {:?} in {:?}", addr, proof_verification_start.elapsed());
+        debug!(
+            "Proof verification completed for {:?} in {:?}",
+            addr,
+            proof_verification_start.elapsed()
+        );
 
         // * ---------------------------------------------------------------------*
         // *        Perform validation over batcher queue                         *
@@ -1059,7 +1081,9 @@ impl Batcher {
 
             // Try to find any candidate whose lock we can acquire and immediately process them
             for candidate_addr in eviction_candidates {
-                if let Some(user_state_arc) = self.user_states.read().await.get(&candidate_addr).cloned() {
+                if let Some(user_state_arc) =
+                    self.user_states.read().await.get(&candidate_addr).cloned()
+                {
                     if let Ok(mut user_guard) = user_state_arc.try_lock() {
                         // Found someone whose lock we can get - now find and remove their entry
                         let entries_to_check: Vec<_> = batch_state_lock
@@ -1093,7 +1117,8 @@ impl Batcher {
                                     &removed,
                                     &batch_state_lock.batch_queue,
                                     &mut user_guard,
-                                ).await;
+                                )
+                                .await;
 
                                 if let Some(ref removed_entry_ws) = removed.messaging_sink {
                                     let ws_sink = removed_entry_ws.clone();
@@ -1135,7 +1160,11 @@ impl Batcher {
             }
         }
 
-        debug!("Queue management and eviction logic completed for {:?} in {:?}", addr, queue_management_start.elapsed());
+        debug!(
+            "Queue management and eviction logic completed for {:?} in {:?}",
+            addr,
+            queue_management_start.elapsed()
+        );
 
         // * ---------------------------------------------------------------------*
         // *        Add message data into the queue and update user state         *
@@ -1165,9 +1194,17 @@ impl Batcher {
         user_state_guard.last_max_fee_limit = max_fee;
         user_state_guard.proofs_in_batch += 1;
         user_state_guard.total_fees_in_queue += max_fee;
-        debug!("Add to batch and user state update completed for {:?} in {:?}", addr, add_to_batch_start.elapsed());
+        debug!(
+            "Add to batch and user state update completed for {:?} in {:?}",
+            addr,
+            add_to_batch_start.elapsed()
+        );
 
-        debug!("Verification data message handled for {:?} - total time: {:?}", addr, start_time.elapsed());
+        debug!(
+            "Verification data message handled for {:?} - total time: {:?}",
+            addr,
+            start_time.elapsed()
+        );
         Ok(())
     }
 
@@ -1429,10 +1466,10 @@ impl Batcher {
 
         // Update metrics
         let queue_len = batch_state_lock.batch_queue.len();
-        let queue_size_bytes: i64= 0;
+        let queue_size_bytes: i64 = 0;
         // let queue_size_bytes = calculate_batch_size(&batch_state_lock.batch_queue)?;
         self.metrics
-            .update_queue_metrics(queue_len as i64, queue_size_bytes as i64);
+            .update_queue_metrics(queue_len as i64, queue_size_bytes);
 
         info!("Current batch queue length: {}", queue_len);
 
@@ -1587,7 +1624,10 @@ impl Batcher {
     /// Cleans up user states after successful batch submission.
     /// Resets last_max_fee_limit to U256::MAX for users who had proofs in the submitted batch
     /// but now have no proofs left in the queue.
-    async fn cleanup_user_states_after_successful_submission(&self, finalized_batch: &[BatchQueueEntry]) {
+    async fn cleanup_user_states_after_successful_submission(
+        &self,
+        finalized_batch: &[BatchQueueEntry],
+    ) {
         use std::collections::HashSet;
 
         // Get unique users from the submitted batch
@@ -1611,7 +1651,8 @@ impl Batcher {
         for user_addr in users_in_batch {
             if !current_user_states.contains_key(&user_addr) {
                 // User has no proofs left in queue - reset their max_fee_limit
-                if let Some(user_state_ref) = self.user_states.read().await.get(&user_addr).cloned() {
+                if let Some(user_state_ref) = self.user_states.read().await.get(&user_addr).cloned()
+                {
                     if let Ok(mut user_state_guard) = user_state_ref.try_lock() {
                         user_state_guard.last_max_fee_limit = U256::max_value();
                     }
@@ -1832,7 +1873,8 @@ impl Batcher {
         }
 
         // Clean up user states for users who had proofs in this batch but now have no proofs left
-        self.cleanup_user_states_after_successful_submission(finalized_batch).await;
+        self.cleanup_user_states_after_successful_submission(finalized_batch)
+            .await;
 
         connection::send_batch_inclusion_data_responses(finalized_batch, &batch_merkle_tree).await
     }

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1430,7 +1430,7 @@ impl Batcher {
 
         // Update metrics
         let queue_len = batch_state_lock.batch_queue.len();
-        let queue_size_bytes= 0;
+        let queue_size_bytes: i64= 100;
         // let queue_size_bytes = calculate_batch_size(&batch_state_lock.batch_queue)?;
         self.metrics
             .update_queue_metrics(queue_len as i64, queue_size_bytes as i64);

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -883,6 +883,7 @@ impl Batcher {
             let dummy_user_state = UserState::new(U256::zero());
             self.user_states
                 .insert(addr, Arc::new(Mutex::new(dummy_user_state)));
+            info!("Dummy user state for address {addr:?} created");
         }
 
         let Some(user_state_ref) = self.user_states.get(&addr) else {

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -844,7 +844,6 @@ impl Batcher {
             return Ok(());
         };
 
-
         let addr;
         let signature = client_msg.signature;
         let nonced_verification_data;
@@ -907,7 +906,6 @@ impl Batcher {
             send_message(ws_conn_sink.clone(), SubmitProofResponseMessage::ServerBusy).await;
             return Ok(());
         };
-
 
         // If the user state was not present, we need to get the nonce from the Ethereum contract and update the dummy user state
         if !is_user_in_state {
@@ -1004,7 +1002,6 @@ impl Batcher {
             self.metrics.user_error(&["invalid_max_fee", ""]);
             return Ok(());
         }
-
 
         if !self
             .verify_proof_if_enabled(
@@ -1126,7 +1123,6 @@ impl Batcher {
                 return Ok(());
             }
         }
-
 
         // * ---------------------------------------------------------------------*
         // *        Add message data into the queue and update user state         *

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -17,7 +17,6 @@ use types::batch_state::BatchState;
 use types::user_state::UserState;
 
 use batch_queue::calculate_batch_size;
-use dashmap::DashMap;
 use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
@@ -111,7 +110,7 @@ pub struct Batcher {
     /// It's used a way to "lock" all the user_states at the same time
     /// If one needed is taken in the handle message it will timeout
     is_recovering_from_submission_failure: RwLock<bool>,
-    user_states: DashMap<Address, Arc<Mutex<UserState>>>,
+    user_states: Arc<tokio::sync::RwLock<HashMap<Address, Arc<Mutex<UserState>>>>>,
 
     last_uploaded_batch_block: Mutex<u64>,
 
@@ -262,7 +261,7 @@ impl Batcher {
         .await
         .expect("Failed to get fallback Service Manager contract");
 
-        let user_states = DashMap::new();
+        let user_states = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
         let batch_state = BatchState::new(config.batcher.max_queue_size);
         let non_paying_config = if let Some(non_paying_config) = config.batcher.non_paying {
             warn!("Non-paying address configuration detected. Will replace non-paying address {} with configured address.",
@@ -276,7 +275,7 @@ impl Batcher {
                 .expect("Could not get non-paying nonce from Ethereum");
 
             let non_paying_user_state = UserState::new(nonpaying_nonce);
-            user_states.insert(
+            user_states.write().await.insert(
                 non_paying_config.replacement.address(),
                 Arc::new(Mutex::new(non_paying_user_state)),
             );
@@ -335,7 +334,7 @@ impl Batcher {
         }
     }
 
-    fn update_evicted_user_state_with_lock(
+    async fn update_evicted_user_state_with_lock(
         &self,
         removed_entry: &types::batch_queue::BatchQueueEntry,
         batch_queue: &types::batch_queue::BatchQueue,
@@ -350,7 +349,7 @@ impl Batcher {
         {
             Some((last_entry, _)) => last_entry.nonced_verification_data.max_fee,
             None => {
-                self.user_states.remove(&addr);
+                self.user_states.write().await.remove(&addr);
                 return;
             }
         };
@@ -376,12 +375,12 @@ impl Batcher {
         {
             Some((last_entry, _)) => last_entry.nonced_verification_data.max_fee,
             None => {
-                self.user_states.remove(&addr);
+                self.user_states.write().await.remove(&addr);
                 return Some(());
             }
         };
 
-        let user_state = self.user_states.get(&addr)?;
+        let user_state = self.user_states.read().await.get(&addr)?.clone();
         let mut user_state_guard = user_state.lock().await;
         user_state_guard.proofs_in_batch -= 1;
         user_state_guard.nonce -= U256::one();
@@ -432,7 +431,7 @@ impl Batcher {
     where
         F: std::future::Future<Output = T>,
     {
-        match timeout(Duration::from_secs(15), lock_future).await {
+        match timeout(Duration::from_secs(150), lock_future).await {
             Ok(result) => Some(result),
             Err(_) => {
                 warn!("Batch lock acquisition timed out");
@@ -735,7 +734,7 @@ impl Batcher {
         }
 
         let cached_user_nonce = {
-            let user_state_ref = self.user_states.get(&address);
+            let user_state_ref = self.user_states.read().await.get(&address).cloned();
             match user_state_ref {
                 Some(user_state_ref) => {
                     let Some(user_state_guard) = self
@@ -881,18 +880,18 @@ impl Batcher {
         // If it was not present, then the user nonce is queried to the Aligned contract.
         // Lastly, we get a lock of the batch state again and insert the user state if it was still missing.
 
-        let is_user_in_state = self.user_states.contains_key(&addr);
+        let is_user_in_state = self.user_states.read().await.contains_key(&addr);
 
         if !is_user_in_state {
             warn!("User state for address {addr:?} not found, creating a new one");
             // We add a dummy user state to grab a lock on the user state
             let dummy_user_state = UserState::new(U256::zero());
             self.user_states
-                .insert(addr, Arc::new(Mutex::new(dummy_user_state)));
+                .write().await.insert(addr, Arc::new(Mutex::new(dummy_user_state)));
             warn!("Dummy user state for address {addr:?} created");
         }
 
-        let Some(user_state_ref) = self.user_states.get(&addr) else {
+        let Some(user_state_ref) = self.user_states.read().await.get(&addr).cloned() else {
             error!("This should never happen, user state has previously been inserted if it didn't exist");
             send_message(
                 ws_conn_sink.clone(),
@@ -1060,7 +1059,7 @@ impl Batcher {
 
             // Try to find any candidate whose lock we can acquire and immediately process them
             for candidate_addr in eviction_candidates {
-                if let Some(user_state_arc) = self.user_states.get(&candidate_addr) {
+                if let Some(user_state_arc) = self.user_states.read().await.get(&candidate_addr).cloned() {
                     if let Ok(mut user_guard) = user_state_arc.try_lock() {
                         // Found someone whose lock we can get - now find and remove their entry
                         let entries_to_check: Vec<_> = batch_state_lock
@@ -1094,7 +1093,7 @@ impl Batcher {
                                     &removed,
                                     &batch_state_lock.batch_queue,
                                     &mut user_guard,
-                                );
+                                ).await;
 
                                 if let Some(ref removed_entry_ws) = removed.messaging_sink {
                                     let ws_sink = removed_entry_ws.clone();
@@ -1553,7 +1552,7 @@ impl Batcher {
     ) -> Result<(), BatcherError> {
         // Update each user's state with proper lock ordering
         for addr in affected_users {
-            if let Some(user_state) = self.user_states.get(&addr) {
+            if let Some(user_state) = self.user_states.read().await.get(&addr).cloned() {
                 let mut user_state_guard = user_state.lock().await; // First: user lock
                 let batch_state_lock = self.batch_state.lock().await; // Second: batch lock
 
@@ -1588,7 +1587,7 @@ impl Batcher {
     /// Cleans up user states after successful batch submission.
     /// Resets last_max_fee_limit to U256::MAX for users who had proofs in the submitted batch
     /// but now have no proofs left in the queue.
-    fn cleanup_user_states_after_successful_submission(&self, finalized_batch: &[BatchQueueEntry]) {
+    async fn cleanup_user_states_after_successful_submission(&self, finalized_batch: &[BatchQueueEntry]) {
         use std::collections::HashSet;
 
         // Get unique users from the submitted batch
@@ -1612,7 +1611,7 @@ impl Batcher {
         for user_addr in users_in_batch {
             if !current_user_states.contains_key(&user_addr) {
                 // User has no proofs left in queue - reset their max_fee_limit
-                if let Some(user_state_ref) = self.user_states.get(&user_addr) {
+                if let Some(user_state_ref) = self.user_states.read().await.get(&user_addr).cloned() {
                     if let Ok(mut user_state_guard) = user_state_ref.try_lock() {
                         user_state_guard.last_max_fee_limit = U256::max_value();
                     }
@@ -1833,7 +1832,7 @@ impl Batcher {
         }
 
         // Clean up user states for users who had proofs in this batch but now have no proofs left
-        self.cleanup_user_states_after_successful_submission(finalized_batch);
+        self.cleanup_user_states_after_successful_submission(finalized_batch).await;
 
         connection::send_batch_inclusion_data_responses(finalized_batch, &batch_merkle_tree).await
     }
@@ -1851,7 +1850,7 @@ impl Batcher {
 
         let Some(nonpaying_replacement_addr) = self.get_nonpaying_replacement_addr() else {
             batch_state_lock.batch_queue.clear();
-            self.user_states.clear();
+            self.user_states.write().await.clear();
             return;
         };
 
@@ -1863,13 +1862,13 @@ impl Batcher {
             .await
         else {
             batch_state_lock.batch_queue.clear();
-            self.user_states.clear();
+            self.user_states.write().await.clear();
             return;
         };
         batch_state_lock.batch_queue.clear();
-        self.user_states.clear();
+        self.user_states.write().await.clear();
         let nonpaying_user_state = UserState::new(nonpaying_replacement_addr_nonce);
-        self.user_states.insert(
+        self.user_states.write().await.insert(
             nonpaying_replacement_addr,
             Arc::new(Mutex::new(nonpaying_user_state)),
         );

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1430,9 +1430,10 @@ impl Batcher {
 
         // Update metrics
         let queue_len = batch_state_lock.batch_queue.len();
+        let queue_size_bytes= 0;
         // let queue_size_bytes = calculate_batch_size(&batch_state_lock.batch_queue)?;
-        // self.metrics
-        //     .update_queue_metrics(queue_len as i64, queue_size_bytes as i64);
+        self.metrics
+            .update_queue_metrics(queue_len as i64, queue_size_bytes as i64);
 
         info!("Current batch queue length: {}", queue_len);
 

--- a/crates/batcher/src/metrics.rs
+++ b/crates/batcher/src/metrics.rs
@@ -178,6 +178,7 @@ impl BatcherMetrics {
 
     pub fn update_queue_metrics(&self, queue_len: i64, queue_size: i64) {
         self.queue_len.set(queue_len);
+        println!("Queue length: {:?}", self.queue_len);
         self.queue_size_bytes.set(queue_size);
     }
 

--- a/crates/batcher/src/metrics.rs
+++ b/crates/batcher/src/metrics.rs
@@ -178,7 +178,6 @@ impl BatcherMetrics {
 
     pub fn update_queue_metrics(&self, queue_len: i64, queue_size: i64) {
         self.queue_len.set(queue_len);
-        println!("Queue length: {:?}", self.queue_len);
         self.queue_size_bytes.set(queue_size);
     }
 


### PR DESCRIPTION
# refactor: use Hashmap instead of Dashmap

## Description

https://github.com/xacrimon/dashmap/issues/233

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
