### PR TITLE
Restore flush logic (Nuclear option for state recovery)

### DIFF
--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1826,6 +1826,11 @@ impl Batcher {
                     // TODO: In the future, we should re-add the failed batch back to the queue
                     // For now, we flush everything as a safety measure
                     self.flush_queue_and_clear_nonce_cache().await;
+                    
+                    // Return a different error that indicates state was corrupted and flushed
+                    return Err(BatcherError::StateCorruptedAndFlushed(
+                        format!("Queue and user states flushed due to insufficient balance for user {:?}", address)
+                    ));
                 }
                 _ => {
                     // Add more cases here if we want in the future
@@ -1954,14 +1959,10 @@ impl Batcher {
             if let Err(e) = batch_finalization_result {
                 error!("Batch finalization failed: {:?}", e);
 
-                // Don't restore proofs for insufficient balance errors - the queue was already flushed
+                // If the queue was flushed, don't recover
                 match &e {
-                    BatcherError::TransactionSendError(
-                        TransactionSendError::SubmissionInsufficientBalance(_),
-                    ) => {
-                        info!(
-                            "Queue was flushed due to insufficient balance - not restoring proofs"
-                        );
+                    BatcherError::StateCorruptedAndFlushed(_) => {
+                        info!("State was corrupted and flushed - not restoring proofs");
                     }
                     _ => {
                         info!("Restoring proofs to queue after batch failure");

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1952,12 +1952,23 @@ impl Batcher {
 
             // If batch finalization failed, restore the proofs to the queue
             if let Err(e) = batch_finalization_result {
-                error!(
-                    "Batch finalization failed, restoring proofs to queue: {:?}",
-                    e
-                );
-                self.restore_proofs_after_batch_failure(&finalized_batch)
-                    .await;
+                error!("Batch finalization failed: {:?}", e);
+
+                // Don't restore proofs for insufficient balance errors - the queue was already flushed
+                match &e {
+                    BatcherError::TransactionSendError(
+                        TransactionSendError::SubmissionInsufficientBalance(_),
+                    ) => {
+                        info!(
+                            "Queue was flushed due to insufficient balance - not restoring proofs"
+                        );
+                    }
+                    _ => {
+                        info!("Restoring proofs to queue after batch failure");
+                        self.restore_proofs_after_batch_failure(&finalized_batch)
+                            .await;
+                    }
+                }
                 return Err(e);
             }
         }

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -2041,6 +2041,19 @@ impl Batcher {
 
                     self.flush_queue_and_clear_nonce_cache().await;
 
+                    for entry in finalized_batch {
+                        if let Some(ws_sink) = entry.messaging_sink.as_ref() {
+                            tokio::spawn(send_message(
+                                ws_sink.clone(),
+                                SubmitProofResponseMessage::BatchReset,
+                            ));
+                        } else {
+                            warn!(
+                                "Websocket sink was found empty. This should only happen in tests"
+                            );
+                        }
+                    }
+
                     return Err(BatcherError::StateCorruptedAndFlushed(format!(
                         "Queue and user states flushed due to insufficient balance for user {:?}",
                         address
@@ -2082,7 +2095,10 @@ impl Batcher {
         let mut batch_state_lock = self.batch_state.lock().await;
         for (entry, _) in batch_state_lock.batch_queue.iter() {
             if let Some(ws_sink) = entry.messaging_sink.as_ref() {
-                send_message(ws_sink.clone(), SubmitProofResponseMessage::BatchReset).await;
+                tokio::spawn(send_message(
+                    ws_sink.clone(),
+                    SubmitProofResponseMessage::BatchReset,
+                ));
             } else {
                 warn!("Websocket sink was found empty. This should only happen in tests");
             }

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1827,10 +1827,10 @@ impl Batcher {
                     // For now, we flush everything as a safety measure
                     self.flush_queue_and_clear_nonce_cache().await;
                     
-                    // Return a different error that indicates state was corrupted and flushed
-                    return Err(BatcherError::StateCorruptedAndFlushed(
-                        format!("Queue and user states flushed due to insufficient balance for user {:?}", address)
-                    ));
+                    return Err(BatcherError::StateCorruptedAndFlushed(format!(
+                        "Queue and user states flushed due to insufficient balance for user {:?}",
+                        address
+                    )));
                 }
                 _ => {
                     // Add more cases here if we want in the future

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1826,7 +1826,7 @@ impl Batcher {
                     // TODO: In the future, we should re-add the failed batch back to the queue
                     // For now, we flush everything as a safety measure
                     self.flush_queue_and_clear_nonce_cache().await;
-                    
+
                     return Err(BatcherError::StateCorruptedAndFlushed(format!(
                         "Queue and user states flushed due to insufficient balance for user {:?}",
                         address

--- a/crates/batcher/src/types/errors.rs
+++ b/crates/batcher/src/types/errors.rs
@@ -66,6 +66,7 @@ pub enum BatcherError {
     WsSinkEmpty,
     AddressNotFoundInUserStates(Address),
     QueueRemoveError(String),
+    StateCorruptedAndFlushed(String),
 }
 
 impl From<tungstenite::Error> for BatcherError {
@@ -146,6 +147,9 @@ impl fmt::Debug for BatcherError {
             }
             BatcherError::QueueRemoveError(e) => {
                 write!(f, "Error while removing entry from queue: {}", e)
+            }
+            BatcherError::StateCorruptedAndFlushed(reason) => {
+                write!(f, "Batcher state was corrupted and flushed: {}", reason)
             }
         }
     }


### PR DESCRIPTION
# Restore flush logic (Nuclear option for state recovery)

## Description

Restore flush logic (Nuclear option for state recovery)

## How to test

You can test it with an anvil rich account private key:

1. Insert the following line in the batcher (`crates/batcher/src/lib.rs`) code so that you have enough time to unlock and withdraw eth from the batcher payment contract: 
```suggestion
2012+       warn!("SLEEPING FOR 60 SECONDS BEFORE FINALIZING BLOCK ADVANCE BLOCKS NOW!!!!");
2013+       tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
```
2. Fund an account: 
```shell
cd crates/cli
cargo run --release -- deposit-to-batcher --amount 1ether --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97  --network devnet --rpc_url http://localhost:8545
```

3. Send a proof:
```shell
cargo run --release -- submit \
                --proving_system Risc0 \
                --proof ../../scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_3_0_3.proof \
                --vm_program ../../scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_id_3_0_3.bin \
                --rpc_url http://localhost:8545 \
                --network devnet \
                --instant_fee_estimate \
                --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
                --random_address
```
4. Wait until you see the message:
```shell
[2025-09-15T15:13:17Z WARN  aligned_batcher] SLEEPING BEFORE FINALIZING BLOCK ADVANCE BLOCKS NOW!!!!
```

**Now hurry up (you only have 60 seconds to unlock, advance blocks and withdraw from the batcher payment service)**

5. Unlock balance: 
```shell
cast send 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650  "unlock()" --rpc-url http://localhost:8545 --private-key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97
```
6. Advance `anvil` seconds to not wait: 
```shell
curl http://localhost:8545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[20000],"id":1}'
```
7. Get your balance and copy the value:
```shell
cast call 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650 "user_balances(address)" --rpc-url  http://localhost:8545 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f 
```
9. Finally withdraw passing the copied value from the previous step: 
```shell
cast send 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650  "withdraw(uint256)" <PREV_VALUE> --rpc-url http://localhost:8545 --private-key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97      
```
10. See that the queue is in effect flushed and the CLI receives the BatcherReset message

