### PR TITLE
perf(batcher): do not serialize to CBOR on batch size calculation

### DIFF
--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -2398,22 +2398,9 @@ impl Batcher {
         client_msg: &SubmitProofMessage,
         ws_conn_sink: &WsMessageSink,
     ) -> bool {
-        let verification_data = match cbor_serialize(&client_msg.verification_data) {
-            Ok(data) => data,
-            // This should never happened, the user sent all his data serialized
-            Err(_) => {
-                error!("Proof serialization error");
-                send_message(
-                    ws_conn_sink.clone(),
-                    SubmitProofResponseMessage::Error("Proof serialization error".to_string()),
-                )
-                .await;
-                self.metrics.user_error(&["proof_serialization_error", ""]);
-                return false;
-            }
-        };
+        let verification_data_size = client_msg.verification_data.cbor_size_upper_bound();
 
-        if verification_data.len() > self.max_proof_size {
+        if verification_data_size > self.max_proof_size {
             error!("Proof size exceeds the maximum allowed size.");
             send_message(
                 ws_conn_sink.clone(),

--- a/crates/batcher/src/types/batch_queue.rs
+++ b/crates/batcher/src/types/batch_queue.rs
@@ -123,7 +123,7 @@ pub(crate) fn calculate_batch_size(batch_queue: &BatchQueue) -> Result<usize, Ba
     let folded_result = batch_queue.iter().try_fold(0, |acc, (entry, _)| {
         let verification_data_size = entry.nonced_verification_data.cbor_size_upper_bound();
         let current_batch_size = acc + verification_data_size;
-        ControlFlow::Continue(current_batch_size)
+        ControlFlow::<usize, usize>::Continue(current_batch_size)
     });
 
     if let ControlFlow::Continue(batch_size) = folded_result {

--- a/crates/batcher/src/types/batch_queue.rs
+++ b/crates/batcher/src/types/batch_queue.rs
@@ -3,7 +3,6 @@ use aligned_sdk::{
         constants::CBOR_ARRAY_MAX_OVERHEAD,
         types::{NoncedVerificationData, VerificationDataCommitment},
     },
-    communication::serialization::cbor_serialize,
 };
 use ethers::types::{Address, Signature, U256};
 use priority_queue::PriorityQueue;
@@ -124,14 +123,9 @@ pub(crate) type BatchQueue = PriorityQueue<BatchQueueEntry, BatchQueueEntryPrior
 /// Calculates the size of the batch represented by the given batch queue.
 pub(crate) fn calculate_batch_size(batch_queue: &BatchQueue) -> Result<usize, BatcherError> {
     let folded_result = batch_queue.iter().try_fold(0, |acc, (entry, _)| {
-        if let Ok(verification_data_bytes) =
-            cbor_serialize(&entry.nonced_verification_data.verification_data)
-        {
-            let current_batch_size = acc + verification_data_bytes.len();
-            ControlFlow::Continue(current_batch_size)
-        } else {
-            ControlFlow::Break(())
-        }
+        let verification_data_size = entry.nonced_verification_data.cbor_size_upper_bound();
+        let current_batch_size = acc + verification_data_size;
+        ControlFlow::Continue(current_batch_size)
     });
 
     if let ControlFlow::Continue(batch_size) = folded_result {
@@ -178,10 +172,7 @@ pub(crate) fn extract_batch_directly(
             let (rejected_entry, rejected_priority) = batch_queue.pop().unwrap();
 
             // Update batch size
-            let verification_data_size =
-                cbor_serialize(&rejected_entry.nonced_verification_data.verification_data)
-                    .unwrap()
-                    .len();
+            let verification_data_size = rejected_entry.nonced_verification_data.cbor_size_upper_bound();
             batch_size -= verification_data_size;
 
             rejected_entries.push((rejected_entry, rejected_priority));

--- a/crates/batcher/src/types/batch_queue.rs
+++ b/crates/batcher/src/types/batch_queue.rs
@@ -1,8 +1,6 @@
-use aligned_sdk::{
-    common::{
-        constants::CBOR_ARRAY_MAX_OVERHEAD,
-        types::{NoncedVerificationData, VerificationDataCommitment},
-    },
+use aligned_sdk::common::{
+    constants::CBOR_ARRAY_MAX_OVERHEAD,
+    types::{NoncedVerificationData, VerificationDataCommitment},
 };
 use ethers::types::{Address, Signature, U256};
 use priority_queue::PriorityQueue;
@@ -172,7 +170,9 @@ pub(crate) fn extract_batch_directly(
             let (rejected_entry, rejected_priority) = batch_queue.pop().unwrap();
 
             // Update batch size
-            let verification_data_size = rejected_entry.nonced_verification_data.cbor_size_upper_bound();
+            let verification_data_size = rejected_entry
+                .nonced_verification_data
+                .cbor_size_upper_bound();
             batch_size -= verification_data_size;
 
             rejected_entries.push((rejected_entry, rejected_priority));

--- a/crates/sdk/src/common/types.rs
+++ b/crates/sdk/src/common/types.rs
@@ -99,9 +99,9 @@ impl NoncedVerificationData {
     }
 
     /// Returns an upper bound for the CBOR encoding size without performing serialization.
-    /// Sums the length of all Vec<u8> fields in the inner VerificationData and adds 256 bytes as overhead.
+    /// Sums the length of all Vec<u8> fields in the inner VerificationData and adds 1024 bytes as overhead. This covers the constant size data and extra headers
     pub fn cbor_size_upper_bound(&self) -> usize {
-        const CBOR_OVERHEAD_BYTES: usize = 256;
+        const CBOR_OVERHEAD_BYTES: usize = 1024;
         let mut total_size = 0;
 
         // Add length of proof Vec<u8>

--- a/crates/sdk/src/common/types.rs
+++ b/crates/sdk/src/common/types.rs
@@ -72,6 +72,7 @@ pub struct VerificationData {
     pub proof_generator_addr: Address,
 }
 
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NoncedVerificationData {
     pub verification_data: VerificationData,
@@ -96,6 +97,34 @@ impl NoncedVerificationData {
             chain_id,
             payment_service_addr,
         }
+    }
+
+    /// Returns an upper bound for the CBOR encoding size without performing serialization.
+    /// Sums the length of all Vec<u8> fields in the inner VerificationData and adds 256 bytes as overhead.
+    pub fn cbor_size_upper_bound(&self) -> usize {
+        const CBOR_OVERHEAD_BYTES: usize = 256;
+        let mut total_size = 0;
+        
+        // Add length of proof Vec<u8>
+        total_size += self.verification_data.proof.len();
+        
+        // Add length of pub_input Option<Vec<u8>>
+        if let Some(ref pub_input) = self.verification_data.pub_input {
+            total_size += pub_input.len();
+        }
+        
+        // Add length of verification_key Option<Vec<u8>>
+        if let Some(ref verification_key) = self.verification_data.verification_key {
+            total_size += verification_key.len();
+        }
+        
+        // Add length of vm_program_code Option<Vec<u8>>
+        if let Some(ref vm_program_code) = self.verification_data.vm_program_code {
+            total_size += vm_program_code.len();
+        }
+        
+        // Add overhead bytes for the full NoncedVerificationData structure
+        total_size + CBOR_OVERHEAD_BYTES
     }
 }
 

--- a/crates/sdk/src/common/types.rs
+++ b/crates/sdk/src/common/types.rs
@@ -72,7 +72,6 @@ pub struct VerificationData {
     pub proof_generator_addr: Address,
 }
 
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NoncedVerificationData {
     pub verification_data: VerificationData,
@@ -104,25 +103,25 @@ impl NoncedVerificationData {
     pub fn cbor_size_upper_bound(&self) -> usize {
         const CBOR_OVERHEAD_BYTES: usize = 256;
         let mut total_size = 0;
-        
+
         // Add length of proof Vec<u8>
         total_size += self.verification_data.proof.len();
-        
+
         // Add length of pub_input Option<Vec<u8>>
         if let Some(ref pub_input) = self.verification_data.pub_input {
             total_size += pub_input.len();
         }
-        
+
         // Add length of verification_key Option<Vec<u8>>
         if let Some(ref verification_key) = self.verification_data.verification_key {
             total_size += verification_key.len();
         }
-        
+
         // Add length of vm_program_code Option<Vec<u8>>
         if let Some(ref vm_program_code) = self.verification_data.vm_program_code {
             total_size += vm_program_code.len();
         }
-        
+
         // Add overhead bytes for the full NoncedVerificationData structure
         total_size + CBOR_OVERHEAD_BYTES
     }


### PR DESCRIPTION
# Do not serialize to CBOR on batch size calculation

## Description

Description of the pull request changes and motivation.

## Type of change

- [x] Optimization

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
