### PR TITLE
feat: notify user after replacement message

### DIFF
--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1502,7 +1502,8 @@ impl Batcher {
                     send_message(
                         messaging_sink.clone(),
                         SubmitProofResponseMessage::ProofReplaced,
-                    ).await;
+                    )
+                    .await;
 
                     // Note: This shuts down the sink, but does not wait for it to close, so the other side
                     // might not receive the message. However, we don't want to wait here since it would

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1496,13 +1496,25 @@ impl Batcher {
         // Close old sink in old entry and replace it with the new one
         {
             if let Some(messaging_sink) = replacement_entry.messaging_sink {
-                let mut old_sink = messaging_sink.write().await;
-                if let Err(e) = old_sink.close().await {
-                    // we dont want to exit here, just log the error
-                    warn!("Error closing sink: {e:?}");
-                } else {
-                    info!("Old websocket sink closed");
-                }
+                tokio::spawn(async move {
+                    // Before closing the old sink, send a message to the client notifying that their proof
+                    // has been replaced
+                    send_message(
+                        messaging_sink.clone(),
+                        SubmitProofResponseMessage::ProofReplaced,
+                    ).await;
+
+                    // Note: This shuts down the sink, but does not wait for it to close, so the other side
+                    // might not receive the message. However, we don't want to wait here since it would
+                    // block the batcher.
+                    let mut old_sink = messaging_sink.write().await;
+                    if let Err(e) = old_sink.close().await {
+                        // we dont want to exit here, just log the error
+                        warn!("Error closing sink: {e:?}");
+                    } else {
+                        info!("Old websocket sink closed");
+                    }
+                });
             } else {
                 warn!(
                     "Old websocket sink was empty. This should only happen in testing environments"

--- a/crates/sdk/src/common/errors.rs
+++ b/crates/sdk/src/common/errors.rs
@@ -221,7 +221,7 @@ impl fmt::Display for SubmitError {
             }
             SubmitError::ProofReplaced => write!(
                 f,
-                "Proof has been replaced by a higher fee for the same proof"
+                "Proof has been replaced by a higher fee for the same nonce"
             ),
             SubmitError::GetNonceError(e) => write!(f, "Error while getting nonce {}", e),
             SubmitError::UserFundsUnlocked => write!(

--- a/crates/sdk/src/common/errors.rs
+++ b/crates/sdk/src/common/errors.rs
@@ -214,9 +214,15 @@ impl fmt::Display for SubmitError {
                 write!(f, "Batcher responded with invalid batch inclusion data. Can't verify your proof was correctly included in the batch.")
             }
             SubmitError::BatchQueueLimitExceededError => {
-                write!(f, "Error while adding entry to batch, queue limit exceeded.")
+                write!(
+                    f,
+                    "Error while adding entry to batch, queue limit exceeded."
+                )
             }
-            SubmitError::ProofReplaced => write!(f, "Proof has been replaced by a higher fee for the same proof"),
+            SubmitError::ProofReplaced => write!(
+                f,
+                "Proof has been replaced by a higher fee for the same proof"
+            ),
             SubmitError::GetNonceError(e) => write!(f, "Error while getting nonce {}", e),
             SubmitError::UserFundsUnlocked => write!(
                 f,

--- a/crates/sdk/src/common/errors.rs
+++ b/crates/sdk/src/common/errors.rs
@@ -99,6 +99,7 @@ pub enum SubmitError {
     BatchQueueLimitExceededError,
     GenericError(String),
     UserFundsUnlocked,
+    ProofReplaced,
 }
 
 impl From<tokio_tungstenite::tungstenite::Error> for SubmitError {
@@ -213,9 +214,9 @@ impl fmt::Display for SubmitError {
                 write!(f, "Batcher responded with invalid batch inclusion data. Can't verify your proof was correctly included in the batch.")
             }
             SubmitError::BatchQueueLimitExceededError => {
-                write!(f, "Error while adding entry to batch, queue limit exeeded.")
+                write!(f, "Error while adding entry to batch, queue limit exceeded.")
             }
-
+            SubmitError::ProofReplaced => write!(f, "Proof has been replaced by a higher fee for the same proof"),
             SubmitError::GetNonceError(e) => write!(f, "Error while getting nonce {}", e),
             SubmitError::UserFundsUnlocked => write!(
                 f,

--- a/crates/sdk/src/common/types.rs
+++ b/crates/sdk/src/common/types.rs
@@ -454,6 +454,7 @@ pub enum SubmitProofResponseMessage {
     UnderpricedProof,
     ServerBusy,
     UserFundsUnlocked,
+    ProofReplaced,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/sdk/src/communication/messaging.rs
+++ b/crates/sdk/src/communication/messaging.rs
@@ -279,6 +279,10 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             error!("User funds have been unlocked and proofs removed from queue. Funds have not been spent.");
             Err(SubmitError::UserFundsUnlocked)
         }
+        Ok(SubmitProofResponseMessage::ProofReplaced) => {
+            error!("Proof has been replaced by a higher fee for the same proof. Funds have not been spent.");
+            Err(SubmitError::ProofReplaced)
+        }
         Err(e) => {
             error!(
                 "Error while deserializing batch inclusion data: {}. Funds have not been spent.",

--- a/crates/sdk/src/communication/messaging.rs
+++ b/crates/sdk/src/communication/messaging.rs
@@ -280,7 +280,7 @@ async fn handle_batcher_response(msg: Message) -> Result<BatchInclusionData, Sub
             Err(SubmitError::UserFundsUnlocked)
         }
         Ok(SubmitProofResponseMessage::ProofReplaced) => {
-            error!("Proof has been replaced by a higher fee for the same proof. Funds have not been spent.");
+            error!("Proof has been replaced by a higher fee for the same nonce. Funds have not been spent.");
             Err(SubmitError::ProofReplaced)
         }
         Err(e) => {

--- a/crates/sdk/src/verification_layer/mod.rs
+++ b/crates/sdk/src/verification_layer/mod.rs
@@ -78,6 +78,7 @@ use std::path::PathBuf;
 /// * `ProofTooLarge` if the proof is too large.
 /// * `InsufficientBalance` if the sender balance is insufficient or unlocked
 /// * `ProofQueueFlushed` if there is an error in the batcher and the proof queue is flushed.
+/// * `ProofReplaced` if the proof has been replaced.
 /// * `GenericError` if the error doesn't match any of the previous ones.
 #[allow(clippy::too_many_arguments)] // TODO: Refactor this function, use NoncedVerificationData
 pub async fn submit_multiple_and_wait_verification(
@@ -245,6 +246,7 @@ async fn fetch_gas_price(
 /// * `ProofTooLarge` if the proof is too large.
 /// * `InsufficientBalance` if the sender balance is insufficient or unlocked.
 /// * `ProofQueueFlushed` if there is an error in the batcher and the proof queue is flushed.
+/// * `ProofReplaced` if the proof has been replaced.
 /// * `GenericError` if the error doesn't match any of the previous ones.
 pub async fn submit_multiple(
     network: Network,
@@ -364,6 +366,7 @@ async fn _submit_multiple(
 /// * `ProofTooLarge` if the proof is too large.
 /// * `InsufficientBalance` if the sender balance is insufficient or unlocked
 /// * `ProofQueueFlushed` if there is an error in the batcher and the proof queue is flushed.
+/// * `ProofReplaced` if the proof has been replaced.
 /// * `GenericError` if the error doesn't match any of the previous ones.
 #[allow(clippy::too_many_arguments)] // TODO: Refactor this function, use NoncedVerificationData
 pub async fn submit_and_wait_verification(
@@ -421,6 +424,7 @@ pub async fn submit_and_wait_verification(
 /// * `ProofTooLarge` if the proof is too large.
 /// * `InsufficientBalance` if the sender balance is insufficient or unlocked
 /// * `ProofQueueFlushed` if there is an error in the batcher and the proof queue is flushed.
+/// * `ProofReplaced` if the proof has been replaced.
 /// * `GenericError` if the error doesn't match any of the previous ones.
 pub async fn submit(
     network: Network,

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -44,6 +44,7 @@ pub async fn submit(
 - `InsufficientBalance` if the sender balance is not enough or unlocked
 - `ProofQueueFlushed` if there is an error in the batcher and the proof queue is flushed.
 - `NotAContract(address)` if you are trying to send to an address that is not a contract. This generally occurs if you have misconfigured the `environment` parameter.
+- `ProofReplaced` if the proof has been replaced.
 - `GenericError` if the error doesn't match any of the previous ones.
 
 ### `submit_multiple`
@@ -87,6 +88,7 @@ pub async fn submit_multiple(
 - `ProofTooLarge` if the proof is too large.
 - `InsufficientBalance` if the sender balance is not enough or unlocked
 - `ProofQueueFlushed` if there is an error in the batcher and the proof queue is flushed.
+- `ProofReplaced` if the proof has been replaced.
 - `GenericError` if the error doesn't match any of the previous ones.
 
 ### `submit_and_wait_verification`
@@ -137,6 +139,7 @@ pub async fn submit_and_wait_verification(
 - `InsufficientBalance` if the sender balance is not enough or unlocked
 - `ProofQueueFlushed` if there is an error in the batcher and the proof queue is flushed.
 - `NotAContract(address)` if you are trying to send to an address that is not a contract. This generally occurs if you have misconfigured the `environment` parameter.
+- `ProofReplaced` if the proof has been replaced.
 - `GenericError` if the error doesn't match any of the previous ones.
 
 ### `submit_multiple_and_wait_verification`
@@ -186,6 +189,7 @@ pub async fn submit_multiple_and_wait_verification(
 - `InsufficientBalance` if the sender balance is not enough or unlocked
 - `ProofQueueFlushed` if there is an error in the batcher and the proof queue is flushed.
 - `NotAContract(address)` if you are trying to send to an address that is not a contract. This generally occurs if you have misconfigured the `environment` parameter.
+- `ProofReplaced` if the proof has been replaced.
 - `GenericError` if the error doesn't match any of the previous ones.
 
 ### `is_proof_verified`


### PR DESCRIPTION
# Notify user after replacement message

## Description

In the message replacement process, the old sink was being closed silently, without notifying the other side about the reason for the disconnection. With this change, the batcher now sends a ProofReplaced message before closing it.

Note: The closing handshake might not be handled gracefully by the other side, since we are replacing the sink with a new one. However, this can be improved in a future PR.

## How to test

1. Reinstall aligned CLI:

``` shell
make aligned_install_compiling
```

2. Start anvil:
``` shell
make anvil_start
```

3. Start the batcher:
``` shell
make batcher_start_local
```

4. Run the aggregator:
``` shell
make aggregator_start ENVIRONMENT=devnet
```

5. Run the operator
``` shell
make operator_full_registration_and_start ENVIRONMENT=devnet
```

6. Deposit in Aligned (for example, with an anvil-rich account):
``` shell
cd crates/cli
cargo run --release -- deposit-to-batcher \
    --amount 1ether \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
    --network devnet \
    --rpc_url http://localhost:8545
```

7. Send a proof:
``` shell
cargo run --release -- submit \
                --proving_system Risc0 \
                --proof ../../scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_3_0_3.proof \
                --vm_program ../../scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_id_3_0_3.bin \
                --rpc_url http://localhost:8545 \
                --network devnet \
                --default_fee_estimate \
                --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
                --random_address \
                --nonce 0
```

8. Send the same proof with a higher fee from another terminal:
``` shell
cd crates/cli
cargo run --release -- submit \
                --proving_system Risc0 \
                --proof ../../scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_3_0_3.proof \
                --vm_program ../../scripts/test_files/risc_zero/no_public_inputs/risc_zero_no_pub_input_id_3_0_3.bin \
                --rpc_url http://localhost:8545 \
                --network devnet \
                --instant_fee_estimate \
                --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
                --random_address \
                --nonce 0
```

You should see the replacement message on the replaced proof CLI.
 
## Type of change

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
