### PR TITLE
fix(explorer): get proof bytes correctly

### DIFF
--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -347,7 +347,7 @@ defmodule Utils do
   def calculate_proof_hashes(deserialized_batch) do
     deserialized_batch
     |> Enum.map(fn s3_object ->
-      ExKeccak.hash_256(:erlang.list_to_binary(s3_object["proof"]))
+      ExKeccak.hash_256(s3_object["proof"].value)
     end)
   end
 
@@ -378,9 +378,9 @@ defmodule Utils do
   def fetch_batch_data_pointer_with_multiple_urls(batch_data_pointers) do
     # Parse comma-separated URLs and limit to max 5
     urls = parse_batch_urls(batch_data_pointers)
-    
+
     errors = []
-    
+
     # Try each URL until first successful response
     try_urls(urls, errors)
   end


### PR DESCRIPTION
# fix(explorer): get proof bytes correctly

## Description

The changes in the serialization introduced in #2064, changes how the explorer has to access to proof data

Instead of receiving a list, it nows receives a tuple

Old version:

```
[debug] [%{"proof" => [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 74, 204, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...], "proof_generator_addr" => "0xf8faa5183efc75cda6586d6076d1519369695543", "proving_system" => "Risc0", "pub_input" => [244, 4, 0, 0, 134, 7, 0, 0], "verification_key" => nil, "vm_program_code" => [236, 222, 198, 17, 126, 252, 216, 2, 56, 215, 95, 204, 16, 38, 112, 127, 170, 202, 125, 234, 155, 16, 60, 144, 189, 141, 130, 37, 32, 26, 83, 174]}]
```

New version:

```
[debug] [%{"proof" => %CBOR.Tag{tag: :bytes, value: <<0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 74, 204, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...>>}, "proof_generator_addr" => "0xb44f4b5946f7e1f9e6e60c9a6865b3f99dce12a3", "proving_system" => "Risc0", "pub_input" => %CBOR.Tag{tag: :bytes, value: <<244, 4, 0, 0, 134, 7, 0, 0>>}, "vm_program_code" => %CBOR.Tag{tag: :bytes, value: <<236, 222, 198, 17, 126, 252, 216, 2, 56, 215, 95, 204, 16, 38, 112, 127, 170, 202, 125, 234, 155, 16, 60, 144, 189, 141, 130, 37, 32, 26, 83, 174>>}}]
```

## Type of change

- [x] Bug fix\

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
