### PR TITLE
fix(ethereum-package): pin to v5.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1446,7 +1446,7 @@ ansible_telemetry_deploy: ## Deploy the Telemetry. Parameters: INVENTORY
 __ETHEREUM_PACKAGE__:  ## ____
 
 ethereum_package_start: ## Starts the ethereum_package environment
-	kurtosis run --enclave aligned github.com/ethpandaops/ethereum-package --args-file network_params.yaml
+	kurtosis run --enclave aligned github.com/ethpandaops/ethereum-package@5.0.1 --args-file network_params.yaml
 
 ethereum_package_inspect: ## Prints detailed information about the net
 	kurtosis enclave inspect aligned

--- a/config-files/config-aggregator-ethereum-package.yaml
+++ b/config-files/config-aggregator-ethereum-package.yaml
@@ -4,9 +4,9 @@ environment: "production"
 aligned_layer_deployment_config_file_path: "./contracts/script/output/devnet/alignedlayer_deployment_output.json"
 eigen_layer_deployment_config_file_path: "./contracts/script/output/devnet/eigenlayer_deployment_output.json"
 eth_rpc_url: "http://localhost:8545"
-eth_rpc_url_fallback: "http://localhost:8552"
+eth_rpc_url_fallback: "http://localhost:8551"
 eth_ws_url: "ws://localhost:8546"
-eth_ws_url_fallback: "ws://localhost:8553"
+eth_ws_url_fallback: "ws://localhost:8552"
 eigen_metrics_ip_port_address: "localhost:9090"
 
 ## ECDSA Configurations

--- a/config-files/config-batcher-ethereum-package.yaml
+++ b/config-files/config-batcher-ethereum-package.yaml
@@ -4,9 +4,9 @@ environment: "production"
 aligned_layer_deployment_config_file_path: "./contracts/script/output/devnet/alignedlayer_deployment_output.json"
 eigen_layer_deployment_config_file_path: "./contracts/script/output/devnet/eigenlayer_deployment_output.json"
 eth_rpc_url: "http://localhost:8545"
-eth_rpc_url_fallback: "http://localhost:8552"
+eth_rpc_url_fallback: "http://localhost:8551"
 eth_ws_url: "ws://localhost:8546"
-eth_ws_url_fallback: "ws://localhost:8553"
+eth_ws_url_fallback: "ws://localhost:8552"
 eigen_metrics_ip_port_address: "localhost:9090"
 
 ## ECDSA Configurations

--- a/config-files/config-operator-1-ethereum-package.yaml
+++ b/config-files/config-operator-1-ethereum-package.yaml
@@ -3,10 +3,10 @@
 environment: 'development'
 aligned_layer_deployment_config_file_path: './contracts/script/output/devnet/alignedlayer_deployment_output.json'
 eigen_layer_deployment_config_file_path: './contracts/script/output/devnet/eigenlayer_deployment_output.json'
-eth_rpc_url: "http://localhost:8552"
-eth_rpc_url_fallback: "http://localhost:8559"
-eth_ws_url: "ws://localhost:8553"
-eth_ws_url_fallback: "ws://localhost:8560"
+eth_rpc_url: "http://localhost:8545"
+eth_rpc_url_fallback: "http://localhost:8551"
+eth_ws_url: "ws://localhost:8546"
+eth_ws_url_fallback: "ws://localhost:8552"
 eigen_metrics_ip_port_address: 'localhost:9090'
 
 ## ECDSA Configurations


### PR DESCRIPTION
# fix(ethereum-package): pin to v5.0.1

## Description

Pin ethereum package to latest stable release to avoid unexpected breaking changes 

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
