### PR TITLE
Log address on lack of funds error

### DIFF
--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1820,8 +1820,9 @@ impl Batcher {
             // decide if i want to flush the queue:
             match e {
                 BatcherError::TransactionSendError(
-                    TransactionSendError::SubmissionInsufficientBalance,
+                    TransactionSendError::SubmissionInsufficientBalance(address),
                 ) => {
+                    warn!("User {:?} has insufficient balance, flushing entire queue as safety measure", address);
                     // TODO: In the future, we should re-add the failed batch back to the queue
                     // For now, we flush everything as a safety measure
                     self.flush_queue_and_clear_nonce_cache().await;

--- a/crates/batcher/src/types/errors.rs
+++ b/crates/batcher/src/types/errors.rs
@@ -7,7 +7,7 @@ pub enum TransactionSendError {
     NoProofSubmitters,
     NoFeePerProof,
     InsufficientFeeForAggregator,
-    SubmissionInsufficientBalance,
+    SubmissionInsufficientBalance(Address),
     BatchAlreadySubmitted,
     InsufficientFunds,
     OnlyBatcherAllowed,
@@ -30,8 +30,16 @@ impl From<Bytes> for TransactionSendError {
             "0x3102f10c" => TransactionSendError::BatchAlreadySubmitted, // can happen, don't flush
             "0x5c54305e" => TransactionSendError::InsufficientFunds, // shouldn't happen, don't flush
             "0x152bc288" => TransactionSendError::OnlyBatcherAllowed, // won't happen, don't flush
-            "0x4f779ceb" => TransactionSendError::SubmissionInsufficientBalance, // shouldn't happen,
-            // flush can help if something went wrong
+            "0x4f779ceb" => {
+                // SubmissionInsufficientBalance(address sender, uint256 balance, uint256 required)
+                // Try to decode the address parameter (first parameter after selector)
+                let address = byte_string
+                    .get(34..74) // Skip "0x" + selector (8 chars) + padding (24 chars)
+                    .and_then(|hex_str| hex::decode(hex_str).ok())
+                    .map(|bytes| Address::from_slice(&bytes))
+                    .unwrap_or(Address::zero());
+                TransactionSendError::SubmissionInsufficientBalance(address)
+            }
             _ => {
                 // flush because unkown error
                 TransactionSendError::Generic(format!("Unknown bytestring error: {}", byte_string))
@@ -155,8 +163,8 @@ impl fmt::Display for TransactionSendError {
             TransactionSendError::InsufficientFeeForAggregator => {
                 write!(f, "Insufficient fee for aggregator")
             }
-            TransactionSendError::SubmissionInsufficientBalance => {
-                write!(f, "Submission insufficient balance")
+            TransactionSendError::SubmissionInsufficientBalance(address) => {
+                write!(f, "Submission insufficient balance for address: {:?}", address)
             }
             TransactionSendError::BatchAlreadySubmitted => {
                 write!(f, "Batch already submitted")

--- a/crates/batcher/src/types/errors.rs
+++ b/crates/batcher/src/types/errors.rs
@@ -164,7 +164,11 @@ impl fmt::Display for TransactionSendError {
                 write!(f, "Insufficient fee for aggregator")
             }
             TransactionSendError::SubmissionInsufficientBalance(address) => {
-                write!(f, "Submission insufficient balance for address: {:?}", address)
+                write!(
+                    f,
+                    "Submission insufficient balance for address: {:?}",
+                    address
+                )
             }
             TransactionSendError::BatchAlreadySubmitted => {
                 write!(f, "Batch already submitted")


### PR DESCRIPTION
# Log address on lack of funds error

## How to test

You can test it with an anvil rich account private key:

0. Insert the following line in the batcher (`crates/batcher/src/lib.rs`) code so that you have enough time to unlock and withdraw eth from the batcher payment contract: 
```suggestion
1800+       warn!("SLEEPING FOR 60 SECONDS BEFORE FINALIZING BLOCK ADVANCE BLOCKS NOW!!!!");
1801+       tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
```
2. Fund an account: 
```shell
cd crates/cli
cargo run --release -- deposit-to-batcher --amount 1ether --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97  --network devnet --rpc_url http://localhost:8545
```

3. Send a proof:
```shell
cargo run --release -- submit \
                --proving_system Risc0 \
                --proof ../../scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_3_0_3.proof \
                --vm_program ../../scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_id_3_0_3.bin \
                --rpc_url http://localhost:8545 \
                --network devnet \
                --instant_fee_estimate \
                --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
                --random_address
```
4. Wait until you see the message:
```shell
[2025-09-15T15:13:17Z WARN  aligned_batcher] SLEEPING BEFORE FINALIZING BLOCK ADVANCE BLOCKS NOW!!!!
```

**Now hurry up (you only have 60 seconds to unlock, advance blocks and withdraw from the batcher payment service)**

5. Unlock balance: 
```shell
cast send 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650  "unlock()" --rpc-url http://localhost:8545 --private-key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97
```
6. Advance `anvil` seconds to not wait: 
```shell
curl http://localhost:8545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[20000],"id":1}'
```
7. Get your balance and copy the value:
```shell
cast call 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650 "user_balances(address)" --rpc-url  http://localhost:8545 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 
```
9. Finally withdraw passing the copied value from the previous step: 
```shell
cast send 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650  "withdraw(uint256)" <PREV_VALUE> --rpc-url http://localhost:8545 --private-key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97      
```
10. See the expected log