### PR TITLE
feat(operator): disable SP1 cache

### DIFF
--- a/operator/sp1/lib/src/lib.rs
+++ b/operator/sp1/lib/src/lib.rs
@@ -3,7 +3,11 @@ use log::{error, warn};
 use sp1_sdk::{ProverClient, EnvProver, SP1ProofWithPublicValues};
 
 lazy_static! {
-    static ref PROVER_CLIENT: EnvProver = ProverClient::from_env();
+    static ref PROVER_CLIENT: EnvProver = unsafe{
+        std::env::set_var("SP1_DISABLE_PROGRAM_CACHE", "1");
+        std::env::set_var("PROVER_CORE_CACHE_SIZE", "1");
+        ProverClient::from_env()
+    };
 }
 
 fn inner_verify_sp1_proof_ffi(


### PR DESCRIPTION
# feat(operator): disable SP1 cache

## Description

This PR sets the following env variables for the SP1 prover

```rust
std::env::set_var("SP1_DISABLE_PROGRAM_CACHE", "1");
std::env::set_var("PROVER_CORE_CACHE_SIZE", "1");
```


## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
