### PR TITLE
docs: update Holesky network for Hoodi in the examples of submitting proofs tutorial

### DIFF
--- a/docs/3_guides/0_submitting_proofs.md
+++ b/docs/3_guides/0_submitting_proofs.md
@@ -71,8 +71,8 @@ To use it, you can use the `aligned` CLI, as shown with the following example:
 
 ```bash
 aligned deposit-to-batcher \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---network holesky \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com \
+--network hoodi \
 --keystore_path <keystore_path> \
 --amount 0.1ether
 ```
@@ -89,8 +89,8 @@ After depositing funds, you can verify the Service has correctly received them b
 
 ```bash
 aligned get-user-balance \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
---network holesky \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com \
+--network hoodi \
 --user_addr <user_addr>
 ```
 
@@ -138,8 +138,8 @@ aligned submit \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 
 **Example**
@@ -152,8 +152,8 @@ aligned submit \
 --vm_program ./scripts/test_files/sp1/sp1_fibonacci_5_0_0.elf \
 --public_input ./scripts/test_files/sp1/sp1_fibonacci_5_0_0.pub \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 
 ### Risc0 proof
@@ -172,8 +172,8 @@ aligned submit \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 
 **NOTE**: As said above, Aligned currently supports Risc0 proofs from `risc0-zkvm` version `v3.0.3`. For generating proofs using `cargo risc-zero` please ensure you are using `v3.0.3` or your proof will not be verified. 
@@ -198,8 +198,8 @@ aligned submit \
 --public_input ./scripts/test_files/risc_zero/fibonacci_proof_generator/risc_zero_fibonacci_3_0_3.pub \
 --aligned_verification_data_path ~/.aligned/aligned_verification_data \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 
 ### GnarkPlonkBn254, GnarkPlonkBls12_381 and GnarkGroth16Bn254
@@ -216,8 +216,8 @@ aligned submit \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 
 **Examples**:
@@ -230,8 +230,8 @@ aligned submit \
 --public_input ./scripts/test_files/gnark_plonk_bn254_script/gnark_plonk_pub_input_0_12_0.pub \
 --vk ./scripts/test_files/gnark_plonk_bn254_script/gnark_plonk_0_12_0.vk \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 
 ```bash
@@ -242,8 +242,8 @@ aligned submit \
 --public_input ./scripts/test_files/gnark_plonk_bls12_381_script/gnark_plonk_pub_input_0_12_0.pub \
 --vk ./scripts/test_files/gnark_plonk_bls12_381_script/gnark_plonk_0_12_0.vk \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 
 ```bash
@@ -254,8 +254,8 @@ aligned submit \
 --public_input ./scripts/test_files/gnark_groth16_bn254_script/gnark_groth16_0_12_0.pub \
 --vk ./scripts/test_files/gnark_groth16_bn254_script/gnark_groth16_0_12_0.vk \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 
 ### CircomGroth16Bn256
@@ -272,8 +272,8 @@ aligned submit \
 --proof_generator_addr [proof_generator_addr] \
 --batch_inclusion_data_directory_path [batch_inclusion_data_directory_path] \
 --keystore_path <path_to_ecdsa_keystore> \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```
 **Example**
 
@@ -285,6 +285,6 @@ aligned submit \
 --public_input ./scripts/test_files/circom_groth16_bn256_script/public.json \
 --vk ./scripts/test_files/circom_groth16_bn256_script/verification_key.json \
 --keystore_path ~/.aligned_keystore/keystore0 \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com
 ```


### PR DESCRIPTION
## Description

This PR updates the Holesky network for the Hoodi one in the 'Submitting Proofs' tutorial examples.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
