### PR TITLE
docs: add Operator config file template for Sepolia Network

### DIFF
--- a/config-files/config-operator-sepolia.yaml
+++ b/config-files/config-operator-sepolia.yaml
@@ -1,0 +1,35 @@
+# Common variables for all the services
+# 'production' only prints info and above. 'development' also prints debug
+environment: 'production'
+aligned_layer_deployment_config_file_path: './contracts/script/output/sepolia/alignedlayer_deployment_output.json'
+eigen_layer_deployment_config_file_path: './contracts/script/output/sepolia/eigenlayer_deployment_output.json'
+eth_rpc_url: 'https://ethereum-sepolia-rpc.publicnode.com' # DO NOT USE PUBLIC NODE IN PRODUCTION
+eth_rpc_url_fallback: 'https://ethereum-sepolia-rpc.publicnode.com'
+eth_ws_url: 'wss://ethereum-sepolia-rpc.publicnode.com' # DO NOT USE PUBLIC NODE IN PRODUCTION
+eth_ws_url_fallback: 'wss://ethereum-sepolia-rpc.publicnode.com'
+eigen_metrics_ip_port_address: 'localhost:9090'
+
+## ECDSA Configurations
+ecdsa:
+  private_key_store_path: '<ecdsa_key_store_location_path>'
+  private_key_store_password: '<ecdsa_key_store_password>'
+
+## BLS Configurations
+bls:
+  private_key_store_path: '<bls_key_store_location_path>'
+  private_key_store_password: '<bls_key_store_password>'
+
+## Operator Configurations
+operator:
+  aggregator_rpc_server_ip_port_address: sepolia.aggregator.alignedlayer.com:8090
+  operator_tracker_ip_port_address: https://sepolia.telemetry.alignedlayer.com
+  address: '<operator_address>'
+  earnings_receiver_address: '<earnings_receiver_address>' #Can be the same as the operator.
+  delegation_approver_address: '0x0000000000000000000000000000000000000000'
+  staker_opt_out_window_blocks: 0
+  metadata_url: <metadata_url>
+  enable_metrics: true
+  metrics_ip_port_address: localhost:9092
+  max_batch_size: 268435456 # 256 MiB
+  last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
+  poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified


### PR DESCRIPTION
# docs: add Operator config file template for Sepolia Network

## Description

Closes #2084

## Type of change

Please delete options that are not relevant.

- [x] Documentation

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
