### PR TITLE
fix(explorer): do not use @firstBlock to fetch logs from Ethereum

### DIFF
--- a/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
@@ -162,7 +162,7 @@ defmodule AlignedLayerServiceManager do
       response_timestamp: batch_response.block_timestamp,
       amount_of_proofs: nil,
       proof_hashes: nil,
-      fee_per_proof: BatcherPaymentServiceManager.get_fee_per_proof(%{merkle_root: created_batch.batchMerkleRoot}),
+      fee_per_proof: BatcherPaymentServiceManager.get_fee_per_proof(%{merkle_root: created_batch.batchMerkleRoot, fromBlock: batch_creation.block_number}),
       sender_address: Utils.string_to_bytes32(created_batch.senderAddress),
       max_aggregator_fee: created_batch.maxAggregatorFee,
       is_valid: true # set to false later if a process determines it is invalid

--- a/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
@@ -54,36 +54,47 @@ defmodule AlignedLayerServiceManager do
   end
 
   def get_latest_block_number() do
+    Logger.info("Fetching latest block number")
     {:ok, num} = Ethers.current_block_number()
+    Logger.info("Latest block number: #{num}")
     num
   end
 
   def get_new_batch_events(%{fromBlock: fromBlock, toBlock: toBlock}) do
+    Logger.info("Fetching new batch events from #{fromBlock} to #{toBlock}")
     events =
       AlignedLayerServiceManager.EventFilters.new_batch_v3(nil)
         |> Ethers.get_logs(fromBlock: fromBlock, toBlock: toBlock)
 
     case events do
       {:ok, []} ->
+        Logger.info("No new batch events found in blocks #{fromBlock}-#{toBlock}")
         []
 
       {:ok, list} ->
+        Logger.info("Found #{length(list)} new batch events in blocks #{fromBlock}-#{toBlock}")
         Enum.map(list, &extract_new_batch_event_info/1)
 
       {:error, reason} ->
+        Logger.error("Error fetching new batch events from #{fromBlock} to #{toBlock}: #{Map.get(reason, "message")}")
         raise("Error fetching events: #{Map.get(reason, "message")}")
     end
   end
 
   def extract_new_batch_event_info(event) do
+    block_number = event |> Map.get(:block_number)
+    tx_hash = event |> Map.get(:transaction_hash)
+    Logger.info("Extracting new batch event info for block #{block_number}, tx: #{tx_hash}")
+    
     new_batch = parse_new_batch_event(event)
+    Logger.info("New batch event parsed: #{inspect(new_batch)}")
 
     {:ok,
      %NewBatchInfo{
        address: event |> Map.get(:address),
-       block_number: event |> Map.get(:block_number),
-       block_timestamp: get_block_timestamp(event |> Map.get(:block_number)),
-       transaction_hash: event |> Map.get(:transaction_hash),
+       block_number: block_number,
+       block_timestamp: get_block_timestamp(block_number),
+       transaction_hash: tx_hash,
        new_batch: new_batch
      }}
   end
@@ -101,29 +112,42 @@ defmodule AlignedLayerServiceManager do
     }
   end
 
-  def is_batch_responded(merkle_root) do
+  def is_batch_responded(merkle_root, fromBlock) do
+    Logger.info("Checking if batch is responded for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
+    
     event =
       Utils.string_to_bytes32(merkle_root)
       |> AlignedLayerServiceManager.EventFilters.batch_verified()
-      |> Ethers.get_logs(fromBlock: @first_block)
+      |> Ethers.get_logs(fromBlock: fromBlock)
 
     case event do
-      {:error, reason} -> {:error, reason}
-      {_, []} -> false
-      {:ok, _} -> true
+      {:error, reason} -> 
+        Logger.error("Error checking batch response for #{merkle_root}: #{inspect(reason)}")
+        {:error, reason}
+      {_, []} -> 
+        Logger.info("Batch #{merkle_root} not responded yet")
+        false
+      {:ok, events} -> 
+        Logger.info("Batch #{merkle_root} responded, found #{length(events)} verification events")
+        true
     end
   end
 
   # for new batches
   def extract_batch_response({_status, %NewBatchInfo{} = batch_creation}) do
     created_batch = batch_creation.new_batch
-    was_batch_responded = is_batch_responded(created_batch.batchMerkleRoot)
+    Logger.info("Extracting batch response for new batch: #{created_batch.batchMerkleRoot}")
+    was_batch_responded = is_batch_responded(created_batch.batchMerkleRoot, fromBlock: batch_creation.block_number)
 
     batch_response =
       case was_batch_responded do
-        true -> fetch_batch_response(created_batch.batchMerkleRoot)
+        true -> 
+          Logger.info("Batch #{created_batch.batchMerkleRoot} was responded, fetching response details")
+          fetch_batch_response(created_batch.batchMerkleRoot, batch_creation.block_number)
         # was not verified, fill with nils
-        false -> %{block_number: nil, transaction_hash: nil, block_timestamp: nil}
+        false -> 
+          Logger.info("Batch #{created_batch.batchMerkleRoot} was not responded yet")
+          %{block_number: nil, transaction_hash: nil, block_timestamp: nil}
       end
 
     %BatchDB{
@@ -147,15 +171,18 @@ defmodule AlignedLayerServiceManager do
 
   # for existing but unverified batches
   def extract_batch_response(%Batches{} = unverified_batch) do
-    was_batch_responded = is_batch_responded(unverified_batch.merkle_root)
+    Logger.info("Extracting batch response for existing unverified batch: #{unverified_batch.merkle_root}")
+    was_batch_responded = is_batch_responded(unverified_batch.merkle_root, unverified_batch.submission_block_number)
 
     case was_batch_responded do
       # Do nothing since unverified batch was not yet verified
       false ->
+        Logger.info("Unverified batch #{unverified_batch.merkle_root} still not responded")
         nil
 
       true ->
-        batch_response = fetch_batch_response(unverified_batch.merkle_root)
+        Logger.info("Unverified batch #{unverified_batch.merkle_root} now responded, updating status")
+        batch_response = fetch_batch_response(unverified_batch.merkle_root, unverified_batch.submission_block_number)
 
         %BatchDB{
           merkle_root: unverified_batch.merkle_root,
@@ -177,29 +204,46 @@ defmodule AlignedLayerServiceManager do
     end
   end
 
-  def fetch_batch_response(merkle_root) do
-    case get_batch_verified_events(%{merkle_root: merkle_root}) do
-      {:ok, batch_verified_info} -> batch_verified_info
-      {:empty, _} -> nil
-      {:error, error} -> raise("Error fetching batch response: #{error}")
+  def fetch_batch_response(merkle_root, fromBlock \\ @first_block) do
+    Logger.info("Fetching batch response for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
+    case get_batch_verified_events(%{merkle_root: merkle_root, fromBlock: fromBlock}) do
+      {:ok, batch_verified_info} -> 
+        Logger.info("Successfully fetched batch response for #{merkle_root}")
+        batch_verified_info
+      {:empty, _} -> 
+        Logger.info("No batch verified events found for #{merkle_root}")
+        nil
+      {:error, error} -> 
+        Logger.error("Error fetching batch response for #{merkle_root}: #{error}")
+        raise("Error fetching batch response: #{error}")
     end
   end
 
-  def get_batch_verified_events(%{merkle_root: merkle_root}) do
+  def get_batch_verified_events(%{merkle_root: merkle_root, fromBlock: fromBlock}) do
+    Logger.info("Getting batch verified events for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
     event =
       AlignedLayerServiceManager.EventFilters.batch_verified(Utils.string_to_bytes32(merkle_root))
-      |> Ethers.get_logs(fromBlock: @first_block)
+      |> Ethers.get_logs(fromBlock: fromBlock)
 
     case event do
-      {:error, reason} -> {:error, reason}
-      {_, []} -> {:empty, "No task found"}
-      {:ok, event} -> extract_batch_verified_event_info(event |> List.first())
+      {:error, reason} -> 
+        Logger.error("Error getting batch verified events for #{merkle_root}: #{inspect(reason)}")
+        {:error, reason}
+      {_, []} -> 
+        Logger.info("No batch verified events found for #{merkle_root}")
+        {:empty, "No task found"}
+      {:ok, events} -> 
+        Logger.info("Found #{length(events)} batch verified events for #{merkle_root}")
+        extract_batch_verified_event_info(events |> List.first())
     end
   end
 
   defp extract_batch_verified_event_info(event) do
     batch_merkle_root = event |> Map.get(:topics_raw) |> Enum.at(1)
     sender_address = event |> Map.get(:data) |> Enum.at(0)
+    block_number = event |> Map.get(:block_number)
+    tx_hash = event |> Map.get(:transaction_hash)
+    Logger.info("Extracting batch verified event info for block #{block_number}, tx: #{tx_hash}, merkle_root: #{batch_merkle_root}")
 
     {:ok,
      %BatchVerifiedInfo{
@@ -213,9 +257,15 @@ defmodule AlignedLayerServiceManager do
   end
 
   def get_block_timestamp(block_number) do
+    Logger.info("Fetching block timestamp for block #{block_number}")
     case Ethers.Utils.get_block_timestamp(block_number) do
-      {:ok, timestamp} -> DateTime.from_unix!(timestamp)
-      {:error, error} -> raise("Error fetching block timestamp: #{error}")
+      {:ok, timestamp} -> 
+        datetime = DateTime.from_unix!(timestamp)
+        Logger.info("Block #{block_number} timestamp: #{datetime}")
+        datetime
+      {:error, error} -> 
+        Logger.error("Error fetching block timestamp for block #{block_number}: #{error}")
+        raise("Error fetching block timestamp: #{error}")
     end
   end
 
@@ -230,8 +280,10 @@ defmodule AlignedLayerServiceManager do
   end
 
   def update_restakeable_strategies() do
+    Logger.info("Updating restakeable strategies")
     case AlignedLayerServiceManager.get_restakeable_strategies() |> Ethers.call() do
       {:ok, restakeable_strategies} ->
+        Logger.info("Successfully fetched #{length(restakeable_strategies)} restakeable strategies")
         Strategies.update(restakeable_strategies)
 
       {:error, error} ->

--- a/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
@@ -137,7 +137,7 @@ defmodule AlignedLayerServiceManager do
   def extract_batch_response({_status, %NewBatchInfo{} = batch_creation}) do
     created_batch = batch_creation.new_batch
     Logger.info("Extracting batch response for new batch: #{created_batch.batchMerkleRoot}")
-    was_batch_responded = is_batch_responded(created_batch.batchMerkleRoot, fromBlock: batch_creation.block_number)
+    was_batch_responded = is_batch_responded(created_batch.batchMerkleRoot, batch_creation.block_number)
 
     batch_response =
       case was_batch_responded do

--- a/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
@@ -45,7 +45,6 @@ defmodule AlignedLayerServiceManager do
   end
 
   def get_latest_block_number() do
-    Logger.info("Fetching latest block number")
     {:ok, num} = Ethers.current_block_number()
     Logger.info("Latest block number: #{num}")
     num
@@ -104,8 +103,6 @@ defmodule AlignedLayerServiceManager do
   end
 
   def is_batch_responded(merkle_root, fromBlock) do
-    Logger.info("Checking if batch is responded for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
-
     event =
       Utils.string_to_bytes32(merkle_root)
       |> AlignedLayerServiceManager.EventFilters.batch_verified()
@@ -116,10 +113,8 @@ defmodule AlignedLayerServiceManager do
         Logger.error("Error checking batch response for #{merkle_root}: #{inspect(reason)}")
         {:error, reason}
       {_, []} ->
-        Logger.info("Batch #{merkle_root} not responded yet")
         false
-      {:ok, events} ->
-        Logger.info("Batch #{merkle_root} responded, found #{length(events)} verification events")
+      {:ok, _events} ->
         true
     end
   end
@@ -127,7 +122,6 @@ defmodule AlignedLayerServiceManager do
   # for new batches
   def extract_batch_response({_status, %NewBatchInfo{} = batch_creation}) do
     created_batch = batch_creation.new_batch
-    Logger.info("Extracting batch response for new batch: #{created_batch.batchMerkleRoot}")
     was_batch_responded = is_batch_responded(created_batch.batchMerkleRoot, batch_creation.block_number)
 
     batch_response =
@@ -162,7 +156,6 @@ defmodule AlignedLayerServiceManager do
 
   # for existing but unverified batches
   def extract_batch_response(%Batches{} = unverified_batch) do
-    Logger.info("Extracting batch response for existing unverified batch: #{unverified_batch.merkle_root}")
     was_batch_responded = is_batch_responded(unverified_batch.merkle_root, unverified_batch.submission_block_number)
 
     case was_batch_responded do
@@ -196,7 +189,6 @@ defmodule AlignedLayerServiceManager do
   end
 
   def fetch_batch_response(merkle_root, fromBlock) do
-    Logger.info("Fetching batch response for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
     case get_batch_verified_events(%{merkle_root: merkle_root, fromBlock: fromBlock}) do
       {:ok, batch_verified_info} ->
         Logger.info("Successfully fetched batch response for #{merkle_root}")
@@ -211,7 +203,6 @@ defmodule AlignedLayerServiceManager do
   end
 
   def get_batch_verified_events(%{merkle_root: merkle_root, fromBlock: fromBlock}) do
-    Logger.info("Getting batch verified events for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
     event =
       AlignedLayerServiceManager.EventFilters.batch_verified(Utils.string_to_bytes32(merkle_root))
       |> Ethers.get_logs(fromBlock: fromBlock)
@@ -230,30 +221,23 @@ defmodule AlignedLayerServiceManager do
   end
 
   defp extract_batch_verified_event_info(event) do
-    batch_merkle_root = event |> Map.get(:topics_raw) |> Enum.at(1)
-    sender_address = event |> Map.get(:data) |> Enum.at(0)
     block_number = event |> Map.get(:block_number)
-    tx_hash = event |> Map.get(:transaction_hash)
-    Logger.info("Extracting batch verified event info for block #{block_number}, tx: #{tx_hash}, merkle_root: #{batch_merkle_root}")
 
     {:ok,
      %BatchVerifiedInfo{
        address: event |> Map.get(:address),
-       block_number: event |> Map.get(:block_number),
-       block_timestamp: get_block_timestamp(event |> Map.get(:block_number)),
+       block_number: block_number,
+       block_timestamp: get_block_timestamp(block_number),
        transaction_hash: event |> Map.get(:transaction_hash),
-       batch_merkle_root: batch_merkle_root,
-       sender_address: sender_address
+       batch_merkle_root: event |> Map.get(:topics_raw) |> Enum.at(1),
+       sender_address: event |> Map.get(:data) |> Enum.at(0)
      }}
   end
 
   def get_block_timestamp(block_number) do
-    Logger.info("Fetching block timestamp for block #{block_number}")
     case Ethers.Utils.get_block_timestamp(block_number) do
       {:ok, timestamp} ->
-        datetime = DateTime.from_unix!(timestamp)
-        Logger.info("Block #{block_number} timestamp: #{datetime}")
-        datetime
+        DateTime.from_unix!(timestamp)
       {:error, error} ->
         Logger.error("Error fetching block timestamp for block #{block_number}: #{error}")
         raise("Error fetching block timestamp: #{error}")

--- a/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/aligned_layer_service_manager.ex
@@ -36,15 +36,6 @@ defmodule AlignedLayerServiceManager do
                                          |> Map.get("addresses")
                                          |> Map.get("alignedLayerServiceManager")
 
-  @first_block (case @environment do
-                  "devnet" -> 0
-                  "holesky" -> 1_728_056
-                  "mainnet" -> 19_000_000
-                  "sepolia" -> 9_062_616
-                  "hoodi" -> 1_093_860
-                  _ -> raise("Invalid environment")
-                end)
-
   use Ethers.Contract,
     abi_file: "lib/abi/AlignedLayerServiceManager.json",
     default_address: @aligned_layer_service_manager_address
@@ -85,7 +76,7 @@ defmodule AlignedLayerServiceManager do
     block_number = event |> Map.get(:block_number)
     tx_hash = event |> Map.get(:transaction_hash)
     Logger.info("Extracting new batch event info for block #{block_number}, tx: #{tx_hash}")
-    
+
     new_batch = parse_new_batch_event(event)
     Logger.info("New batch event parsed: #{inspect(new_batch)}")
 
@@ -114,20 +105,20 @@ defmodule AlignedLayerServiceManager do
 
   def is_batch_responded(merkle_root, fromBlock) do
     Logger.info("Checking if batch is responded for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
-    
+
     event =
       Utils.string_to_bytes32(merkle_root)
       |> AlignedLayerServiceManager.EventFilters.batch_verified()
       |> Ethers.get_logs(fromBlock: fromBlock)
 
     case event do
-      {:error, reason} -> 
+      {:error, reason} ->
         Logger.error("Error checking batch response for #{merkle_root}: #{inspect(reason)}")
         {:error, reason}
-      {_, []} -> 
+      {_, []} ->
         Logger.info("Batch #{merkle_root} not responded yet")
         false
-      {:ok, events} -> 
+      {:ok, events} ->
         Logger.info("Batch #{merkle_root} responded, found #{length(events)} verification events")
         true
     end
@@ -141,11 +132,11 @@ defmodule AlignedLayerServiceManager do
 
     batch_response =
       case was_batch_responded do
-        true -> 
+        true ->
           Logger.info("Batch #{created_batch.batchMerkleRoot} was responded, fetching response details")
           fetch_batch_response(created_batch.batchMerkleRoot, batch_creation.block_number)
         # was not verified, fill with nils
-        false -> 
+        false ->
           Logger.info("Batch #{created_batch.batchMerkleRoot} was not responded yet")
           %{block_number: nil, transaction_hash: nil, block_timestamp: nil}
       end
@@ -204,16 +195,16 @@ defmodule AlignedLayerServiceManager do
     end
   end
 
-  def fetch_batch_response(merkle_root, fromBlock \\ @first_block) do
+  def fetch_batch_response(merkle_root, fromBlock) do
     Logger.info("Fetching batch response for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
     case get_batch_verified_events(%{merkle_root: merkle_root, fromBlock: fromBlock}) do
-      {:ok, batch_verified_info} -> 
+      {:ok, batch_verified_info} ->
         Logger.info("Successfully fetched batch response for #{merkle_root}")
         batch_verified_info
-      {:empty, _} -> 
+      {:empty, _} ->
         Logger.info("No batch verified events found for #{merkle_root}")
         nil
-      {:error, error} -> 
+      {:error, error} ->
         Logger.error("Error fetching batch response for #{merkle_root}: #{error}")
         raise("Error fetching batch response: #{error}")
     end
@@ -226,13 +217,13 @@ defmodule AlignedLayerServiceManager do
       |> Ethers.get_logs(fromBlock: fromBlock)
 
     case event do
-      {:error, reason} -> 
+      {:error, reason} ->
         Logger.error("Error getting batch verified events for #{merkle_root}: #{inspect(reason)}")
         {:error, reason}
-      {_, []} -> 
+      {_, []} ->
         Logger.info("No batch verified events found for #{merkle_root}")
         {:empty, "No task found"}
-      {:ok, events} -> 
+      {:ok, events} ->
         Logger.info("Found #{length(events)} batch verified events for #{merkle_root}")
         extract_batch_verified_event_info(events |> List.first())
     end
@@ -259,11 +250,11 @@ defmodule AlignedLayerServiceManager do
   def get_block_timestamp(block_number) do
     Logger.info("Fetching block timestamp for block #{block_number}")
     case Ethers.Utils.get_block_timestamp(block_number) do
-      {:ok, timestamp} -> 
+      {:ok, timestamp} ->
         datetime = DateTime.from_unix!(timestamp)
         Logger.info("Block #{block_number} timestamp: #{datetime}")
         datetime
-      {:error, error} -> 
+      {:error, error} ->
         Logger.error("Error fetching block timestamp for block #{block_number}: #{error}")
         raise("Error fetching block timestamp: #{error}")
     end

--- a/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
@@ -43,12 +43,13 @@ defmodule BatcherPaymentServiceManager do
     @batcher_payment_service_address
   end
 
-  def get_fee_per_proof(%{merkle_root: merkle_root}) do
+  def get_fee_per_proof(%{merkle_root: merkle_root, fromBlock: fromBlock}) do
+    Logger.info("Getting fee per proof for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
     BatcherPaymentServiceManager.EventFilters.task_created(
       merkle_root
       |> Utils.string_to_bytes32()
     )
-    |> Ethers.get_logs(fromBlock: @first_block)
+    |> Ethers.get_logs(fromBlock: fromBlock)
     |> case do
       {:ok, []} ->
         Logger.warning("No fee per proof events found for merkle root: #{merkle_root}.")
@@ -57,7 +58,7 @@ defmodule BatcherPaymentServiceManager do
       {:ok, events} ->
         event = events |> hd()
         fee_per_proof = event.data |> hd()
-        Logger.debug("Fee per proof of #{merkle_root}: #{fee_per_proof} WEI.")
+        Logger.info("Fee per proof of #{merkle_root}: #{fee_per_proof} WEI.")
 
         fee_per_proof
 

--- a/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
@@ -34,7 +34,6 @@ defmodule BatcherPaymentServiceManager do
   end
 
   def get_fee_per_proof(%{merkle_root: merkle_root, fromBlock: fromBlock}) do
-    Logger.info("Getting fee per proof for merkle_root: #{merkle_root}, fromBlock: #{fromBlock}")
     BatcherPaymentServiceManager.EventFilters.task_created(
       merkle_root
       |> Utils.string_to_bytes32()

--- a/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
+++ b/explorer/lib/explorer/contract_managers/batcher_payment_service_manager.ex
@@ -3,16 +3,6 @@ defmodule BatcherPaymentServiceManager do
 
   @aligned_config_file System.get_env("ALIGNED_CONFIG_FILE")
 
-  @environment System.get_env("ENVIRONMENT")
-  @first_block (case @environment do
-                  "devnet" -> 0
-                  "holesky" -> 1_728_056
-                  "mainnet" -> 19_000_000
-                  "sepolia" -> 9_062_616
-                  "hoodi" -> 1_093_860
-                  _ -> raise("Invalid environment")
-                end)
-
   config_file_path =
     case @aligned_config_file do
       nil -> raise("ALIGNED_CONFIG_FILE not set in .env")

--- a/explorer/lib/explorer_web/components/agg_proofs_table.ex
+++ b/explorer/lib/explorer_web/components/agg_proofs_table.ex
@@ -6,7 +6,7 @@ defmodule ExplorerWeb.AggProofsTable do
 
   def agg_proofs_table(assigns) do
     ~H"""
-    <.table id="agg_proofs" rows={@proofs}>
+    <.table id="agg_proofs" rows={@agg_proofs}>
       <:col :let={proof} label="Merkle root" class="text-left">
         <.link navigate={~p"/aggregated_proofs/#{proof.id}"}>
           <span class="inline-flex gap-x-3 items-center group-hover:text-foreground/80">

--- a/explorer/lib/explorer_web/components/nav.ex
+++ b/explorer/lib/explorer_web/components/nav.ex
@@ -199,9 +199,9 @@ defmodule NavComponent do
   @doc """
     Renders a dropdown on hover component with links.
   """
-  attr(:title, :list, doc: "the selector title")
+  attr(:title, :string, doc: "the selector title")
   attr(:class, :list, doc: "class for selector")
-  attr(:links, :string, doc: "the links to render: (name, link, class)")
+  attr(:links, :list, doc: "the links to render: (name, link, class)")
 
   def nav_links_dropdown(assigns) do
     ~H"""

--- a/explorer/lib/explorer_web/live/pages/agg_proofs/index.html.heex
+++ b/explorer/lib/explorer_web/live/pages/agg_proofs/index.html.heex
@@ -2,7 +2,7 @@
   <.card_preheding>Aggregation</.card_preheding>
   <%= if @proofs != :empty and @proofs != [] do %>
     <.card_background class="w-full overflow-x-auto sm:col-span-2">
-      <.agg_proofs_table proofs={@proofs} />
+      <.agg_proofs_table agg_proofs={@proofs} />
     </.card_background>
   <% else %>
     <.empty_card_background text="No aggregated proofs To Display." class="sm:col-span-2" />

--- a/explorer/lib/explorer_web/live/utils.ex
+++ b/explorer/lib/explorer_web/live/utils.ex
@@ -191,19 +191,19 @@ defmodule ExplorerWeb.Helpers do
   end
 
   def get_aligned_contracts_addresses() do
-    Map.merge(get_batcher_service_addresses(), get_proof_aggregation_addresses())
+    Map.merge(get_verification_layer_addresses(), get_proof_aggregation_addresses())
   end
 
   defp get_proof_aggregation_addresses() do
     proof_agg_config_file = System.get_env("ALIGNED_PROOF_AGG_CONFIG_FILE")
     {_, config_json_string} = File.read(proof_agg_config_file)
-    proof_agg_service_addresses = Jason.decode!(config_json_string) |> Map.get("addresses")
+    Jason.decode!(config_json_string) |> Map.get("addresses")
   end
 
-  defp get_batcher_service_addresses() do
+  defp get_verification_layer_addresses() do
     aligned_config_file = System.get_env("ALIGNED_CONFIG_FILE")
     {_, config_json_string} = File.read(aligned_config_file)
-    agg_service_addresses = Jason.decode!(config_json_string) |> Map.get("addresses")
+    Jason.decode!(config_json_string) |> Map.get("addresses")
   end
 
   def binary_to_hex_string(binary) do


### PR DESCRIPTION
# fix(explorer): do not use @fromBlock to fetch logs from Ethereum

## Description

If using @firstBlock we have the risk to get the following error

```
query exceeds max block range 100000
```

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
