### PR TITLE
fix(makefile): load operator address correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ else
 endif
 
 CONFIG_FILE?=config-files/config.yaml
-export OPERATOR_ADDRESS ?= $(shell yq -r '.operator.address' $(CONFIG_FILE))
 AGG_CONFIG_FILE?=config-files/config-aggregator.yaml
 
 OPERATOR_VERSION=v0.18.0
@@ -356,11 +355,16 @@ operator_set_eigen_sdk_go_version_error:
 
 operator_full_registration: operator_get_eth operator_register_with_eigen_layer operator_mint_mock_tokens operator_deposit_into_mock_strategy operator_whitelist_devnet operator_register_with_aligned_layer ## Register the operator in EigenLayer and AlignedLayer. Parameters: ENVIRONMENT=<devnet|testnet|mainnet>, CONFIG_FILE
 
-operator_full_registration_and_start: $(GET_SDK_VERSION) operator_full_registration operator_start ## Register the operator in EigenLayer and AlignedLayer, then start the Operator. Parameters: ENVIRONMENT=<devnet|testnet|mainnet>, CONFIG_FILE
+operator_full_registration_and_start:
+	@echo "Operator address: $$(yq -r '.operator.address' $$CONFIG_FILE)" && \
+	$(MAKE) operator_full_registration CONFIG_FILE=$(CONFIG_FILE) && \
+	$(MAKE) operator_start ENVIRONMENT=devnet CONFIG_FILE=$(CONFIG_FILE)
 
 operator_full_registration_and_start_ethereum_package: ## Register the operator in EigenLayer and AlignedLayer, then start the Operator with Ethereum package config
-	$(MAKE) operator_full_registration CONFIG_FILE=config-files/config-operator-1-ethereum-package.yaml
-	$(MAKE) operator_start ENVIRONMENT=devnet CONFIG_FILE=config-files/config-operator-1-ethereum-package.yaml
+	@export CONFIG_FILE=config-files/config-operator-1-ethereum-package.yaml && \
+	echo "Operator address: $$(yq -r '.operator.address' $$CONFIG_FILE)" && \
+	$(MAKE) operator_full_registration CONFIG_FILE=$$CONFIG_FILE && \
+	$(MAKE) operator_start ENVIRONMENT=devnet CONFIG_FILE=$$CONFIG_FILE
 
 
 operator_build: deps ## Build the Operator. Parameters: ENVIRONMENT=<devnet|testnet|mainnet>
@@ -416,7 +420,8 @@ operator_generate_config:
 
 operator_get_eth:
 	@echo "Sending funds to operator address on devnet"
-	@. ./scripts/fund_operator_devnet.sh
+	@OPERATOR_ADDRESS=$$(yq -r '.operator.address' $(CONFIG_FILE)) && \
+	. ./scripts/fund_operator_devnet.sh
 
 operator_register_with_eigen_layer:
 	@echo "Registering operator with EigenLayer"
@@ -424,25 +429,30 @@ operator_register_with_eigen_layer:
 
 operator_mint_mock_tokens:
 	@echo "Minting tokens"
+	@OPERATOR_ADDRESS=$$(yq -r '.operator.address' $(CONFIG_FILE)) && \
 	. ./scripts/mint_mock_token.sh $(CONFIG_FILE) 100000000000000000
 
 operator_whitelist_devnet:
 	@echo "Whitelisting operator"
-	@echo "Operator address: $(OPERATOR_ADDRESS)"
-	RPC_URL="http://localhost:8545" PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" OUTPUT_PATH=./script/output/devnet/alignedlayer_deployment_output.json ./contracts/scripts/operator_whitelist.sh $(OPERATOR_ADDRESS)
+	@OPERATOR_ADDRESS=$$(yq -r '.operator.address' $(CONFIG_FILE)) && \
+	echo "Operator address: $$OPERATOR_ADDRESS" && \
+	RPC_URL="http://localhost:8545" PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" OUTPUT_PATH=./script/output/devnet/alignedlayer_deployment_output.json ./contracts/scripts/operator_whitelist.sh $$OPERATOR_ADDRESS
 
 operator_remove_from_whitelist_devnet:
 	@echo "Removing operator"
-	@echo "Operator address: $(OPERATOR_ADDRESS)"
-	RPC_URL="http://localhost:8545" PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" OUTPUT_PATH=./script/output/devnet/alignedlayer_deployment_output.json ./contracts/scripts/operator_remove_from_whitelist.sh $(OPERATOR_ADDRESS)
+	@OPERATOR_ADDRESS=$$(yq -r '.operator.address' $(CONFIG_FILE)) && \
+	echo "Operator address: $$OPERATOR_ADDRESS" && \
+	RPC_URL="http://localhost:8545" PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" OUTPUT_PATH=./script/output/devnet/alignedlayer_deployment_output.json ./contracts/scripts/operator_remove_from_whitelist.sh $$OPERATOR_ADDRESS
 
 operator_whitelist:
-	@echo "Whitelisting operator $(OPERATOR_ADDRESS) on $(NETWORK)"
-	@. contracts/scripts/.env.$(NETWORK) && . contracts/scripts/operator_whitelist.sh $(OPERATOR_ADDRESS)
+	@OPERATOR_ADDRESS=$$(yq -r '.operator.address' $(CONFIG_FILE)) && \
+	echo "Whitelisting operator $$OPERATOR_ADDRESS on $(NETWORK)" && \
+	. contracts/scripts/.env.$(NETWORK) && . contracts/scripts/operator_whitelist.sh $$OPERATOR_ADDRESS
 
 operator_remove_from_whitelist:
-	@echo "Removing operator $(OPERATOR_ADDRESS)"
-	@. contracts/scripts/.env && . contracts/scripts/operator_remove_from_whitelist.sh $(OPERATOR_ADDRESS)
+	@OPERATOR_ADDRESS=$$(yq -r '.operator.address' $(CONFIG_FILE)) && \
+	echo "Removing operator $$OPERATOR_ADDRESS" && \
+	. contracts/scripts/.env && . contracts/scripts/operator_remove_from_whitelist.sh $$OPERATOR_ADDRESS
 
 operator_deposit_into_mock_strategy:
 	@echo "Depositing into mock strategy"

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ operator_set_eigen_sdk_go_version_error:
 
 operator_full_registration: operator_get_eth operator_register_with_eigen_layer operator_mint_mock_tokens operator_deposit_into_mock_strategy operator_whitelist_devnet operator_register_with_aligned_layer ## Register the operator in EigenLayer and AlignedLayer. Parameters: ENVIRONMENT=<devnet|testnet|mainnet>, CONFIG_FILE
 
-operator_full_registration_and_start:
+operator_full_registration_and_start: ## Register the operator in EigenLayer and AlignedLayer, then start the Operator. Parameters: ENVIRONMENT=<devnet|testnet|mainnet>, CONFIG_FILE
 	@echo "Operator address: $$(yq -r '.operator.address' $$CONFIG_FILE)" && \
 	$(MAKE) operator_full_registration CONFIG_FILE=$(CONFIG_FILE) && \
 	$(MAKE) operator_start ENVIRONMENT=devnet CONFIG_FILE=$(CONFIG_FILE)


### PR DESCRIPTION
# fix(makefile): load operator address correctly

## Description

### How To Test

```
make ethereum_package_start
```

```
make batcher_start_ethereum_package
```

```
make aggregator_start_ethereum_package ENVIRONMENT=devnet
```

```
make operator_full_registration_and_start_ethereum_package ENVIRONMENT=devnet
```

```
make batcher_send_proof_with_random_address PROOF_TYPE=risc0
```

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
