### PR TITLE
fix(test): Change the RPC url used in tests to the Hoodi one

### DIFF
--- a/crates/sdk/src/verification_layer/mod.rs
+++ b/crates/sdk/src/verification_layer/mod.rs
@@ -832,15 +832,15 @@ fn save_response_json(
 #[cfg(test)]
 mod test {
     //Public constants for convenience
-    pub const HOLESKY_PUBLIC_RPC_URL: &str = "https://ethereum-holesky-rpc.publicnode.com";
+    pub const HOODI_PUBLIC_RPC_URL: &str = "https://ethereum-hoodi-rpc.publicnode.com";
     use super::*;
 
     #[tokio::test]
     async fn computed_max_fee_for_larger_batch_is_smaller() {
-        let small_fee = estimate_fee_per_proof_with_rpc(5, HOLESKY_PUBLIC_RPC_URL)
+        let small_fee = estimate_fee_per_proof_with_rpc(5, HOODI_PUBLIC_RPC_URL)
             .await
             .unwrap();
-        let large_fee = estimate_fee_per_proof_with_rpc(2, HOLESKY_PUBLIC_RPC_URL)
+        let large_fee = estimate_fee_per_proof_with_rpc(2, HOODI_PUBLIC_RPC_URL)
             .await
             .unwrap();
 
@@ -849,10 +849,10 @@ mod test {
 
     #[tokio::test]
     async fn computed_max_fee_for_more_proofs_larger_than_for_less_proofs() {
-        let small_fee = estimate_fee_per_proof_with_rpc(20, HOLESKY_PUBLIC_RPC_URL)
+        let small_fee = estimate_fee_per_proof_with_rpc(20, HOODI_PUBLIC_RPC_URL)
             .await
             .unwrap();
-        let large_fee = estimate_fee_per_proof_with_rpc(10, HOLESKY_PUBLIC_RPC_URL)
+        let large_fee = estimate_fee_per_proof_with_rpc(10, HOODI_PUBLIC_RPC_URL)
             .await
             .unwrap();
 
@@ -861,13 +861,13 @@ mod test {
 
     #[tokio::test]
     async fn estimate_fee_are_larger_than_one_another() {
-        let min_fee = estimate_fee(HOLESKY_PUBLIC_RPC_URL, FeeEstimationType::Custom(100))
+        let min_fee = estimate_fee(HOODI_PUBLIC_RPC_URL, FeeEstimationType::Custom(100))
             .await
             .unwrap();
-        let default_fee = estimate_fee(HOLESKY_PUBLIC_RPC_URL, FeeEstimationType::Default)
+        let default_fee = estimate_fee(HOODI_PUBLIC_RPC_URL, FeeEstimationType::Default)
             .await
             .unwrap();
-        let instant_fee = estimate_fee(HOLESKY_PUBLIC_RPC_URL, FeeEstimationType::Instant)
+        let instant_fee = estimate_fee(HOODI_PUBLIC_RPC_URL, FeeEstimationType::Instant)
             .await
             .unwrap();
 


### PR DESCRIPTION
# fix(test): Change the RPC url used in tests to the Hoodi one

## Description

Since the Holesky RPC node is no longer functional, this PR replaces it with the Hoodi one in some tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
