### PR TITLE
feat(batcher): poll for unlock events and remove users with unlocked funds

### DIFF
--- a/config-files/config-batcher-docker.yaml
+++ b/config-files/config-batcher-docker.yaml
@@ -37,4 +37,6 @@ batcher:
   # When replacing the message, how much higher should the max fee in comparison to the original one
   # The calculation is replacement_max_fee >= original_max_fee + original_max_fee * min_bump_percentage / 100
   min_bump_percentage: 10
+  # How often to poll for BalanceUnlocked events in seconds (default: 600 seconds = 10 minutes)
+  balance_unlock_polling_interval_seconds: 600
 

--- a/config-files/config-batcher-ethereum-package.yaml
+++ b/config-files/config-batcher-ethereum-package.yaml
@@ -35,4 +35,6 @@ batcher:
   # When replacing the message, how much higher should the max fee in comparison to the original one
   # The calculation is replacement_max_fee >= original_max_fee + original_max_fee * min_bump_percentage / 100
   min_bump_percentage: 10
+  # How often to poll for BalanceUnlocked events in seconds (default: 600 seconds = 10 minutes)
+  balance_unlock_polling_interval_seconds: 600
 

--- a/config-files/config-batcher.yaml
+++ b/config-files/config-batcher.yaml
@@ -37,3 +37,5 @@ batcher:
   # When replacing the message, how much higher should the max fee in comparison to the original one
   # The calculation is replacement_max_fee >= original_max_fee + original_max_fee * min_bump_percentage / 100
   min_bump_percentage: 10
+  # How often to poll for BalanceUnlocked events in seconds (default: 600 seconds = 10 minutes)
+  balance_unlock_polling_interval_seconds: 600

--- a/crates/batcher/src/config/mod.rs
+++ b/crates/batcher/src/config/mod.rs
@@ -53,6 +53,7 @@ pub struct BatcherConfigFromYaml {
     pub non_paying: Option<NonPayingConfigFromYaml>,
     pub amount_of_proofs_for_min_max_fee: usize,
     pub min_bump_percentage: u64,
+    pub balance_unlock_polling_interval_seconds: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -678,7 +678,7 @@ impl Batcher {
             .batch_queue
             .extract_if(|entry, _| entry.sender == user_address);
 
-        // Notify user via websocket before removing the proofs
+        // Notify user via websocket
         for (entry, _) in removed_entries {
             if let Some(ws_sink) = entry.messaging_sink {
                 let ws_sink_clone = ws_sink.clone();

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -7,10 +7,10 @@ use eth::utils::{calculate_bumped_gas_price, get_batcher_signer, get_gas_price};
 use ethers::contract::ContractError;
 use ethers::signers::Signer;
 use retry::batcher_retryables::{
-    cancel_create_new_task_retryable, create_new_task_retryable, get_user_balance_retryable,
-    get_user_nonce_from_ethereum_retryable, simulate_create_new_task_retryable,
-    user_balance_is_unlocked_retryable, get_current_block_number_retryable,
-    query_balance_unlocked_events_retryable,
+    cancel_create_new_task_retryable, create_new_task_retryable,
+    get_current_block_number_retryable, get_user_balance_retryable,
+    get_user_nonce_from_ethereum_retryable, query_balance_unlocked_events_retryable,
+    simulate_create_new_task_retryable, user_balance_is_unlocked_retryable,
 };
 use retry::{retry_function, RetryError};
 use tokio::time::{timeout, Instant};
@@ -40,7 +40,7 @@ use aligned_sdk::common::types::{
 
 use aws_sdk_s3::client::Client as S3Client;
 use eth::payment_service::{BatcherPaymentService, CreateNewTaskFeeParams, SignerMiddlewareT};
-use ethers::prelude::{Middleware, Provider, Http};
+use ethers::prelude::{Http, Middleware, Provider};
 use ethers::types::{Address, Signature, TransactionReceipt, U256, U64};
 use futures_util::{future, join, SinkExt, StreamExt, TryStreamExt};
 use lambdaworks_crypto::merkle_tree::merkle::MerkleTree;
@@ -333,7 +333,9 @@ impl Batcher {
             max_batch_proof_qty: config.batcher.max_batch_proof_qty,
             amount_of_proofs_for_min_max_fee: config.batcher.amount_of_proofs_for_min_max_fee,
             min_bump_percentage: U256::from(config.batcher.min_bump_percentage),
-            balance_unlock_polling_interval_seconds: config.batcher.balance_unlock_polling_interval_seconds,
+            balance_unlock_polling_interval_seconds: config
+                .batcher
+                .balance_unlock_polling_interval_seconds,
             last_uploaded_batch_block: Mutex::new(last_uploaded_batch_block),
             pre_verification_is_enabled: config.batcher.pre_verification_is_enabled,
             non_paying_config,
@@ -502,11 +504,13 @@ impl Batcher {
     /// Runs at configurable intervals and checks recent blocks for events (2x the polling interval).
     /// When an event is detected, removes user's proofs from queue and resets UserState.
     pub async fn poll_balance_unlocked_events(self: Arc<Self>) -> Result<(), BatcherError> {
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(self.balance_unlock_polling_interval_seconds));
-        
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
+            self.balance_unlock_polling_interval_seconds,
+        ));
+
         loop {
             interval.tick().await;
-            
+
             if let Err(e) = self.process_balance_unlocked_events().await {
                 error!("Error processing BalanceUnlocked events: {:?}", e);
                 // Continue polling even if there's an error
@@ -528,37 +532,59 @@ impl Batcher {
         // Formula: interval / 12 * 2 (assuming 12-second block times, look back 2x the interval)
         let block_range = (self.balance_unlock_polling_interval_seconds / 12) * 2;
         let from_block = current_block.saturating_sub(U64::from(block_range));
-        
+
         // Query events with retry logic
-        let events = match self.query_balance_unlocked_events(from_block, current_block).await {
+        let events = match self
+            .query_balance_unlocked_events(from_block, current_block)
+            .await
+        {
             Ok(events) => events,
             Err(e) => {
-                warn!("Failed to query BalanceUnlocked events after retries: {:?}", e);
+                warn!(
+                    "Failed to query BalanceUnlocked events after retries: {:?}",
+                    e
+                );
                 return Ok(());
             }
         };
 
-        info!("Found {} BalanceUnlocked events in blocks {} to {}", 
-              events.len(), from_block, current_block);
+        info!(
+            "Found {} BalanceUnlocked events in blocks {} to {}",
+            events.len(),
+            from_block,
+            current_block
+        );
 
         // Process each event
         for event in events {
             let user_address = event.user;
-            info!("Processing BalanceUnlocked event for user: {:?}", user_address);
-            
+            info!(
+                "Processing BalanceUnlocked event for user: {:?}",
+                user_address
+            );
+
             // Check if user has proofs in queue
             if self.user_has_proofs_in_queue(user_address).await {
-                info!("User {:?} has proofs in queue, verifying funds are still unlocked", user_address);
-                
+                info!(
+                    "User {:?} has proofs in queue, verifying funds are still unlocked",
+                    user_address
+                );
+
                 // Double-check that funds are still unlocked by calling the contract
                 if self.user_balance_is_unlocked(&user_address).await {
                     info!("User {:?} funds confirmed unlocked, removing proofs and resetting UserState", user_address);
                     self.remove_user_proofs_and_reset_state(user_address).await;
                 } else {
-                    info!("User {:?} funds are now locked, ignoring stale unlock event", user_address);
+                    info!(
+                        "User {:?} funds are now locked, ignoring stale unlock event",
+                        user_address
+                    );
                 }
             } else {
-                info!("User {:?} has no proofs in queue, ignoring event", user_address);
+                info!(
+                    "User {:?} has no proofs in queue, ignoring event",
+                    user_address
+                );
             }
         }
 
@@ -591,7 +617,12 @@ impl Batcher {
     /// Queries BalanceUnlocked events from the BatcherPaymentService contract.
     /// Retries on recoverable errors using exponential backoff up to `ETHEREUM_CALL_MAX_RETRIES` times:
     /// (0,5 secs - 1 secs - 2 secs - 4 secs - 8 secs).
-    async fn query_balance_unlocked_events(&self, from_block: U64, to_block: U64) -> Result<Vec<aligned_sdk::eth::batcher_payment_service::BalanceUnlockedFilter>, BatcherError> {
+    async fn query_balance_unlocked_events(
+        &self,
+        from_block: U64,
+        to_block: U64,
+    ) -> Result<Vec<aligned_sdk::eth::batcher_payment_service::BalanceUnlockedFilter>, BatcherError>
+    {
         retry_function(
             || {
                 query_balance_unlocked_events_retryable(
@@ -616,7 +647,10 @@ impl Batcher {
     async fn user_has_proofs_in_queue(&self, user_address: Address) -> bool {
         let user_states = self.user_states.read().await;
         if let Some(user_state) = user_states.get(&user_address) {
-            if let Some(user_state_guard) = self.try_user_lock_with_timeout(user_address, user_state.lock()).await {
+            if let Some(user_state_guard) = self
+                .try_user_lock_with_timeout(user_address, user_state.lock())
+                .await
+            {
                 user_state_guard.proofs_in_batch > 0
             } else {
                 false
@@ -629,20 +663,28 @@ impl Batcher {
     async fn remove_user_proofs_and_reset_state(&self, user_address: Address) {
         // Follow locking rules: acquire user_states before batch_state to avoid deadlocks
         let user_states = self.user_states.write().await;
-        
+
         // Use timeout for batch lock
-        let batch_state_guard = match self.try_batch_lock_with_timeout(self.batch_state.lock()).await {
+        let batch_state_guard = match self
+            .try_batch_lock_with_timeout(self.batch_state.lock())
+            .await
+        {
             Some(guard) => guard,
             None => {
-                warn!("Failed to acquire batch lock for user {:?}, skipping removal", user_address);
+                warn!(
+                    "Failed to acquire batch lock for user {:?}, skipping removal",
+                    user_address
+                );
                 return;
             }
         };
-        
+
         let mut batch_state_guard = batch_state_guard;
-        
+
         // Process all entries for this user
-        while let Some(entry) = batch_state_guard.batch_queue.iter()
+        while let Some(entry) = batch_state_guard
+            .batch_queue
+            .iter()
             .find(|(entry, _)| entry.sender == user_address)
             .map(|(entry, _)| entry.clone())
         {
@@ -651,12 +693,16 @@ impl Batcher {
                 send_message(
                     ws_sink.clone(),
                     SubmitProofResponseMessage::UserFundsUnlocked,
-                ).await;
+                )
+                .await;
 
                 // Close websocket connection
                 let mut sink_guard = ws_sink.write().await;
                 if let Err(e) = sink_guard.close().await {
-                    warn!("Error closing websocket for user {:?}: {:?}", user_address, e);
+                    warn!(
+                        "Error closing websocket for user {:?}: {:?}",
+                        user_address, e
+                    );
                 } else {
                     info!("Closed websocket connection for user {:?}", user_address);
                 }
@@ -664,19 +710,29 @@ impl Batcher {
 
             // Remove the entry from batch queue
             batch_state_guard.batch_queue.remove(&entry);
-            info!("Removed proof with nonce {} for user {:?} from batch queue", entry.nonced_verification_data.nonce, user_address);
+            info!(
+                "Removed proof with nonce {} for user {:?} from batch queue",
+                entry.nonced_verification_data.nonce, user_address
+            );
         }
 
         // Reset UserState using timeout
         if let Some(user_state) = user_states.get(&user_address) {
-            if let Some(mut user_state_guard) = self.try_user_lock_with_timeout(user_address, user_state.lock()).await {
-                user_state_guard.nonce -= U256::from(user_state_guard.proofs_in_batch);
+            if let Some(mut user_state_guard) = self
+                .try_user_lock_with_timeout(user_address, user_state.lock())
+                .await
+            {
+                let proofs_count = user_state_guard.proofs_in_batch;
+                user_state_guard.nonce -= U256::from(proofs_count);
                 user_state_guard.proofs_in_batch = 0;
                 user_state_guard.total_fees_in_queue = U256::zero();
                 user_state_guard.last_max_fee_limit = U256::max_value();
                 info!("Reset UserState for user {:?}", user_address);
             } else {
-                warn!("Failed to acquire user lock for {:?}, skipping UserState reset", user_address);
+                warn!(
+                    "Failed to acquire user lock for {:?}, skipping UserState reset",
+                    user_address
+                );
             }
         }
     }

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -688,16 +688,6 @@ impl Batcher {
                         SubmitProofResponseMessage::UserFundsUnlocked,
                     )
                     .await;
-                    // Close websocket connection
-                    let mut sink_guard = ws_sink_clone.write().await;
-                    if let Err(e) = sink_guard.close().await {
-                        warn!(
-                            "Error closing websocket for user {:?}: {:?}",
-                            user_address, e
-                        );
-                    } else {
-                        info!("Closed websocket connection for user {:?}", user_address);
-                    }
                 });
             }
             info!(

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -669,28 +669,31 @@ impl Batcher {
             }
         };
 
-        let removed_entries = batch_state_guard
+        let removed_entries: Vec<_> = batch_state_guard
             .batch_queue
-            .extract_if(|entry, _| entry.sender == user_address);
+            .extract_if(|entry, _| entry.sender == user_address)
+            .collect();
 
         // Notify user via websocket before removing the proofs
         for (entry, _) in removed_entries {
-            if let Some(ws_sink) = entry.messaging_sink.as_ref() {
-                send_message(
-                    ws_sink.clone(),
-                    SubmitProofResponseMessage::UserFundsUnlocked,
-                )
-                .await;
-                // Close websocket connection
-                let mut sink_guard = ws_sink.write().await;
-                if let Err(e) = sink_guard.close().await {
-                    warn!(
-                        "Error closing websocket for user {:?}: {:?}",
-                        user_address, e
-                    );
-                } else {
-                    info!("Closed websocket connection for user {:?}", user_address);
-                }
+            if let Some(ws_sink) = entry.messaging_sink {
+                tokio::spawn(async move {
+                    send_message(
+                        ws_sink.clone(),
+                        SubmitProofResponseMessage::UserFundsUnlocked,
+                    )
+                    .await;
+                    // Close websocket connection
+                    let mut sink_guard = ws_sink.write().await;
+                    if let Err(e) = sink_guard.close().await {
+                        warn!(
+                            "Error closing websocket for user {:?}: {:?}",
+                            user_address, e
+                        );
+                    } else {
+                        info!("Closed websocket connection for user {:?}", user_address);
+                    }
+                });
             }
             info!(
                 "Removed proof with nonce {} for user {:?} from batch queue",

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -504,21 +504,32 @@ impl Batcher {
     /// Runs at configurable intervals and checks recent blocks for events (2x the polling interval).
     /// When an event is detected, removes user's proofs from queue and resets UserState.
     pub async fn poll_balance_unlocked_events(self: Arc<Self>) -> Result<(), BatcherError> {
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(
+        let mut interval = tokio::time::interval(Duration::from_secs(
             self.balance_unlock_polling_interval_seconds,
         ));
+        let mut from_block = self.get_current_block_number().await.map_err(|e| {
+            BatcherError::EthereumProviderError(format!(
+                "Failed to get current block number: {:?}",
+                e
+            ))
+        })?;
 
         loop {
             interval.tick().await;
 
-            if let Err(e) = self.process_balance_unlocked_events().await {
-                error!("Error processing BalanceUnlocked events: {:?}", e);
-                // Continue polling even if there's an error
+            match self.process_balance_unlocked_events(from_block).await {
+                Ok(current_block) => {
+                    from_block = current_block;
+                }
+                Err(e) => {
+                    error!("Error processing BalanceUnlocked events: {:?}", e);
+                    // On error, keep from_block unchanged to retry the same range next time
+                }
             }
         }
     }
 
-    async fn process_balance_unlocked_events(&self) -> Result<(), BatcherError> {
+    async fn process_balance_unlocked_events(&self, from_block: U64) -> Result<U64, BatcherError> {
         // Get current block number using HTTP providers
         let current_block = self.get_current_block_number().await.map_err(|e| {
             BatcherError::EthereumProviderError(format!(
@@ -526,11 +537,6 @@ impl Batcher {
                 e
             ))
         })?;
-
-        // Calculate the block range based on polling interval
-        // Formula: interval / 12 * 2 (assuming 12-second block times, look back 2x the interval)
-        let block_range = (self.balance_unlock_polling_interval_seconds / 12) * 2;
-        let from_block = current_block.saturating_sub(U64::from(block_range));
 
         // Query events with retry logic
         let events = self
@@ -574,7 +580,7 @@ impl Batcher {
             }
         }
 
-        Ok(())
+        Ok(current_block)
     }
 
     /// Gets the current block number from Ethereum.

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -520,8 +520,12 @@ impl Batcher {
 
     async fn process_balance_unlocked_events(&self) -> Result<(), BatcherError> {
         // Get current block number using HTTP providers
-        let current_block = self.get_current_block_number().await
-            .map_err(|e| BatcherError::EthereumProviderError(format!("Failed to get current block number: {:?}", e)))?;
+        let current_block = self.get_current_block_number().await.map_err(|e| {
+            BatcherError::EthereumProviderError(format!(
+                "Failed to get current block number: {:?}",
+                e
+            ))
+        })?;
 
         // Calculate the block range based on polling interval
         // Formula: interval / 12 * 2 (assuming 12-second block times, look back 2x the interval)
@@ -532,7 +536,12 @@ impl Batcher {
         let events = self
             .query_balance_unlocked_events(from_block, current_block)
             .await
-            .map_err(|e| BatcherError::EthereumProviderError(format!("Failed to query BalanceUnlocked events: {:?}", e)))?;
+            .map_err(|e| {
+                BatcherError::EthereumProviderError(format!(
+                    "Failed to query BalanceUnlocked events: {:?}",
+                    e
+                ))
+            })?;
 
         info!(
             "Found {} BalanceUnlocked events in blocks {} to {}",

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -570,10 +570,15 @@ impl Batcher {
             );
 
             // Check if user has proofs in queue
+            //
             // Double-check that funds are still unlocked by calling the contract
             // This is necessary because we query events over a block range, and the
             // user’s state may have changed (e.g., funds could be locked again) after
             // the event was emitted. Verifying on-chain ensures we don’t act on stale data.
+            //
+            // There is a brief period between the checks and the removal during which the user's
+            // proofs could be sent. This is acceptable, as the removal will not fail;
+            // it will simply clear the user's state.
             if self.user_has_proofs_in_queue(user_address).await
                 && self.user_balance_is_unlocked(&user_address).await
             {

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -598,42 +598,31 @@ impl Batcher {
         };
         
         let mut batch_state_guard = batch_state_guard;
-        let mut proofs_to_remove = Vec::new();
-        let mut websocket_sinks = Vec::new();
         
-        // Collect all entries for this user and their websocket connections
-        for (entry, _) in batch_state_guard.batch_queue.iter() {
-            if entry.sender == user_address {
-                // Store websocket sink before removing the entry
-                if let Some(ws_sink) = entry.messaging_sink.as_ref() {
-                    websocket_sinks.push(ws_sink.clone());
+        // Process all entries for this user directly
+        while let Some(entry) = batch_state_guard.batch_queue.iter()
+            .find(|(entry, _)| entry.sender == user_address)
+            .map(|(entry, _)| entry.clone())
+        {
+            // Notify user via websocket before removing the proof
+            if let Some(ws_sink) = entry.messaging_sink.as_ref() {
+                send_message(
+                    ws_sink.clone(),
+                    SubmitProofResponseMessage::UserFundsUnlocked,
+                ).await;
+
+                // Close websocket connection
+                let mut sink_guard = ws_sink.write().await;
+                if let Err(e) = sink_guard.close().await {
+                    warn!("Error closing websocket for user {:?}: {:?}", user_address, e);
+                } else {
+                    info!("Closed websocket connection for user {:?}", user_address);
                 }
-                proofs_to_remove.push(entry.clone());
             }
-        }
 
-        // Notify users via websocket before removing their proofs
-        for ws_sink in &websocket_sinks {
-            send_message(
-                ws_sink.clone(),
-                aligned_sdk::common::types::SubmitProofResponseMessage::UserFundsUnlocked,
-            ).await;
-        }
-
-        // Remove collected entries
-        for entry in proofs_to_remove {
+            // Remove the entry from batch queue
             batch_state_guard.batch_queue.remove(&entry);
-            info!("Removed proof for user {:?} from batch queue", user_address);
-        }
-
-        // Close websocket connections
-        for ws_sink in websocket_sinks {
-            let mut sink_guard = ws_sink.write().await;
-            if let Err(e) = sink_guard.close().await {
-                warn!("Error closing websocket for user {:?}: {:?}", user_address, e);
-            } else {
-                info!("Closed websocket connection for user {:?}", user_address);
-            }
+            info!("Removed proof with nonce {} for user {:?} from batch queue", entry.nonced_verification_data.nonce, user_address);
         }
 
         // Reset UserState using timeout

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -39,8 +39,8 @@ use aligned_sdk::common::types::{
 
 use aws_sdk_s3::client::Client as S3Client;
 use eth::payment_service::{BatcherPaymentService, CreateNewTaskFeeParams, SignerMiddlewareT};
-use ethers::prelude::{Middleware, Provider};
-use ethers::types::{Address, Signature, TransactionReceipt, U256};
+use ethers::prelude::{Middleware, Provider, Http};
+use ethers::types::{Address, Signature, TransactionReceipt, U256, U64};
 use futures_util::{future, join, SinkExt, StreamExt, TryStreamExt};
 use lambdaworks_crypto::merkle_tree::merkle::MerkleTree;
 use lambdaworks_crypto::merkle_tree::traits::IsMerkleTreeBackend;
@@ -86,6 +86,8 @@ pub struct Batcher {
     eth_ws_url_fallback: String,
     batcher_signer: Arc<SignerMiddlewareT>,
     batcher_signer_fallback: Arc<SignerMiddlewareT>,
+    eth_http_provider: Provider<Http>,
+    eth_http_provider_fallback: Provider<Http>,
     chain_id: U256,
     payment_service: BatcherPaymentService,
     payment_service_fallback: BatcherPaymentService,
@@ -315,6 +317,8 @@ impl Batcher {
             eth_ws_url_fallback: config.eth_ws_url_fallback,
             batcher_signer,
             batcher_signer_fallback,
+            eth_http_provider,
+            eth_http_provider_fallback,
             chain_id,
             payment_service,
             payment_service_fallback,
@@ -489,6 +493,160 @@ impl Batcher {
         )
         .await
         .map_err(|e| e.inner())
+    }
+
+    /// Poll for BalanceUnlocked events from BatcherPaymentService contract.
+    /// Runs every 10 minutes and checks the last 100 blocks for events.
+    /// When an event is detected, removes user's proofs from queue and resets UserState.
+    pub async fn poll_balance_unlocked_events(self: Arc<Self>) -> Result<(), BatcherError> {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(20)); // 10 minutes
+        
+        loop {
+            interval.tick().await;
+            
+            if let Err(e) = self.process_balance_unlocked_events().await {
+                error!("Error processing BalanceUnlocked events: {:?}", e);
+                // Continue polling even if there's an error
+            }
+        }
+    }
+
+    async fn process_balance_unlocked_events(&self) -> Result<(), BatcherError> {
+        // Get current block number using HTTP providers
+        let current_block = match self.get_current_block_number().await {
+            Ok(block) => block,
+            Err(e) => {
+                warn!("Failed to get current block number: {:?}", e);
+                return Ok(());
+            }
+        };
+
+        // Calculate the block range (last 100 blocks)
+        let from_block = current_block.saturating_sub(U64::from(100));
+        
+        // Create filter for BalanceUnlocked events
+        let filter = self.payment_service
+            .balance_unlocked_filter()
+            .from_block(from_block)
+            .to_block(current_block);
+
+        // Query events
+        let events = match filter.query().await {
+            Ok(events) => events,
+            Err(e) => {
+                warn!("Failed to query BalanceUnlocked events: {:?}", e);
+                return Ok(());
+            }
+        };
+
+        info!("Found {} BalanceUnlocked events in blocks {} to {}", 
+              events.len(), from_block, current_block);
+
+        // Process each event
+        for event in events {
+            let user_address = event.user;
+            info!("Processing BalanceUnlocked event for user: {:?}", user_address);
+            
+            // Check if user has proofs in queue
+            if self.user_has_proofs_in_queue(user_address).await {
+                info!("User {:?} has proofs in queue, removing them and resetting UserState", user_address);
+                self.remove_user_proofs_and_reset_state(user_address).await;
+            } else {
+                info!("User {:?} has no proofs in queue, ignoring event", user_address);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get_current_block_number(&self) -> Result<U64, BatcherError> {
+        // Try primary provider first
+        match self.eth_http_provider.get_block_number().await {
+            Ok(block) => Ok(block),
+            Err(_) => {
+                // Fallback to secondary provider
+                self.eth_http_provider_fallback.get_block_number().await
+                    .map_err(|e| BatcherError::EthereumProviderError(e.to_string()))
+            }
+        }
+    }
+
+    async fn user_has_proofs_in_queue(&self, user_address: Address) -> bool {
+        let user_states = self.user_states.read().await;
+        if let Some(user_state) = user_states.get(&user_address) {
+            if let Some(user_state_guard) = self.try_user_lock_with_timeout(user_address, user_state.lock()).await {
+                user_state_guard.proofs_in_batch > 0
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    async fn remove_user_proofs_and_reset_state(&self, user_address: Address) {
+        // Follow locking rules: acquire user_states before batch_state to avoid deadlocks
+        let user_states = self.user_states.write().await;
+        
+        // Use timeout for batch lock
+        let batch_state_guard = match self.try_batch_lock_with_timeout(self.batch_state.lock()).await {
+            Some(guard) => guard,
+            None => {
+                warn!("Failed to acquire batch lock for user {:?}, skipping removal", user_address);
+                return;
+            }
+        };
+        
+        let mut batch_state_guard = batch_state_guard;
+        let mut proofs_to_remove = Vec::new();
+        let mut websocket_sinks = Vec::new();
+        
+        // Collect all entries for this user and their websocket connections
+        for (entry, _) in batch_state_guard.batch_queue.iter() {
+            if entry.sender == user_address {
+                // Store websocket sink before removing the entry
+                if let Some(ws_sink) = entry.messaging_sink.as_ref() {
+                    websocket_sinks.push(ws_sink.clone());
+                }
+                proofs_to_remove.push(entry.clone());
+            }
+        }
+
+        // Notify users via websocket before removing their proofs
+        for ws_sink in &websocket_sinks {
+            send_message(
+                ws_sink.clone(),
+                aligned_sdk::common::types::SubmitProofResponseMessage::UserFundsUnlocked,
+            ).await;
+        }
+
+        // Remove collected entries
+        for entry in proofs_to_remove {
+            batch_state_guard.batch_queue.remove(&entry);
+            info!("Removed proof for user {:?} from batch queue", user_address);
+        }
+
+        // Close websocket connections
+        for ws_sink in websocket_sinks {
+            let mut sink_guard = ws_sink.write().await;
+            if let Err(e) = sink_guard.close().await {
+                warn!("Error closing websocket for user {:?}: {:?}", user_address, e);
+            } else {
+                info!("Closed websocket connection for user {:?}", user_address);
+            }
+        }
+
+        // Reset UserState using timeout
+        if let Some(user_state) = user_states.get(&user_address) {
+            if let Some(mut user_state_guard) = self.try_user_lock_with_timeout(user_address, user_state.lock()).await {
+                user_state_guard.proofs_in_batch = 0;
+                user_state_guard.total_fees_in_queue = U256::zero();
+                user_state_guard.last_max_fee_limit = U256::max_value();
+                info!("Reset UserState for user {:?}", user_address);
+            } else {
+                warn!("Failed to acquire user lock for {:?}, skipping UserState reset", user_address);
+            }
+        }
     }
 
     pub async fn listen_new_blocks_retryable(

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -637,18 +637,18 @@ impl Batcher {
 
     async fn user_has_proofs_in_queue(&self, user_address: Address) -> bool {
         let user_states = self.user_states.read().await;
-        if let Some(user_state) = user_states.get(&user_address) {
-            if let Some(user_state_guard) = self
-                .try_user_lock_with_timeout(user_address, user_state.lock())
-                .await
-            {
-                user_state_guard.proofs_in_batch > 0
-            } else {
-                false
-            }
-        } else {
-            false
-        }
+        let Some(user_state) = user_states.get(&user_address) else {
+            return false;
+        };
+
+        let Some(user_state_guard) = self
+            .try_user_lock_with_timeout(user_address, user_state.lock())
+            .await
+        else {
+            return false;
+        };
+
+        user_state_guard.proofs_in_batch > 0
     }
 
     async fn remove_user_proofs_and_reset_state(&self, user_address: Address) {

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -2029,14 +2029,16 @@ impl Batcher {
                 warn!("Failed to send task status to telemetry: {:?}", e);
             }
 
-            // decide if i want to flush the queue:
             match e {
+                // This should never happen, there is a task that regularly cleans up
+                // user proofs with unlocked states 
+                // (and it runs more frequently than the 1H the user needs to withdraw funds)
                 BatcherError::TransactionSendError(
                     TransactionSendError::SubmissionInsufficientBalance(address),
                 ) => {
+                    // In the future we could do a more granular recovery
                     warn!("User {:?} has insufficient balance, flushing entire queue as safety measure", address);
-                    // TODO: In the future, we should re-add the failed batch back to the queue
-                    // For now, we flush everything as a safety measure
+
                     self.flush_queue_and_clear_nonce_cache().await;
                 }
                 _ => {

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -51,6 +51,7 @@ use tokio::sync::{Mutex, MutexGuard, RwLock};
 
 // Message handler lock timeout
 const MESSAGE_HANDLER_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+const POLLING_EVENTS_LOCK_TIMEOUT: Duration = Duration::from_secs(300);
 use tokio_tungstenite::tungstenite::{Error, Message};
 use types::batch_queue::{self, BatchQueueEntry, BatchQueueEntryPriority};
 use types::errors::{BatcherError, TransactionSendError};
@@ -445,12 +446,16 @@ impl Batcher {
         }
     }
 
-    /// Helper to apply 15-second timeout to batch lock acquisition with consistent logging and metrics
-    async fn try_batch_lock_with_timeout<F, T>(&self, lock_future: F) -> Option<T>
+    /// Helper to apply `duration` timeout to batch lock acquisition with consistent logging and metrics
+    async fn try_batch_lock_with_timeout<F, T>(
+        &self,
+        lock_future: F,
+        duration: Duration,
+    ) -> Option<T>
     where
         F: std::future::Future<Output = T>,
     {
-        match timeout(MESSAGE_HANDLER_LOCK_TIMEOUT, lock_future).await {
+        match timeout(duration, lock_future).await {
             Ok(result) => Some(result),
             Err(_) => {
                 warn!("Batch lock acquisition timed out");
@@ -647,17 +652,19 @@ impl Batcher {
     }
 
     async fn remove_user_proofs_and_reset_state(&self, user_address: Address) {
-        // Use timeout for batch lock
+        let mut user_states = self.user_states.write().await;
+
         let mut batch_state_guard = match self
-            .try_batch_lock_with_timeout(self.batch_state.lock())
+            .try_batch_lock_with_timeout(self.batch_state.lock(), POLLING_EVENTS_LOCK_TIMEOUT)
             .await
         {
             Some(guard) => guard,
             None => {
-                warn!(
-                    "Failed to acquire batch lock for user {:?}, skipping removal",
+                error!(
+                    "Failed to acquire batch lock when trying to remove proofs from user {:?}, skipping removal",
                     user_address
                 );
+                // TODO metrics for batch lock timeout during event processing
                 return;
             }
         };
@@ -691,8 +698,7 @@ impl Batcher {
             );
         }
 
-        // Remove UserState entry
-        self.user_states.write().await.remove(&user_address);
+        user_states.remove(&user_address);
         info!(
             "Removed UserState entry for user {:?} after processing BalanceUnlocked event",
             user_address
@@ -1260,7 +1266,7 @@ impl Batcher {
         // * ---------------------------------------------------------------------*
 
         let Some(mut batch_state_lock) = self
-            .try_batch_lock_with_timeout(self.batch_state.lock())
+            .try_batch_lock_with_timeout(self.batch_state.lock(), MESSAGE_HANDLER_LOCK_TIMEOUT)
             .await
         else {
             send_message(ws_conn_sink.clone(), SubmitProofResponseMessage::ServerBusy).await;
@@ -1430,7 +1436,7 @@ impl Batcher {
         let replacement_max_fee = nonced_verification_data.max_fee;
         let nonce = nonced_verification_data.nonce;
         let Some(mut batch_state_guard) = self
-            .try_batch_lock_with_timeout(self.batch_state.lock())
+            .try_batch_lock_with_timeout(self.batch_state.lock(), MESSAGE_HANDLER_LOCK_TIMEOUT)
             .await
         else {
             drop(user_state_guard);

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -9,7 +9,8 @@ use ethers::signers::Signer;
 use retry::batcher_retryables::{
     cancel_create_new_task_retryable, create_new_task_retryable, get_user_balance_retryable,
     get_user_nonce_from_ethereum_retryable, simulate_create_new_task_retryable,
-    user_balance_is_unlocked_retryable,
+    user_balance_is_unlocked_retryable, get_current_block_number_retryable,
+    query_balance_unlocked_events_retryable,
 };
 use retry::{retry_function, RetryError};
 use tokio::time::{timeout, Instant};
@@ -528,17 +529,11 @@ impl Batcher {
         let block_range = (self.balance_unlock_polling_interval_seconds / 12) * 2;
         let from_block = current_block.saturating_sub(U64::from(block_range));
         
-        // Create filter for BalanceUnlocked events
-        let filter = self.payment_service
-            .balance_unlocked_filter()
-            .from_block(from_block)
-            .to_block(current_block);
-
-        // Query events
-        let events = match filter.query().await {
+        // Query events with retry logic
+        let events = match self.query_balance_unlocked_events(from_block, current_block).await {
             Ok(events) => events,
             Err(e) => {
-                warn!("Failed to query BalanceUnlocked events: {:?}", e);
+                warn!("Failed to query BalanceUnlocked events after retries: {:?}", e);
                 return Ok(());
             }
         };
@@ -553,8 +548,15 @@ impl Batcher {
             
             // Check if user has proofs in queue
             if self.user_has_proofs_in_queue(user_address).await {
-                info!("User {:?} has proofs in queue, removing them and resetting UserState", user_address);
-                self.remove_user_proofs_and_reset_state(user_address).await;
+                info!("User {:?} has proofs in queue, verifying funds are still unlocked", user_address);
+                
+                // Double-check that funds are still unlocked by calling the contract
+                if self.user_balance_is_unlocked(&user_address).await {
+                    info!("User {:?} funds confirmed unlocked, removing proofs and resetting UserState", user_address);
+                    self.remove_user_proofs_and_reset_state(user_address).await;
+                } else {
+                    info!("User {:?} funds are now locked, ignoring stale unlock event", user_address);
+                }
             } else {
                 info!("User {:?} has no proofs in queue, ignoring event", user_address);
             }
@@ -563,16 +565,52 @@ impl Batcher {
         Ok(())
     }
 
+    /// Gets the current block number from Ethereum.
+    /// Retries on recoverable errors using exponential backoff up to `ETHEREUM_CALL_MAX_RETRIES` times:
+    /// (0,5 secs - 1 secs - 2 secs - 4 secs - 8 secs).
     async fn get_current_block_number(&self) -> Result<U64, BatcherError> {
-        // Try primary provider first
-        match self.eth_http_provider.get_block_number().await {
-            Ok(block) => Ok(block),
-            Err(_) => {
-                // Fallback to secondary provider
-                self.eth_http_provider_fallback.get_block_number().await
-                    .map_err(|e| BatcherError::EthereumProviderError(e.to_string()))
-            }
-        }
+        retry_function(
+            || {
+                get_current_block_number_retryable(
+                    &self.eth_http_provider,
+                    &self.eth_http_provider_fallback,
+                )
+            },
+            ETHEREUM_CALL_MIN_RETRY_DELAY,
+            ETHEREUM_CALL_BACKOFF_FACTOR,
+            ETHEREUM_CALL_MAX_RETRIES,
+            ETHEREUM_CALL_MAX_RETRY_DELAY,
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to get current block number: {:?}", e);
+            BatcherError::EthereumProviderError(e.inner())
+        })
+    }
+
+    /// Queries BalanceUnlocked events from the BatcherPaymentService contract.
+    /// Retries on recoverable errors using exponential backoff up to `ETHEREUM_CALL_MAX_RETRIES` times:
+    /// (0,5 secs - 1 secs - 2 secs - 4 secs - 8 secs).
+    async fn query_balance_unlocked_events(&self, from_block: U64, to_block: U64) -> Result<Vec<aligned_sdk::eth::batcher_payment_service::BalanceUnlockedFilter>, BatcherError> {
+        retry_function(
+            || {
+                query_balance_unlocked_events_retryable(
+                    &self.payment_service,
+                    &self.payment_service_fallback,
+                    from_block,
+                    to_block,
+                )
+            },
+            ETHEREUM_CALL_MIN_RETRY_DELAY,
+            ETHEREUM_CALL_BACKOFF_FACTOR,
+            ETHEREUM_CALL_MAX_RETRIES,
+            ETHEREUM_CALL_MAX_RETRY_DELAY,
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to query BalanceUnlocked events: {:?}", e);
+            BatcherError::EthereumProviderError(e.inner())
+        })
     }
 
     async fn user_has_proofs_in_queue(&self, user_address: Address) -> bool {
@@ -632,6 +670,7 @@ impl Batcher {
         // Reset UserState using timeout
         if let Some(user_state) = user_states.get(&user_address) {
             if let Some(mut user_state_guard) = self.try_user_lock_with_timeout(user_address, user_state.lock()).await {
+                user_state_guard.nonce -= U256::from(user_state_guard.proofs_in_batch);
                 user_state_guard.proofs_in_batch = 0;
                 user_state_guard.total_fees_in_queue = U256::zero();
                 user_state_guard.last_max_fee_limit = U256::max_value();

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -664,7 +664,7 @@ impl Batcher {
                     "Failed to acquire batch lock when trying to remove proofs from user {:?}, skipping removal",
                     user_address
                 );
-                // TODO metrics for batch lock timeout during event processing
+                self.metrics.inc_unlocked_event_polling_batch_lock_timeout();
                 return;
             }
         };

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -105,6 +105,7 @@ pub struct Batcher {
     current_min_max_fee: RwLock<U256>,
     amount_of_proofs_for_min_max_fee: usize,
     min_bump_percentage: U256,
+    balance_unlock_polling_interval_seconds: u64,
 
     // Shared state access:
     // Two kinds of threads interact with the shared state:
@@ -331,6 +332,7 @@ impl Batcher {
             max_batch_proof_qty: config.batcher.max_batch_proof_qty,
             amount_of_proofs_for_min_max_fee: config.batcher.amount_of_proofs_for_min_max_fee,
             min_bump_percentage: U256::from(config.batcher.min_bump_percentage),
+            balance_unlock_polling_interval_seconds: config.batcher.balance_unlock_polling_interval_seconds,
             last_uploaded_batch_block: Mutex::new(last_uploaded_batch_block),
             pre_verification_is_enabled: config.batcher.pre_verification_is_enabled,
             non_paying_config,
@@ -496,10 +498,10 @@ impl Batcher {
     }
 
     /// Poll for BalanceUnlocked events from BatcherPaymentService contract.
-    /// Runs every 10 minutes and checks the last 100 blocks for events.
+    /// Runs at configurable intervals and checks recent blocks for events (2x the polling interval).
     /// When an event is detected, removes user's proofs from queue and resets UserState.
     pub async fn poll_balance_unlocked_events(self: Arc<Self>) -> Result<(), BatcherError> {
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(20)); // 10 minutes
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(self.balance_unlock_polling_interval_seconds));
         
         loop {
             interval.tick().await;
@@ -521,8 +523,10 @@ impl Batcher {
             }
         };
 
-        // Calculate the block range (last 100 blocks)
-        let from_block = current_block.saturating_sub(U64::from(100));
+        // Calculate the block range based on polling interval
+        // Formula: interval / 12 * 2 (assuming 12-second block times, look back 2x the interval)
+        let block_range = (self.balance_unlock_polling_interval_seconds / 12) * 2;
+        let from_block = current_block.saturating_sub(U64::from(block_range));
         
         // Create filter for BalanceUnlocked events
         let filter = self.payment_service

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -2031,7 +2031,7 @@ impl Batcher {
 
             match e {
                 // This should never happen, there is a task that regularly cleans up
-                // user proofs with unlocked states 
+                // user proofs with unlocked states
                 // (and it runs more frequently than the 1H the user needs to withdraw funds)
                 BatcherError::TransactionSendError(
                     TransactionSendError::SubmissionInsufficientBalance(address),

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -669,22 +669,22 @@ impl Batcher {
             }
         };
 
-        let removed_entries: Vec<_> = batch_state_guard
+        let removed_entries = batch_state_guard
             .batch_queue
-            .extract_if(|entry, _| entry.sender == user_address)
-            .collect();
+            .extract_if(|entry, _| entry.sender == user_address);
 
         // Notify user via websocket before removing the proofs
         for (entry, _) in removed_entries {
             if let Some(ws_sink) = entry.messaging_sink {
+                let ws_sink_clone = ws_sink.clone();
                 tokio::spawn(async move {
                     send_message(
-                        ws_sink.clone(),
+                        ws_sink_clone.clone(),
                         SubmitProofResponseMessage::UserFundsUnlocked,
                     )
                     .await;
                     // Close websocket connection
-                    let mut sink_guard = ws_sink.write().await;
+                    let mut sink_guard = ws_sink_clone.write().await;
                     if let Err(e) = sink_guard.close().await {
                         warn!(
                             "Error closing websocket for user {:?}: {:?}",

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -599,7 +599,7 @@ impl Batcher {
         
         let mut batch_state_guard = batch_state_guard;
         
-        // Process all entries for this user directly
+        // Process all entries for this user
         while let Some(entry) = batch_state_guard.batch_queue.iter()
             .find(|(entry, _)| entry.sender == user_address)
             .map(|(entry, _)| entry.clone())

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -520,13 +520,8 @@ impl Batcher {
 
     async fn process_balance_unlocked_events(&self) -> Result<(), BatcherError> {
         // Get current block number using HTTP providers
-        let current_block = match self.get_current_block_number().await {
-            Ok(block) => block,
-            Err(e) => {
-                warn!("Failed to get current block number: {:?}", e);
-                return Ok(());
-            }
-        };
+        let current_block = self.get_current_block_number().await
+            .map_err(|e| BatcherError::EthereumProviderError(format!("Failed to get current block number: {:?}", e)))?;
 
         // Calculate the block range based on polling interval
         // Formula: interval / 12 * 2 (assuming 12-second block times, look back 2x the interval)
@@ -534,19 +529,10 @@ impl Batcher {
         let from_block = current_block.saturating_sub(U64::from(block_range));
 
         // Query events with retry logic
-        let events = match self
+        let events = self
             .query_balance_unlocked_events(from_block, current_block)
             .await
-        {
-            Ok(events) => events,
-            Err(e) => {
-                warn!(
-                    "Failed to query BalanceUnlocked events after retries: {:?}",
-                    e
-                );
-                return Ok(());
-            }
-        };
+            .map_err(|e| BatcherError::EthereumProviderError(format!("Failed to query BalanceUnlocked events: {:?}", e)))?;
 
         info!(
             "Found {} BalanceUnlocked events in blocks {} to {}",
@@ -558,33 +544,24 @@ impl Batcher {
         // Process each event
         for event in events {
             let user_address = event.user;
-            info!(
+            debug!(
                 "Processing BalanceUnlocked event for user: {:?}",
                 user_address
             );
 
             // Check if user has proofs in queue
-            if self.user_has_proofs_in_queue(user_address).await {
+            // Double-check that funds are still unlocked by calling the contract
+            // This is necessary because we query events over a block range, and the
+            // user’s state may have changed (e.g., funds could be locked again) after
+            // the event was emitted. Verifying on-chain ensures we don’t act on stale data.
+            if self.user_has_proofs_in_queue(user_address).await
+                && self.user_balance_is_unlocked(&user_address).await
+            {
                 info!(
-                    "User {:?} has proofs in queue, verifying funds are still unlocked",
+                    "User {:?} has proofs in queue and funds are unlocked, proceeding to remove proofs and resetting UserState",
                     user_address
                 );
-
-                // Double-check that funds are still unlocked by calling the contract
-                if self.user_balance_is_unlocked(&user_address).await {
-                    info!("User {:?} funds confirmed unlocked, removing proofs and resetting UserState", user_address);
-                    self.remove_user_proofs_and_reset_state(user_address).await;
-                } else {
-                    info!(
-                        "User {:?} funds are now locked, ignoring stale unlock event",
-                        user_address
-                    );
-                }
-            } else {
-                info!(
-                    "User {:?} has no proofs in queue, ignoring event",
-                    user_address
-                );
+                self.remove_user_proofs_and_reset_state(user_address).await;
             }
         }
 
@@ -594,7 +571,7 @@ impl Batcher {
     /// Gets the current block number from Ethereum.
     /// Retries on recoverable errors using exponential backoff up to `ETHEREUM_CALL_MAX_RETRIES` times:
     /// (0,5 secs - 1 secs - 2 secs - 4 secs - 8 secs).
-    async fn get_current_block_number(&self) -> Result<U64, BatcherError> {
+    async fn get_current_block_number(&self) -> Result<U64, RetryError<String>> {
         retry_function(
             || {
                 get_current_block_number_retryable(
@@ -608,10 +585,6 @@ impl Batcher {
             ETHEREUM_CALL_MAX_RETRY_DELAY,
         )
         .await
-        .map_err(|e| {
-            error!("Failed to get current block number: {:?}", e);
-            BatcherError::EthereumProviderError(e.inner())
-        })
     }
 
     /// Queries BalanceUnlocked events from the BatcherPaymentService contract.
@@ -621,8 +594,10 @@ impl Batcher {
         &self,
         from_block: U64,
         to_block: U64,
-    ) -> Result<Vec<aligned_sdk::eth::batcher_payment_service::BalanceUnlockedFilter>, BatcherError>
-    {
+    ) -> Result<
+        Vec<aligned_sdk::eth::batcher_payment_service::BalanceUnlockedFilter>,
+        RetryError<String>,
+    > {
         retry_function(
             || {
                 query_balance_unlocked_events_retryable(
@@ -638,10 +613,6 @@ impl Batcher {
             ETHEREUM_CALL_MAX_RETRY_DELAY,
         )
         .await
-        .map_err(|e| {
-            error!("Failed to query BalanceUnlocked events: {:?}", e);
-            BatcherError::EthereumProviderError(e.inner())
-        })
     }
 
     async fn user_has_proofs_in_queue(&self, user_address: Address) -> bool {
@@ -661,11 +632,8 @@ impl Batcher {
     }
 
     async fn remove_user_proofs_and_reset_state(&self, user_address: Address) {
-        // Follow locking rules: acquire user_states before batch_state to avoid deadlocks
-        let user_states = self.user_states.write().await;
-
         // Use timeout for batch lock
-        let batch_state_guard = match self
+        let mut batch_state_guard = match self
             .try_batch_lock_with_timeout(self.batch_state.lock())
             .await
         {
@@ -679,23 +647,18 @@ impl Batcher {
             }
         };
 
-        let mut batch_state_guard = batch_state_guard;
-
-        // Process all entries for this user
-        while let Some(entry) = batch_state_guard
+        let removed_entries = batch_state_guard
             .batch_queue
-            .iter()
-            .find(|(entry, _)| entry.sender == user_address)
-            .map(|(entry, _)| entry.clone())
-        {
-            // Notify user via websocket before removing the proof
+            .extract_if(|entry, _| entry.sender == user_address);
+
+        // Notify user via websocket before removing the proofs
+        for (entry, _) in removed_entries {
             if let Some(ws_sink) = entry.messaging_sink.as_ref() {
                 send_message(
                     ws_sink.clone(),
                     SubmitProofResponseMessage::UserFundsUnlocked,
                 )
                 .await;
-
                 // Close websocket connection
                 let mut sink_guard = ws_sink.write().await;
                 if let Err(e) = sink_guard.close().await {
@@ -707,34 +670,18 @@ impl Batcher {
                     info!("Closed websocket connection for user {:?}", user_address);
                 }
             }
-
-            // Remove the entry from batch queue
-            batch_state_guard.batch_queue.remove(&entry);
             info!(
                 "Removed proof with nonce {} for user {:?} from batch queue",
                 entry.nonced_verification_data.nonce, user_address
             );
         }
 
-        // Reset UserState using timeout
-        if let Some(user_state) = user_states.get(&user_address) {
-            if let Some(mut user_state_guard) = self
-                .try_user_lock_with_timeout(user_address, user_state.lock())
-                .await
-            {
-                let proofs_count = user_state_guard.proofs_in_batch;
-                user_state_guard.nonce -= U256::from(proofs_count);
-                user_state_guard.proofs_in_batch = 0;
-                user_state_guard.total_fees_in_queue = U256::zero();
-                user_state_guard.last_max_fee_limit = U256::max_value();
-                info!("Reset UserState for user {:?}", user_address);
-            } else {
-                warn!(
-                    "Failed to acquire user lock for {:?}, skipping UserState reset",
-                    user_address
-                );
-            }
-        }
+        // Remove UserState entry
+        self.user_states.write().await.remove(&user_address);
+        info!(
+            "Removed UserState entry for user {:?} after processing BalanceUnlocked event",
+            user_address
+        );
     }
 
     pub async fn listen_new_blocks_retryable(

--- a/crates/batcher/src/main.rs
+++ b/crates/batcher/src/main.rs
@@ -55,6 +55,16 @@ async fn main() -> Result<(), BatcherError> {
         }
     });
 
+    // spawn task to poll for BalanceUnlocked events
+    tokio::spawn({
+        let app = batcher.clone();
+        async move {
+            app.poll_balance_unlocked_events()
+                .await
+                .expect("Error polling BalanceUnlocked events")
+        }
+    });
+
     batcher.metrics.inc_batcher_restart();
 
     batcher.listen_connections(&address).await?;

--- a/crates/batcher/src/metrics.rs
+++ b/crates/batcher/src/metrics.rs
@@ -30,6 +30,7 @@ pub struct BatcherMetrics {
     pub message_handler_user_lock_timeouts: IntCounter,
     pub message_handler_batch_lock_timeouts: IntCounter,
     pub message_handler_user_states_lock_timeouts: IntCounter,
+    pub unlocked_event_polling_batch_lock_timeouts: IntCounter,
     pub available_data_services: IntGauge,
 }
 
@@ -103,6 +104,11 @@ impl BatcherMetrics {
             "Message Handler User States Lock Timeouts"
         ))?;
 
+        let unlocked_event_polling_batch_lock_timeouts = register_int_counter!(opts!(
+            "unlocked_event_polling_batch_lock_timeouts_count",
+            "Unlocked Event Polling Batch Lock Timeouts"
+        ))?;
+
         registry.register(Box::new(open_connections.clone()))?;
         registry.register(Box::new(received_proofs.clone()))?;
         registry.register(Box::new(sent_batches.clone()))?;
@@ -122,6 +128,7 @@ impl BatcherMetrics {
         registry.register(Box::new(message_handler_user_lock_timeouts.clone()))?;
         registry.register(Box::new(message_handler_batch_lock_timeouts.clone()))?;
         registry.register(Box::new(message_handler_user_states_lock_timeouts.clone()))?;
+        registry.register(Box::new(unlocked_event_polling_batch_lock_timeouts.clone()))?;
         registry.register(Box::new(available_data_services.clone()))?;
 
         let metrics_route = warp::path!("metrics")
@@ -154,6 +161,7 @@ impl BatcherMetrics {
             message_handler_user_lock_timeouts,
             message_handler_batch_lock_timeouts,
             message_handler_user_states_lock_timeouts,
+            unlocked_event_polling_batch_lock_timeouts,
             available_data_services,
         })
     }
@@ -199,5 +207,9 @@ impl BatcherMetrics {
 
     pub fn inc_message_handler_user_states_lock_timeouts(&self) {
         self.message_handler_user_states_lock_timeouts.inc();
+    }
+
+    pub fn inc_unlocked_event_polling_batch_lock_timeout(&self) {
+        self.unlocked_event_polling_batch_lock_timeouts.inc();
     }
 }

--- a/crates/batcher/src/retry/batcher_retryables.rs
+++ b/crates/batcher/src/retry/batcher_retryables.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use ethers::prelude::*;
+use ethers::providers::Http;
 use log::{info, warn};
 use tokio::time::timeout;
 
@@ -284,4 +285,51 @@ pub async fn cancel_create_new_task_retryable(
         .ok_or(RetryError::Transient(ProviderError::CustomError(
             "Receipt not found".to_string(),
         )))
+}
+
+pub async fn get_current_block_number_retryable(
+    eth_http_provider: &Provider<Http>,
+    eth_http_provider_fallback: &Provider<Http>,
+) -> Result<U64, RetryError<String>> {
+    if let Ok(block_number) = eth_http_provider.get_block_number().await {
+        return Ok(block_number);
+    }
+    
+    eth_http_provider_fallback
+        .get_block_number()
+        .await
+        .map_err(|e| {
+            warn!("Failed to get current block number: {e}");
+            RetryError::Transient(e.to_string())
+        })
+}
+
+pub async fn query_balance_unlocked_events_retryable(
+    payment_service: &BatcherPaymentService,
+    payment_service_fallback: &BatcherPaymentService,
+    from_block: U64,
+    to_block: U64,
+) -> Result<Vec<aligned_sdk::eth::batcher_payment_service::BalanceUnlockedFilter>, RetryError<String>>
+{
+    let filter = payment_service
+        .balance_unlocked_filter()
+        .from_block(from_block)
+        .to_block(to_block);
+    
+    if let Ok(events) = filter.query().await {
+        return Ok(events);
+    }
+    
+    let filter_fallback = payment_service_fallback
+        .balance_unlocked_filter()
+        .from_block(from_block)
+        .to_block(to_block);
+    
+    filter_fallback
+        .query()
+        .await
+        .map_err(|e| {
+            warn!("Failed to query BalanceUnlocked events: {e}");
+            RetryError::Transient(e.to_string())
+        })
 }

--- a/crates/batcher/src/retry/batcher_retryables.rs
+++ b/crates/batcher/src/retry/batcher_retryables.rs
@@ -294,7 +294,7 @@ pub async fn get_current_block_number_retryable(
     if let Ok(block_number) = eth_http_provider.get_block_number().await {
         return Ok(block_number);
     }
-    
+
     eth_http_provider_fallback
         .get_block_number()
         .await
@@ -315,21 +315,18 @@ pub async fn query_balance_unlocked_events_retryable(
         .balance_unlocked_filter()
         .from_block(from_block)
         .to_block(to_block);
-    
+
     if let Ok(events) = filter.query().await {
         return Ok(events);
     }
-    
+
     let filter_fallback = payment_service_fallback
         .balance_unlocked_filter()
         .from_block(from_block)
         .to_block(to_block);
-    
-    filter_fallback
-        .query()
-        .await
-        .map_err(|e| {
-            warn!("Failed to query BalanceUnlocked events: {e}");
-            RetryError::Transient(e.to_string())
-        })
+
+    filter_fallback.query().await.map_err(|e| {
+        warn!("Failed to query BalanceUnlocked events: {e}");
+        RetryError::Transient(e.to_string())
+    })
 }

--- a/crates/batcher/src/types/errors.rs
+++ b/crates/batcher/src/types/errors.rs
@@ -66,6 +66,7 @@ pub enum BatcherError {
     WsSinkEmpty,
     AddressNotFoundInUserStates(Address),
     QueueRemoveError(String),
+    EthereumProviderError(String),
 }
 
 impl From<tungstenite::Error> for BatcherError {
@@ -146,6 +147,9 @@ impl fmt::Debug for BatcherError {
             }
             BatcherError::QueueRemoveError(e) => {
                 write!(f, "Error while removing entry from queue: {}", e)
+            }
+            BatcherError::EthereumProviderError(e) => {
+                write!(f, "Ethereum provider error: {}", e)
             }
         }
     }

--- a/crates/sdk/src/common/errors.rs
+++ b/crates/sdk/src/common/errors.rs
@@ -98,6 +98,7 @@ pub enum SubmitError {
     GetNonceError(String),
     BatchQueueLimitExceededError,
     GenericError(String),
+    UserFundsUnlocked,
 }
 
 impl From<tokio_tungstenite::tungstenite::Error> for SubmitError {
@@ -216,6 +217,7 @@ impl fmt::Display for SubmitError {
             }
 
             SubmitError::GetNonceError(e) => write!(f, "Error while getting nonce {}", e),
+            SubmitError::UserFundsUnlocked => write!(f, "User funds have been unlocked and proofs removed from queue"),
         }
     }
 }

--- a/crates/sdk/src/common/errors.rs
+++ b/crates/sdk/src/common/errors.rs
@@ -217,7 +217,10 @@ impl fmt::Display for SubmitError {
             }
 
             SubmitError::GetNonceError(e) => write!(f, "Error while getting nonce {}", e),
-            SubmitError::UserFundsUnlocked => write!(f, "User funds have been unlocked and proofs removed from queue"),
+            SubmitError::UserFundsUnlocked => write!(
+                f,
+                "User funds have been unlocked and proofs removed from queue"
+            ),
         }
     }
 }

--- a/crates/sdk/src/common/types.rs
+++ b/crates/sdk/src/common/types.rs
@@ -453,6 +453,7 @@ pub enum SubmitProofResponseMessage {
     InvalidPaymentServiceAddress(Address, Address),
     UnderpricedProof,
     ServerBusy,
+    UserFundsUnlocked,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/sdk/src/communication/messaging.rs
+++ b/crates/sdk/src/communication/messaging.rs
@@ -275,6 +275,10 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
                 "Server is busy processing requests, please retry".to_string(),
             ))
         }
+        Ok(SubmitProofResponseMessage::UserFundsUnlocked) => {
+            error!("User funds have been unlocked and proofs removed from queue. Funds have not been spent.");
+            Err(SubmitError::UserFundsUnlocked)
+        }
         Err(e) => {
             error!(
                 "Error while deserializing batch inclusion data: {}. Funds have not been spent.",

--- a/grafana/provisioning/dashboards/aligned/aggregator_batcher.json
+++ b/grafana/provisioning/dashboards/aligned/aggregator_batcher.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -4045,11 +4045,77 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 0,
+        "y": 92
+      },
+      "id": 66,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.10",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "floor(increase(unlocked_event_polling_batch_lock_timeouts_count{job=\"aligned-batcher\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unlocked Events - Batch Lock Timeout",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
         "h": 2,
         "w": 24,
         "x": 0,
-        "y": 92
+        "y": 98
       },
       "id": 46,
       "options": {
@@ -4124,7 +4190,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 94
+        "y": 100
       },
       "id": 47,
       "options": {
@@ -4224,7 +4290,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 94
+        "y": 100
       },
       "id": 43,
       "interval": "1s",
@@ -4321,7 +4387,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 102
+        "y": 108
       },
       "id": 45,
       "options": {
@@ -4452,7 +4518,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 102
+        "y": 108
       },
       "id": 44,
       "interval": "1s",
@@ -4502,6 +4568,6 @@
   "timezone": "browser",
   "title": "System Data",
   "uid": "aggregator",
-  "version": 9,
+  "version": 30,
   "weekStart": ""
 }

--- a/infra/ansible/playbooks/templates/config-files/config-batcher.yaml.j2
+++ b/infra/ansible/playbooks/templates/config-files/config-batcher.yaml.j2
@@ -32,3 +32,11 @@ batcher:
   non_paying:
     address: 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720 # Anvil address 9
     replacement_private_key: {{ batcher_replacement_private_key }}
+  # When validating if the msg covers the minimum max fee
+  # A batch of how many proofs should it cover
+  amount_of_proofs_for_min_max_fee: 128
+  # When replacing the message, how much higher should the max fee in comparison to the original one
+  # The calculation is replacement_max_fee >= original_max_fee + original_max_fee * min_bump_percentage / 100
+  min_bump_percentage: 10
+  # How often to poll for BalanceUnlocked events in seconds (default: 600 seconds = 10 minutes)
+  balance_unlock_polling_interval_seconds: 600


### PR DESCRIPTION
# Feat(batcher): Poll for unlock events and remove users with unlocked funds

## Description

This PR fetches `BalanceUnlocked` events from `BatcherPaymentService` to check if an user has proofs in the queue and has unlocked their funds. 
In that case, the batcher will remove their proofs until the user locks funds again to avoid a withdrawal and trying to discount balace from a user without funds deposited.

Closes #2122

## How to Test

1. Start anvil

2. Set `balance_unlock_polling_interval_seconds` to `60` in `config-files/config-batcher.yaml`. So the polling is executed every 1 minute

3. Start batcher

4. Deposit funds

```
aligned deposit-to-batcher \
    --amount 1ether \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
    --network devnet \
    --rpc_url http://localhost:8545
```

5. Send a proof with low fee

```
aligned submit \
    --proving_system Risc0 \
    --proof ./scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_3_0_3.proof \
    --vm_program ./scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_id_3_0_3.bin \
    --rpc_url http://localhost:8545 \
    --network devnet \
    --custom_fee_estimate 16 \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
    --random_address
```

You can send multiple proofs (less than 16 :p)

6. Unlock your funds

```
cast send 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650  "unlock()" \
    --rpc-url http://localhost:8545 \
    --private-key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97
```

7. You should see logs like:

```
[2025-09-16T21:27:14Z INFO  aligned_batcher] Found 1 BalanceUnlocked events in blocks 770 to 870
[2025-09-16T21:27:14Z INFO  aligned_batcher] Processing BalanceUnlocked event for user: 0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f
```

And the user should receive the error `User funds have been unlocked and proofs removed from queue.`

Other tests cases:

Unlock and lock funds. The batcher should not eject the user proofs

To lock funds again, use

```
cast send 0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650  "lock()" \
    --rpc-url http://localhost:8545 \
    --private-key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97
```


## Type of change

- [x] New feature
- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
