### PR TITLE
fix: change pub input curl URL in get_proof_test_files script

### DIFF
--- a/crates/cli/get_proof_test_files.sh
+++ b/crates/cli/get_proof_test_files.sh
@@ -40,10 +40,10 @@ fi
 
 echo "Downloading SP1 public inputs file..."
 
-if curl -sSf -L "$SP1_PUBLIC_INPUT_NAME" -o "$ALIGNED_TEST_FILES_DIR/$SP1_PUBLIC_INPUT_NAME"; then
+if curl -sSf -L "$SP1_PUBLIC_INPUT_URL" -o "$ALIGNED_TEST_FILES_DIR/$SP1_PUBLIC_INPUT_NAME"; then
     echo "SP1 public inputs downloaded successful"
 else
-    echo "Error: Failed to downloaded $SP1_PUBLIC_INPUT_NAME"
+    echo "Error: Failed to downloaded $SP1_PUBLIC_INPUT_URL"
     exit 1
 fi
 


### PR DESCRIPTION
# fix: change pub input curl URL in get_proof_test_files script

## Description

This PR fixes the URL that was used for the curl that downloaded the SP1 public inputs on the `get_proof_test_files` script, used in the "Try Aligned" section of the documentation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
