### PR TITLE
docs: change Holesky for Hoodi in Generating proofs for Aligned section

### DIFF
--- a/docs/3_guides/4_generating_proofs.md
+++ b/docs/3_guides/4_generating_proofs.md
@@ -41,7 +41,7 @@ aligned submit \
 --vm_program <vm_program_path> \
 --batcher_url wss://batcher.alignedlayer.com \
 --proof_generator_addr <proof_generator_addr> \
---rpc_url https://ethereum-holesky-rpc.publicnode.com 
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com 
 ```
 
 Where `proof_path` is the path to the proof file, `vm_program_path` is the path to the ELF file. `proof_generator_addr` is an optional parameter that works as a helper for some applications where you can be frontrunned.
@@ -90,7 +90,7 @@ aligned submit \
 --vk <verification_key_path> \
 --batcher_url wss://batcher.alignedlayer.com \
 --proof_generator_addr <proof_generator_addr> \
---rpc_url https://ethereum-holesky-rpc.publicnode.com 
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com 
 ```
 
 Where proof path is the path to the proof file, `public_input_path` is the path to the public input file,
@@ -168,7 +168,7 @@ aligned submit \
   --public_input <pub_input_file_path> \
   --batcher_url wss://batcher.alignedlayer.com \
   --proof_generator_addr <proof_generator_addr> \
-  --rpc_url https://ethereum-holesky-rpc.publicnode.com \
+  --rpc_url https://ethereum-hoodi-rpc.publicnode.com \
   --payment_service_addr 0x815aeCA64a974297942D2Bbf034ABEe22a38A003
 ```
 


### PR DESCRIPTION
## Description

This PR utilizes the Hoodi network instead of Holesky in the 'Generating Proofs for Aligned' section, as the Holesky RPC public node is no longer active.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
