### PR TITLE
fix(operator): reduce polling frecuency and remove newbatchv2 logic

### DIFF
--- a/aggregator/pkg/subscriber.go
+++ b/aggregator/pkg/subscriber.go
@@ -24,7 +24,7 @@ func (agg *Aggregator) SubscribeToNewTasks() *chainio.ErrorPair {
 }
 
 func (agg *Aggregator) subscribeToNewTasks() *chainio.ErrorPair {
-	errorPair := agg.avsSubscriber.SubscribeToNewTasksV3(agg.NewBatchChan, agg.taskSubscriber)
+	errorPair := agg.avsSubscriber.SubscribeToNewTasksV3(agg.NewBatchChan, agg.taskSubscriber, agg.AggregatorConfig.Aggregator.PollLatestBatchInterval)
 
 	if errorPair != nil {
 		agg.AggregatorConfig.BaseConfig.Logger.Info("Failed to create task subscriber", "err", errorPair)

--- a/config-files/config-aggregator-docker.yaml
+++ b/config-files/config-aggregator-docker.yaml
@@ -38,3 +38,4 @@ aggregator:
   # The Gas formula is percentage (gas_base_bump_percentage + gas_bump_incremental_percentage * i) / 100) is checked against this value
   # If it is higher, it will default to `gas_bump_percentage_limit`
   time_to_wait_before_bump: 72s # The time to wait for the receipt when responding to task. Suggested value 72 seconds (6 blocks)
+  poll_latest_batch_interval: 20s # The interval to poll for latest batches. Default: 20s

--- a/config-files/config-aggregator-ethereum-package.yaml
+++ b/config-files/config-aggregator-ethereum-package.yaml
@@ -34,3 +34,4 @@ aggregator:
   gas_base_bump_percentage: 10 # How much to bump gas price when responding to task. Suggested value 10%
   gas_bump_incremental_percentage: 2 # An extra percentage to bump every retry i*2 when responding to task. Suggested value 2%
   time_to_wait_before_bump: 36s # The time to wait for the receipt when responding to task. Suggested value 36 seconds (3 blocks)
+  poll_latest_batch_interval: 20s # The interval to poll for latest batches. Default: 20s

--- a/config-files/config-aggregator.yaml
+++ b/config-files/config-aggregator.yaml
@@ -45,21 +45,4 @@ aggregator:
   # The Gas formula is percentage (gas_base_bump_percentage + gas_bump_incremental_percentage * i) / 100) is checked against this value
   # If it is higher, it will default to `gas_bump_percentage_limit`
   time_to_wait_before_bump: 72s # The time to wait for the receipt when responding to task. Suggested value 72 seconds (6 blocks)
-
-## Operator Configurations
-# operator:
-#   aggregator_rpc_server_ip_port_address: localhost:8090
-#   address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
-#   earnings_receiver_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
-#   delegation_approver_address: "0x0000000000000000000000000000000000000000"
-#   staker_opt_out_window_blocks: 0
-#   metadata_url: "https://yetanotherco.github.io/operator_metadata/metadata.json"
-#   enable_metrics: true
-#   metrics_ip_port_address: localhost:9092
-#   max_batch_size: 268435456 # 256 MiB
-# # Operators variables needed for register it in EigenLayer
-# el_delegation_manager_address: "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
-# private_key_store_path: config-files/anvil.ecdsa.key.json
-# bls_private_key_store_path: config-files/anvil.bls.key.json
-# signer_type: local_keystore
-# chain_id: 31337
+  poll_latest_batch_interval: 20s # The interval to poll for latest batches. Default: 20s

--- a/config-files/config-operator-1-ethereum-package.yaml
+++ b/config-files/config-operator-1-ethereum-package.yaml
@@ -32,6 +32,7 @@ operator:
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
   last_processed_batch_filepath: 'config-files/operator-1.last_processed_batch.json'
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 
 # Operators variables needed for register it in EigenLayer
 el_delegation_manager_address: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9'

--- a/config-files/config-operator-1.yaml
+++ b/config-files/config-operator-1.yaml
@@ -32,6 +32,7 @@ operator:
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
   last_processed_batch_filepath: 'config-files/operator-1.last_processed_batch.json'
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 
 # Operators variables needed for register it in EigenLayer
 el_delegation_manager_address: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9'

--- a/config-files/config-operator-2.yaml
+++ b/config-files/config-operator-2.yaml
@@ -30,6 +30,7 @@ operator:
   metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'
   max_batch_size: 268435456 # 256 MiB
   last_processed_batch_filepath: 'config-files/operator-2.last_processed_batch.json'
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 
 # Operators variables needed for register it in EigenLayer
 el_delegation_manager_address: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9'

--- a/config-files/config-operator-3.yaml
+++ b/config-files/config-operator-3.yaml
@@ -30,6 +30,7 @@ operator:
   metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'
   max_batch_size: 268435456 # 256 MiB
   last_processed_batch_filepath: 'config-files/operator-3.last_processed_batch.json'
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 
 # Operators variables needed for register it in EigenLayer
 el_delegation_manager_address: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9'

--- a/config-files/config-operator-docker.yaml
+++ b/config-files/config-operator-docker.yaml
@@ -32,6 +32,7 @@ operator:
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
   last_processed_batch_filepath: config-files/operator.last_processed_batch.json
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 # Operators variables needed for register it in EigenLayer
 el_delegation_manager_address: "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
 private_key_store_path: config-files/anvil.ecdsa.key.json

--- a/config-files/config-operator-holesky.yaml
+++ b/config-files/config-operator-holesky.yaml
@@ -32,3 +32,4 @@ operator:
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
   last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified

--- a/config-files/config-operator-mainnet.yaml
+++ b/config-files/config-operator-mainnet.yaml
@@ -32,3 +32,4 @@ operator:
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
   last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified

--- a/config-files/config-operator.yaml
+++ b/config-files/config-operator.yaml
@@ -32,3 +32,4 @@ operator:
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
   last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified

--- a/core/chainio/avs_subscriber.go
+++ b/core/chainio/avs_subscriber.go
@@ -68,83 +68,6 @@ func NewAvsSubscriberFromConfig(baseConfig *config.BaseConfig) (*AvsSubscriber, 
 	}, nil
 }
 
-func (s *AvsSubscriber) SubscribeToNewTasksV2(newTaskCreatedChan chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2, errorPairChannel chan ErrorPair) *ErrorPair {
-	// Create a new channel to receive new tasks
-	internalChannel := make(chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2)
-
-	// Subscribe to new tasks
-	sub, errMain := SubscribeToNewTasksV2Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManager, internalChannel, nil, retry.NetworkRetryParams())
-	if errMain != nil {
-		s.logger.Error(fmt.Sprintf("Fallback failed to subscribe to new AlignedLayer V3 tasks after %d retries", MaxRetries), "errMain", fmt.Sprintf("%v", errMain))
-	}
-
-	subFallback, errFallback := SubscribeToNewTasksV2Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManagerFallback, internalChannel, nil, retry.NetworkRetryParams())
-	if errFallback != nil {
-		s.logger.Error(fmt.Sprintf("Fallback failed to subscribe to new AlignedLayer V3 tasks after %d retries", MaxRetries), "errFallback", fmt.Sprintf("%v", errFallback))
-	}
-
-	if errMain != nil && errFallback != nil {
-		s.logger.Error("Failed to subscribe to new AlignedLayer V2 tasks with both RPCs", "errMain", errMain, "errFallback", errFallback)
-		return &ErrorPair{ErrorMainRPC: errMain, ErrorFallbackRPC: errFallback}
-	}
-
-	s.logger.Info("Subscribed to new AlignedLayer V2 tasks")
-
-	pollLatestBatchTicker := time.NewTicker(PollLatestBatchInterval)
-
-	// Forward the new tasks to the provided channel
-	go func() {
-		defer pollLatestBatchTicker.Stop()
-		newBatchMutex := &sync.Mutex{}
-		batchesSet := make(map[[32]byte]struct{})
-		for {
-			select {
-			case newBatch := <-internalChannel:
-				s.processNewBatchV2(newBatch, batchesSet, newBatchMutex, newTaskCreatedChan)
-			case <-pollLatestBatchTicker.C:
-				latestBatch, err := s.getLatestNotRespondedTaskFromEthereumV2()
-				if err != nil {
-					s.logger.Debug("Failed to get latest task from blockchain", "err", err)
-					continue
-				}
-				if latestBatch != nil {
-					s.processNewBatchV2(latestBatch, batchesSet, newBatchMutex, newTaskCreatedChan)
-				}
-			}
-		}
-
-	}()
-
-	// Handle errors and resubscribe
-	go func() {
-		var errMain, errFallback error
-		var auxSub, auxSubFallback event.Subscription
-		for errMain == nil || errFallback == nil { //while one is active
-			select {
-			case err := <-sub.Err():
-				s.logger.Warn("Error in new task subscription of main connection", "err", err)
-
-				auxSub, errMain = SubscribeToNewTasksV2Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManager, internalChannel, nil, retry.NetworkRetryParams())
-				if errMain == nil {
-					sub = auxSub // update the subscription only if it was successful
-					s.logger.Info("Main connection resubscribed to new task subscription")
-				}
-			case err := <-subFallback.Err():
-				s.logger.Warn("Error in new task subscription of fallback connection", "err", err)
-
-				auxSubFallback, errFallback = SubscribeToNewTasksV2Retryable(&bind.WatchOpts{}, s.AvsContractBindings.ServiceManagerFallback, internalChannel, nil, retry.NetworkRetryParams())
-				if errFallback == nil {
-					subFallback = auxSubFallback // update the subscription only if it was successful
-					s.logger.Info("Resubscribed to fallback new task subscription")
-				}
-			}
-		}
-		errorPairChannel <- ErrorPair{ErrorMainRPC: errMain, ErrorFallbackRPC: errFallback}
-	}()
-
-	return nil
-}
-
 func (s *AvsSubscriber) SubscribeToNewTasksV3(newTaskCreatedChan chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3, errorPairChannel chan ErrorPair) *ErrorPair {
 	// Create a new channel to receive new tasks
 	internalChannel := make(chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3)
@@ -224,32 +147,6 @@ func (s *AvsSubscriber) SubscribeToNewTasksV3(newTaskCreatedChan chan *servicema
 	return nil
 }
 
-func (s *AvsSubscriber) processNewBatchV2(batch *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2, batchesSet map[[32]byte]struct{}, newBatchMutex *sync.Mutex, newTaskCreatedChan chan<- *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2) {
-	newBatchMutex.Lock()
-	defer newBatchMutex.Unlock()
-
-	batchIdentifier := append(batch.BatchMerkleRoot[:], batch.SenderAddress[:]...)
-	var batchIdentifierHash = *(*[32]byte)(crypto.Keccak256(batchIdentifier))
-
-	if _, ok := batchesSet[batchIdentifierHash]; !ok {
-		s.logger.Info("Received new task",
-			"batchMerkleRoot", hex.EncodeToString(batch.BatchMerkleRoot[:]),
-			"senderAddress", hex.EncodeToString(batch.SenderAddress[:]),
-			"batchIdentifierHash", hex.EncodeToString(batchIdentifierHash[:]))
-
-		batchesSet[batchIdentifierHash] = struct{}{}
-		newTaskCreatedChan <- batch
-
-		// Remove the batch from the set after RemoveBatchFromSetInterval time
-		go func() {
-			time.Sleep(RemoveBatchFromSetInterval)
-			newBatchMutex.Lock()
-			delete(batchesSet, batchIdentifierHash)
-			newBatchMutex.Unlock()
-		}()
-	}
-}
-
 func (s *AvsSubscriber) processNewBatchV3(batch *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3, batchesSet map[[32]byte]struct{}, newBatchMutex *sync.Mutex, newTaskCreatedChan chan<- *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3) {
 	newBatchMutex.Lock()
 	defer newBatchMutex.Unlock()
@@ -274,56 +171,6 @@ func (s *AvsSubscriber) processNewBatchV3(batch *servicemanager.ContractAlignedL
 			newBatchMutex.Unlock()
 		}()
 	}
-}
-
-// getLatestNotRespondedTaskFromEthereum queries the blockchain for the latest not responded task using the FilterNewBatch method.
-func (s *AvsSubscriber) getLatestNotRespondedTaskFromEthereumV2() (*servicemanager.ContractAlignedLayerServiceManagerNewBatchV2, error) {
-
-	latestBlock, err := s.BlockNumberRetryable(context.Background(), retry.NetworkRetryParams())
-	if err != nil {
-		return nil, err
-	}
-
-	var fromBlock uint64
-
-	if latestBlock < BlockInterval {
-		fromBlock = 0
-	} else {
-		fromBlock = latestBlock - BlockInterval
-	}
-
-	logs, err := s.FilterBatchV2Retryable(&bind.FilterOpts{Start: fromBlock, End: nil, Context: context.Background()}, nil, retry.NetworkRetryParams())
-	if err != nil {
-		return nil, err
-	}
-
-	var lastLog *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2
-
-	// Iterate over the logs until the end
-	for logs.Next() {
-		lastLog = logs.Event
-	}
-
-	if err := logs.Error(); err != nil {
-		return nil, err
-	}
-
-	if lastLog == nil {
-		return nil, nil
-	}
-
-	batchIdentifier := append(lastLog.BatchMerkleRoot[:], lastLog.SenderAddress[:]...)
-	batchIdentifierHash := *(*[32]byte)(crypto.Keccak256(batchIdentifier))
-	state, err := s.BatchesStateRetryable(nil, batchIdentifierHash, retry.NetworkRetryParams())
-	if err != nil {
-		return nil, err
-	}
-
-	if state.Responded {
-		return nil, nil
-	}
-
-	return lastLog, nil
 }
 
 // getLatestNotRespondedTaskFromEthereum queries the blockchain for the latest not responded task using the FilterNewBatch method.

--- a/core/chainio/avs_subscriber.go
+++ b/core/chainio/avs_subscriber.go
@@ -24,7 +24,6 @@ const (
 	MaxRetries                        = 100
 	RetryInterval                     = 1 * time.Second
 	BlockInterval              uint64 = 1000
-	PollLatestBatchInterval           = 5 * time.Second
 	RemoveBatchFromSetInterval        = 5 * time.Minute
 )
 
@@ -68,7 +67,7 @@ func NewAvsSubscriberFromConfig(baseConfig *config.BaseConfig) (*AvsSubscriber, 
 	}, nil
 }
 
-func (s *AvsSubscriber) SubscribeToNewTasksV3(newTaskCreatedChan chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3, errorPairChannel chan ErrorPair) *ErrorPair {
+func (s *AvsSubscriber) SubscribeToNewTasksV3(newTaskCreatedChan chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3, errorPairChannel chan ErrorPair, pollInterval time.Duration) *ErrorPair {
 	// Create a new channel to receive new tasks
 	internalChannel := make(chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3)
 
@@ -91,7 +90,7 @@ func (s *AvsSubscriber) SubscribeToNewTasksV3(newTaskCreatedChan chan *servicema
 
 	s.logger.Info("Subscribed to new AlignedLayer V3 tasks")
 
-	pollLatestBatchTicker := time.NewTicker(PollLatestBatchInterval)
+	pollLatestBatchTicker := time.NewTicker(pollInterval)
 
 	// Forward the new tasks to the provided channel
 	go func() {

--- a/core/chainio/retryable.go
+++ b/core/chainio/retryable.go
@@ -127,29 +127,16 @@ func (s *AvsSubscriber) BlockNumberRetryable(ctx context.Context, config *retry.
 }
 
 /*
-FilterBatchV2Retryable
-Get NewBatchV2 logs from the AVS contract.
-- All errors are considered Transient Errors
-- Retry times (3 retries): 1 sec, 2 sec, 4 sec.
-*/
-func (s *AvsSubscriber) FilterBatchV2Retryable(opts *bind.FilterOpts, batchMerkleRoot [][32]byte, config *retry.RetryParams) (*servicemanager.ContractAlignedLayerServiceManagerNewBatchV2Iterator, error) {
-	filterNewBatchV2_func := func() (*servicemanager.ContractAlignedLayerServiceManagerNewBatchV2Iterator, error) {
-		return s.AvsContractBindings.ServiceManager.FilterNewBatchV2(opts, batchMerkleRoot)
-	}
-	return retry.RetryWithData(filterNewBatchV2_func, config)
-}
-
-/*
 FilterBatchV3Retryable
 Get NewBatchV3 logs from the AVS contract.
 - All errors are considered Transient Errors
 - Retry times (3 retries): 1 sec, 2 sec, 4 sec.
 */
 func (s *AvsSubscriber) FilterBatchV3Retryable(opts *bind.FilterOpts, batchMerkleRoot [][32]byte, config *retry.RetryParams) (*servicemanager.ContractAlignedLayerServiceManagerNewBatchV3Iterator, error) {
-	filterNewBatchV2_func := func() (*servicemanager.ContractAlignedLayerServiceManagerNewBatchV3Iterator, error) {
+	filterNewBatchV3_func := func() (*servicemanager.ContractAlignedLayerServiceManagerNewBatchV3Iterator, error) {
 		return s.AvsContractBindings.ServiceManager.FilterNewBatchV3(opts, batchMerkleRoot)
 	}
-	return retry.RetryWithData(filterNewBatchV2_func, config)
+	return retry.RetryWithData(filterNewBatchV3_func, config)
 }
 
 /*
@@ -191,26 +178,6 @@ func (s *AvsSubscriber) SubscribeNewHeadRetryable(ctx context.Context, c chan<- 
 		return sub, err
 	}
 	return retry.RetryWithData(subscribeNewHead_func, config)
-}
-
-/*
-SubscribeToNewTasksV2Retryable
-Subscribe to NewBatchV2 logs from the AVS contract.
-- All errors are considered Transient Errors
-- Retry times (3 retries): 1 sec, 2 sec, 4 sec.
-*/
-func SubscribeToNewTasksV2Retryable(
-	opts *bind.WatchOpts,
-	serviceManager *servicemanager.ContractAlignedLayerServiceManager,
-	newTaskCreatedChan chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2,
-	batchMerkleRoot [][32]byte,
-	config *retry.RetryParams,
-) (event.Subscription, error) {
-	subscribe_func := func() (event.Subscription, error) {
-		log.Info().Msg("Subscribing to NewBatchV2")
-		return serviceManager.WatchNewBatchV2(opts, newTaskCreatedChan, batchMerkleRoot)
-	}
-	return retry.RetryWithData(subscribe_func, config)
 }
 
 /*

--- a/core/config/aggregator.go
+++ b/core/config/aggregator.go
@@ -29,6 +29,7 @@ type AggregatorConfig struct {
 		GasBumpIncrementalPercentage  uint
 		GasBumpPercentageLimit        uint
 		TimeToWaitBeforeBump          time.Duration
+		PollLatestBatchInterval       time.Duration
 	}
 }
 
@@ -48,6 +49,7 @@ type AggregatorConfigFromYaml struct {
 		GasBumpIncrementalPercentage  uint           `yaml:"gas_bump_incremental_percentage"`
 		GasBumpPercentageLimit        uint           `yaml:"gas_bump_percentage_limit"`
 		TimeToWaitBeforeBump          time.Duration  `yaml:"time_to_wait_before_bump"`
+		PollLatestBatchInterval       time.Duration  `yaml:"poll_latest_batch_interval"`
 	} `yaml:"aggregator"`
 }
 
@@ -97,6 +99,7 @@ func NewAggregatorConfig(configFilePath string) *AggregatorConfig {
 			GasBumpIncrementalPercentage  uint
 			GasBumpPercentageLimit        uint
 			TimeToWaitBeforeBump          time.Duration
+			PollLatestBatchInterval       time.Duration
 		}(aggregatorConfigFromYaml.Aggregator),
 	}
 }

--- a/core/config/operator.go
+++ b/core/config/operator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/yetanotherco/aligned_layer/core/utils"
@@ -27,6 +28,7 @@ type OperatorConfig struct {
 		MetricsIpPortAddress          string
 		MaxBatchSize                  int64
 		LastProcessedBatchFilePath    string
+		PollLatestBatchInterval       time.Duration
 	}
 }
 
@@ -44,8 +46,9 @@ type OperatorConfigFromYaml struct {
 		MetricsIpPortAddress          string         `yaml:"metrics_ip_port_address"`
 		MaxBatchSize                  int64          `yaml:"max_batch_size"`
 		LastProcessedBatchFilePath    string         `yaml:"last_processed_batch_filepath"`
+		PollLatestBatchInterval       string         `yaml:"poll_latest_batch_interval"`
 	} `yaml:"operator"`
-	BlsConfigFromYaml   BlsConfigFromYaml   `yaml:"bls"`
+	BlsConfigFromYaml BlsConfigFromYaml `yaml:"bls"`
 }
 
 func NewOperatorConfig(configFilePath string) *OperatorConfig {
@@ -70,6 +73,13 @@ func NewOperatorConfig(configFilePath string) *OperatorConfig {
 		log.Fatal("Error reading operator config: ", err)
 	}
 
+	pollInterval := 20 * time.Second
+	if operatorConfigFromYaml.Operator.PollLatestBatchInterval != "" {
+		if parsed, err := time.ParseDuration(operatorConfigFromYaml.Operator.PollLatestBatchInterval); err == nil {
+			pollInterval = parsed
+		}
+	}
+
 	return &OperatorConfig{
 		BaseConfig:                   baseConfig,
 		BlsConfig:                    blsConfig,
@@ -87,6 +97,21 @@ func NewOperatorConfig(configFilePath string) *OperatorConfig {
 			MetricsIpPortAddress          string
 			MaxBatchSize                  int64
 			LastProcessedBatchFilePath    string
-		}(operatorConfigFromYaml.Operator),
+			PollLatestBatchInterval       time.Duration
+		}{
+			AggregatorServerIpPortAddress: operatorConfigFromYaml.Operator.AggregatorServerIpPortAddress,
+			OperatorTrackerIpPortAddress:  operatorConfigFromYaml.Operator.OperatorTrackerIpPortAddress,
+			Address:                       operatorConfigFromYaml.Operator.Address,
+			EarningsReceiverAddress:       operatorConfigFromYaml.Operator.EarningsReceiverAddress,
+			DelegationApproverAddress:     operatorConfigFromYaml.Operator.DelegationApproverAddress,
+			StakerOptOutWindowBlocks:      operatorConfigFromYaml.Operator.StakerOptOutWindowBlocks,
+			MetadataUrl:                   operatorConfigFromYaml.Operator.MetadataUrl,
+			RegisterOperatorOnStartup:     operatorConfigFromYaml.Operator.RegisterOperatorOnStartup,
+			EnableMetrics:                 operatorConfigFromYaml.Operator.EnableMetrics,
+			MetricsIpPortAddress:          operatorConfigFromYaml.Operator.MetricsIpPortAddress,
+			MaxBatchSize:                  operatorConfigFromYaml.Operator.MaxBatchSize,
+			LastProcessedBatchFilePath:    operatorConfigFromYaml.Operator.LastProcessedBatchFilePath,
+			PollLatestBatchInterval:       pollInterval,
+		},
 	}
 }

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -52,7 +52,6 @@ type Operator struct {
 	OperatorId                eigentypes.OperatorId
 	avsSubscriber             chainio.AvsSubscriber
 	avsReader                 chainio.AvsReader
-	NewTaskCreatedChanV2      chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2
 	NewTaskCreatedChanV3      chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3
 	Logger                    logging.Logger
 	aggRpcClient              AggregatorRpcClient
@@ -93,7 +92,6 @@ func NewOperatorFromConfig(configuration config.OperatorConfig) (*Operator, erro
 	if err != nil {
 		log.Fatalf("Could not create AVS subscriber")
 	}
-	newTaskCreatedChanV2 := make(chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2)
 	newTaskCreatedChanV3 := make(chan *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3)
 
 	rpcClient, err := NewAggregatorRpcClient(configuration.Operator.AggregatorServerIpPortAddress, logger)
@@ -119,7 +117,6 @@ func NewOperatorFromConfig(configuration config.OperatorConfig) (*Operator, erro
 		avsSubscriber:             *avsSubscriber,
 		avsReader:                 *avsReader,
 		Address:                   address,
-		NewTaskCreatedChanV2:      newTaskCreatedChanV2,
 		NewTaskCreatedChanV3:      newTaskCreatedChanV3,
 		aggRpcClient:              *rpcClient,
 		OperatorId:                operatorId,
@@ -141,10 +138,6 @@ func NewOperatorFromConfig(configuration config.OperatorConfig) (*Operator, erro
 	}
 
 	return operator, nil
-}
-
-func (o *Operator) SubscribeToNewTasksV2(errorPairChan chan chainio.ErrorPair) *chainio.ErrorPair {
-	return o.avsSubscriber.SubscribeToNewTasksV2(o.NewTaskCreatedChanV2, errorPairChan)
 }
 
 func (o *Operator) SubscribeToNewTasksV3(errorPairChan chan chainio.ErrorPair) *chainio.ErrorPair {
@@ -209,14 +202,8 @@ func (o *Operator) UpdateLastProcessBatch(blockNumber uint32) error {
 
 func (o *Operator) Start(ctx context.Context) error {
 	// create a new channel to foward errors
-	subV2ErrorChannel := make(chan chainio.ErrorPair)
-	errorPair := o.SubscribeToNewTasksV2(subV2ErrorChannel)
-	if errorPair != nil {
-		log.Fatal("Could not subscribe to new tasks")
-	}
-
 	subV3ErrorChannel := make(chan chainio.ErrorPair)
-	errorPair = o.SubscribeToNewTasksV3(subV3ErrorChannel)
+	errorPair := o.SubscribeToNewTasksV3(subV3ErrorChannel)
 	if errorPair != nil {
 		log.Fatal("Could not subscribe to new tasks")
 	}
@@ -237,20 +224,12 @@ func (o *Operator) Start(ctx context.Context) error {
 			return nil
 		case err := <-metricsErrChan:
 			o.Logger.Errorf("Metrics server failed", "err", err)
-		case errorPair := <-subV2ErrorChannel:
-			o.Logger.Infof("Error in websocket subscription", "err", errorPair)
-			errorPairPtr := o.SubscribeToNewTasksV2(subV2ErrorChannel)
-			if errorPairPtr != nil {
-				o.Logger.Fatal("Could not subscribe to new tasks V2")
-			}
 		case errorPair := <-subV3ErrorChannel:
 			o.Logger.Infof("Error in websocket subscription", "err", errorPair)
 			errorPairPtr := o.SubscribeToNewTasksV3(subV3ErrorChannel)
 			if errorPairPtr != nil {
 				o.Logger.Fatal("Could not subscribe to new tasks V3")
 			}
-		case newBatchLogV2 := <-o.NewTaskCreatedChanV2:
-			go o.handleNewBatchLogV2(newBatchLogV2)
 		case newBatchLogV3 := <-o.NewTaskCreatedChanV3:
 			go o.handleNewBatchLogV3(newBatchLogV3)
 		case blockNumber := <-o.lastProcessedBatch.batchProcessedChan:
@@ -299,97 +278,6 @@ func (o *Operator) ProcessMissedBatchesWhileOffline() {
 		go o.handleNewBatchLogV3(&logEntry)
 	}
 	o.Logger.Info("Finished verifying all batches missed while offline")
-}
-
-// Currently, Operator can handle NewBatchV2 and NewBatchV3 events.
-
-// The difference between these events do not affect the operator
-// So if you read below, handleNewBatchLogV2 and handleNewBatchLogV3
-// are identical.
-
-// This structure may help for future upgrades. Having different logics under
-// different events enables the smooth operator upgradeability
-
-// Process of handling batches from V2 events:
-func (o *Operator) handleNewBatchLogV2(newBatchLog *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2) {
-	var err error
-	defer func() { o.afterHandlingBatchV2(newBatchLog, err == nil) }()
-
-	o.Logger.Info("Received new batch log V2")
-	err = o.ProcessNewBatchLogV2(newBatchLog)
-	if err != nil {
-		o.Logger.Infof("batch %x did not verify. Err: %v", newBatchLog.BatchMerkleRoot, err)
-		return
-	}
-
-	batchIdentifier := append(newBatchLog.BatchMerkleRoot[:], newBatchLog.SenderAddress[:]...)
-	var batchIdentifierHash = *(*[32]byte)(crypto.Keccak256(batchIdentifier))
-	responseSignature := o.SignTaskResponse(batchIdentifierHash)
-	o.Logger.Debugf("responseSignature about to send: %x", responseSignature)
-
-	signedTaskResponse := types.SignedTaskResponse{
-		BatchIdentifierHash: batchIdentifierHash,
-		BatchMerkleRoot:     newBatchLog.BatchMerkleRoot,
-		SenderAddress:       newBatchLog.SenderAddress,
-		BlsSignature:        *responseSignature,
-		OperatorId:          o.OperatorId,
-	}
-	o.Logger.Infof("Signed Task Response to send: BatchIdentifierHash=%s, BatchMerkleRoot=%s, SenderAddress=%s",
-		hex.EncodeToString(signedTaskResponse.BatchIdentifierHash[:]),
-		hex.EncodeToString(signedTaskResponse.BatchMerkleRoot[:]),
-		hex.EncodeToString(signedTaskResponse.SenderAddress[:]),
-	)
-
-	o.aggRpcClient.SendSignedTaskResponseToAggregator(&signedTaskResponse)
-}
-func (o *Operator) ProcessNewBatchLogV2(newBatchLog *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2) error {
-
-	o.Logger.Info("Received new batch with proofs to verify",
-		"batch merkle root", "0x"+hex.EncodeToString(newBatchLog.BatchMerkleRoot[:]),
-		"sender address", "0x"+hex.EncodeToString(newBatchLog.SenderAddress[:]),
-	)
-
-	ctx, cancel := context.WithTimeout(context.Background(), BatchDownloadTimeout)
-	defer cancel()
-
-	verificationDataBatch, err := o.getBatchFromDataServiceWithMultipleURLs(ctx, newBatchLog.BatchDataPointer, newBatchLog.BatchMerkleRoot, BatchDownloadMaxRetries, BatchDownloadRetryDelay)
-	if err != nil {
-		o.Logger.Errorf("Could not get proofs from S3 bucket: %v", err)
-		return err
-	}
-
-	verificationDataBatchLen := len(verificationDataBatch)
-	results := make(chan bool, verificationDataBatchLen)
-	var wg sync.WaitGroup
-	wg.Add(verificationDataBatchLen)
-
-	disabledVerifiersBitmap, err := o.avsReader.DisabledVerifiers()
-	if err != nil {
-		o.Logger.Errorf("Could not check verifiers status: %s", err)
-		results <- false
-		return err
-	}
-
-	for _, verificationData := range verificationDataBatch {
-		go func(data VerificationData) {
-			defer wg.Done()
-			o.verify(data, disabledVerifiersBitmap, results)
-			o.metrics.IncOperatorTaskResponses()
-		}(verificationData)
-	}
-
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	for result := range results {
-		if !result {
-			return fmt.Errorf("invalid proof")
-		}
-	}
-
-	return nil
 }
 
 // Process of handling batches from V3 events:
@@ -469,12 +357,6 @@ func (o *Operator) ProcessNewBatchLogV3(newBatchLog *servicemanager.ContractAlig
 	}
 
 	return nil
-}
-
-func (o *Operator) afterHandlingBatchV2(log *servicemanager.ContractAlignedLayerServiceManagerNewBatchV2, succeeded bool) {
-	if succeeded {
-		o.lastProcessedBatch.batchProcessedChan <- uint32(log.Raw.BlockNumber)
-	}
 }
 
 func (o *Operator) afterHandlingBatchV3(log *servicemanager.ContractAlignedLayerServiceManagerNewBatchV3, succeeded bool) {

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -141,7 +141,7 @@ func NewOperatorFromConfig(configuration config.OperatorConfig) (*Operator, erro
 }
 
 func (o *Operator) SubscribeToNewTasksV3(errorPairChan chan chainio.ErrorPair) *chainio.ErrorPair {
-	return o.avsSubscriber.SubscribeToNewTasksV3(o.NewTaskCreatedChanV3, errorPairChan)
+	return o.avsSubscriber.SubscribeToNewTasksV3(o.NewTaskCreatedChanV3, errorPairChan, o.Config.Operator.PollLatestBatchInterval)
 }
 
 type OperatorLastProcessedBatch struct {


### PR DESCRIPTION
# Reduce polling frecuency and remove newbatchv2 logic

## Description

Closes #2074

## Type of change

- [x] Bug fix
- [x] Optimization
- [x] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
