### PR TITLE
fix: add Hoodi support for the circom example

### DIFF
--- a/examples/circom/.env.example
+++ b/examples/circom/.env.example
@@ -3,4 +3,4 @@ ETH_RPC_URL=<RPC_URL>
 PRIVATE_KEY=<PRIVATE_KEY>
 # Deploy the contract with make deploy_contract_devnet
 FIBONACCI_CONTRACT_ADDRESS=<FIBONACCI_CONTRACT_ADDRESS>
-NETWORK=<devnet|holesky|holeksy-stage|mainnet>
+NETWORK=<devnet|holesky|holeksy-stage|mainnet|hoodi>

--- a/examples/circom/src/config.rs
+++ b/examples/circom/src/config.rs
@@ -32,6 +32,7 @@ impl EnvConfig {
             "holesky-stage" => Network::HoleskyStage,
             "holesky" => Network::Holesky,
             "mainnet" => Network::Mainnet,
+            "hoodi" => Network::Hoodi,
             _ => panic!("Unsupported NETWORK value"),
         };
 


### PR DESCRIPTION
## Description

This PR adds Hoodi support to the Circom use example.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
