### PR TITLE
fix(batcher): initialize dummy state with correct nonce

### DIFF
--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -888,7 +888,7 @@ impl Batcher {
                         ws_conn_sink.clone(),
                         SubmitProofResponseMessage::EthRpcError,
                     )
-                        .await;
+                    .await;
                     self.metrics.user_error(&["eth_rpc_error", ""]);
                     return Ok(());
                 }

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -877,9 +877,25 @@ impl Batcher {
         let is_user_in_state = self.user_states.read().await.contains_key(&addr);
 
         if !is_user_in_state {
+            // If the user state was not present, we need to get the nonce from the Ethereum contract
+            let ethereum_user_nonce = match self.get_user_nonce_from_ethereum(addr).await {
+                Ok(ethereum_user_nonce) => ethereum_user_nonce,
+                Err(e) => {
+                    error!(
+                        "Failed to get user nonce from Ethereum for address {addr:?}. Error: {e:?}"
+                    );
+                    send_message(
+                        ws_conn_sink.clone(),
+                        SubmitProofResponseMessage::EthRpcError,
+                    )
+                        .await;
+                    self.metrics.user_error(&["eth_rpc_error", ""]);
+                    return Ok(());
+                }
+            };
             debug!("User state for address {addr:?} not found, creating a new one");
             // We add a dummy user state to grab a lock on the user state
-            let dummy_user_state = UserState::new(U256::zero());
+            let dummy_user_state = UserState::new(ethereum_user_nonce);
             self.user_states
                 .write()
                 .await
@@ -906,27 +922,6 @@ impl Batcher {
             send_message(ws_conn_sink.clone(), SubmitProofResponseMessage::ServerBusy).await;
             return Ok(());
         };
-
-        // If the user state was not present, we need to get the nonce from the Ethereum contract and update the dummy user state
-        if !is_user_in_state {
-            let ethereum_user_nonce = match self.get_user_nonce_from_ethereum(addr).await {
-                Ok(ethereum_user_nonce) => ethereum_user_nonce,
-                Err(e) => {
-                    error!(
-                        "Failed to get user nonce from Ethereum for address {addr:?}. Error: {e:?}"
-                    );
-                    send_message(
-                        ws_conn_sink.clone(),
-                        SubmitProofResponseMessage::EthRpcError,
-                    )
-                    .await;
-                    self.metrics.user_error(&["eth_rpc_error", ""]);
-                    return Ok(());
-                }
-            };
-            // Update the dummy user state with the correct nonce
-            user_state_guard.nonce = ethereum_user_nonce;
-        }
 
         // * ---------------------------------------------------*
         // *        Perform validations over user state         *


### PR DESCRIPTION
# fix(batcher): initialize dummy state with correct nonce

## Description

When creating a user in the batcher cache, intialize it with the correct nonce instead of 0, to avoid nonces desynchronization

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
