### PR TITLE
feat: unlock, lock and withdraw funds in sdk and cli

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,6 +19,7 @@ use aligned_sdk::verification_layer::estimate_fee;
 use aligned_sdk::verification_layer::get_chain_id;
 use aligned_sdk::verification_layer::get_nonce_from_batcher;
 use aligned_sdk::verification_layer::get_nonce_from_ethereum;
+use aligned_sdk::verification_layer::lock_balance_in_aligned;
 use aligned_sdk::verification_layer::unlock_balance_in_aligned;
 use aligned_sdk::verification_layer::withdraw_balance_from_aligned;
 use aligned_sdk::verification_layer::{deposit_to_aligned, get_balance_in_aligned};
@@ -43,6 +44,7 @@ use crate::AlignedCommands::GetUserBalance;
 use crate::AlignedCommands::GetUserNonce;
 use crate::AlignedCommands::GetUserNonceFromEthereum;
 use crate::AlignedCommands::GetVkCommitment;
+use crate::AlignedCommands::LockFunds;
 use crate::AlignedCommands::Submit;
 use crate::AlignedCommands::UnlockFunds;
 use crate::AlignedCommands::VerifyProofOnchain;
@@ -70,7 +72,9 @@ pub enum AlignedCommands {
     )]
     DepositToBatcher(DepositToBatcherArgs),
     #[clap(about = "Unlocks funds from the batcher", name = "unlock-funds")]
-    UnlockFunds(UnlockFundsArgs),
+    UnlockFunds(LockUnlockFundsArgs),
+    #[clap(about = "Lock funds in the batcher", name = "unlock-funds")]
+    LockFunds(LockUnlockFundsArgs),
     #[clap(about = "Withdraw funds from the batcher", name = "withdraw-funds")]
     WithdrawFunds(WithdrawFundsArgs),
     #[clap(about = "Get user balance from the batcher", name = "get-user-balance")]
@@ -218,7 +222,7 @@ pub struct DepositToBatcherArgs {
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
-pub struct UnlockFundsArgs {
+pub struct LockUnlockFundsArgs {
     #[command(flatten)]
     private_key_type: PrivateKeyType,
     #[arg(
@@ -828,6 +832,50 @@ async fn main() -> Result<(), AlignedError> {
                 Ok(receipt) => {
                     info!(
                         "Funds in batcher unlocked successfully. Receipt: 0x{:x}",
+                        receipt.transaction_hash
+                    );
+                }
+                Err(e) => {
+                    error!("Transaction failed: {:?}", e);
+                }
+            }
+        }
+        LockFunds(args) => {
+            let eth_rpc_url = args.eth_rpc_url;
+            let eth_rpc_provider =
+                Provider::<Http>::try_from(eth_rpc_url.clone()).map_err(|e| {
+                    SubmitError::EthereumProviderError(format!(
+                        "Error while connecting to Ethereum: {}",
+                        e
+                    ))
+                })?;
+
+            let keystore_path = &args.private_key_type.keystore_path;
+            let private_key = &args.private_key_type.private_key;
+
+            let mut wallet = if let Some(keystore_path) = keystore_path {
+                let password = rpassword::prompt_password("Please enter your keystore password:")
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?;
+                Wallet::decrypt_keystore(keystore_path, password)
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?
+            } else if let Some(private_key) = private_key {
+                private_key
+                    .parse::<LocalWallet>()
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?
+            } else {
+                warn!("Missing keystore or private key used for payment.");
+                return Ok(());
+            };
+
+            let chain_id = get_chain_id(eth_rpc_url.as_str()).await?;
+            wallet = wallet.with_chain_id(chain_id);
+
+            let client = SignerMiddleware::new(eth_rpc_provider, wallet);
+
+            match lock_balance_in_aligned(&client, args.network.into()).await {
+                Ok(receipt) => {
+                    info!(
+                        "Funds in batcher locked successfully. Receipt: 0x{:x}",
                         receipt.transaction_hash
                     );
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -78,7 +78,7 @@ pub enum AlignedCommands {
     DepositToBatcher(DepositToBatcherArgs),
     #[clap(about = "Unlocks funds from the batcher", name = "unlock-funds")]
     UnlockFunds(LockUnlockFundsArgs),
-    #[clap(about = "Lock funds in the batcher", name = "unlock-funds")]
+    #[clap(about = "Lock funds in the batcher", name = "lock-funds")]
     LockFunds(LockUnlockFundsArgs),
     #[clap(about = "Withdraw funds from the batcher", name = "withdraw-funds")]
     WithdrawFunds(WithdrawFundsArgs),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,6 +19,8 @@ use aligned_sdk::verification_layer::estimate_fee;
 use aligned_sdk::verification_layer::get_chain_id;
 use aligned_sdk::verification_layer::get_nonce_from_batcher;
 use aligned_sdk::verification_layer::get_nonce_from_ethereum;
+use aligned_sdk::verification_layer::unlock_balance_in_aligned;
+use aligned_sdk::verification_layer::withdraw_balance_from_aligned;
 use aligned_sdk::verification_layer::{deposit_to_aligned, get_balance_in_aligned};
 use aligned_sdk::verification_layer::{get_vk_commitment, save_response, submit_multiple};
 use clap::Args;
@@ -42,7 +44,9 @@ use crate::AlignedCommands::GetUserNonce;
 use crate::AlignedCommands::GetUserNonceFromEthereum;
 use crate::AlignedCommands::GetVkCommitment;
 use crate::AlignedCommands::Submit;
+use crate::AlignedCommands::UnlockFunds;
 use crate::AlignedCommands::VerifyProofOnchain;
+use crate::AlignedCommands::WithdrawFunds;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -65,6 +69,10 @@ pub enum AlignedCommands {
         name = "deposit-to-batcher"
     )]
     DepositToBatcher(DepositToBatcherArgs),
+    #[clap(about = "Unlocks funds from the batcher", name = "unlock-funds")]
+    UnlockFunds(UnlockFundsArgs),
+    #[clap(about = "Withdraw funds from the batcher", name = "withdraw-funds")]
+    WithdrawFunds(WithdrawFundsArgs),
     #[clap(about = "Get user balance from the batcher", name = "get-user-balance")]
     GetUserBalance(GetUserBalanceArgs),
     #[clap(
@@ -205,6 +213,38 @@ pub struct DepositToBatcherArgs {
     #[clap(flatten)]
     network: NetworkArg,
     #[arg(name = "Amount to deposit", long = "amount", required = true)]
+    amount: String,
+}
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct UnlockFundsArgs {
+    #[command(flatten)]
+    private_key_type: PrivateKeyType,
+    #[arg(
+        name = "Ethereum RPC provider address",
+        long = "rpc_url",
+        default_value = "http://localhost:8545"
+    )]
+    eth_rpc_url: String,
+    #[clap(flatten)]
+    network: NetworkArg,
+}
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct WithdrawFundsArgs {
+    #[command(flatten)]
+    private_key_type: PrivateKeyType,
+    #[arg(
+        name = "Ethereum RPC provider address",
+        long = "rpc_url",
+        default_value = "http://localhost:8545"
+    )]
+    eth_rpc_url: String,
+    #[clap(flatten)]
+    network: NetworkArg,
+    #[arg(name = "Amount to withdraw", long = "amount", required = true)]
     amount: String,
 }
 
@@ -744,6 +784,105 @@ async fn main() -> Result<(), AlignedError> {
                 Ok(receipt) => {
                     info!(
                         "Payment sent to the batcher successfully. Tx: 0x{:x}",
+                        receipt.transaction_hash
+                    );
+                }
+                Err(e) => {
+                    error!("Transaction failed: {:?}", e);
+                }
+            }
+        }
+        UnlockFunds(args) => {
+            let eth_rpc_url = args.eth_rpc_url;
+            let eth_rpc_provider =
+                Provider::<Http>::try_from(eth_rpc_url.clone()).map_err(|e| {
+                    SubmitError::EthereumProviderError(format!(
+                        "Error while connecting to Ethereum: {}",
+                        e
+                    ))
+                })?;
+
+            let keystore_path = &args.private_key_type.keystore_path;
+            let private_key = &args.private_key_type.private_key;
+
+            let mut wallet = if let Some(keystore_path) = keystore_path {
+                let password = rpassword::prompt_password("Please enter your keystore password:")
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?;
+                Wallet::decrypt_keystore(keystore_path, password)
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?
+            } else if let Some(private_key) = private_key {
+                private_key
+                    .parse::<LocalWallet>()
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?
+            } else {
+                warn!("Missing keystore or private key used for payment.");
+                return Ok(());
+            };
+
+            let chain_id = get_chain_id(eth_rpc_url.as_str()).await?;
+            wallet = wallet.with_chain_id(chain_id);
+
+            let client = SignerMiddleware::new(eth_rpc_provider, wallet);
+
+            match unlock_balance_in_aligned(&client, args.network.into()).await {
+                Ok(receipt) => {
+                    info!(
+                        "Funds in batcher unlocked successfully. Receipt: 0x{:x}",
+                        receipt.transaction_hash
+                    );
+                }
+                Err(e) => {
+                    error!("Transaction failed: {:?}", e);
+                }
+            }
+        }
+        WithdrawFunds(args) => {
+            if !args.amount.ends_with("ether") {
+                error!("Amount should be in the format XX.XXether");
+                return Ok(());
+            }
+
+            let amount_ether = args.amount.replace("ether", "");
+
+            let amount_wei = parse_ether(&amount_ether).map_err(|e| {
+                SubmitError::EthereumProviderError(format!("Error while parsing amount: {}", e))
+            })?;
+
+            let eth_rpc_url = args.eth_rpc_url;
+            let eth_rpc_provider =
+                Provider::<Http>::try_from(eth_rpc_url.clone()).map_err(|e| {
+                    SubmitError::EthereumProviderError(format!(
+                        "Error while connecting to Ethereum: {}",
+                        e
+                    ))
+                })?;
+
+            let keystore_path = &args.private_key_type.keystore_path;
+            let private_key = &args.private_key_type.private_key;
+
+            let mut wallet = if let Some(keystore_path) = keystore_path {
+                let password = rpassword::prompt_password("Please enter your keystore password:")
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?;
+                Wallet::decrypt_keystore(keystore_path, password)
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?
+            } else if let Some(private_key) = private_key {
+                private_key
+                    .parse::<LocalWallet>()
+                    .map_err(|e| SubmitError::GenericError(e.to_string()))?
+            } else {
+                warn!("Missing keystore or private key used for payment.");
+                return Ok(());
+            };
+
+            let chain_id = get_chain_id(eth_rpc_url.as_str()).await?;
+            wallet = wallet.with_chain_id(chain_id);
+
+            let client = SignerMiddleware::new(eth_rpc_provider, wallet);
+
+            match withdraw_balance_from_aligned(&client, args.network.into(), amount_wei).await {
+                Ok(receipt) => {
+                    info!(
+                        "Balance withdraw from batcher successfully. Receipt: 0x{:x}",
                         receipt.transaction_hash
                     );
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,6 +4,9 @@ use std::io::BufReader;
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use aligned_sdk::aggregation_layer;
 use aligned_sdk::aggregation_layer::AggregationModeVerificationData;
@@ -19,6 +22,7 @@ use aligned_sdk::verification_layer::estimate_fee;
 use aligned_sdk::verification_layer::get_chain_id;
 use aligned_sdk::verification_layer::get_nonce_from_batcher;
 use aligned_sdk::verification_layer::get_nonce_from_ethereum;
+use aligned_sdk::verification_layer::get_unlock_block_time;
 use aligned_sdk::verification_layer::lock_balance_in_aligned;
 use aligned_sdk::verification_layer::unlock_balance_in_aligned;
 use aligned_sdk::verification_layer::withdraw_balance_from_aligned;
@@ -29,6 +33,7 @@ use clap::Parser;
 use clap::Subcommand;
 use clap::ValueEnum;
 use env_logger::Env;
+use ethers::core::k256::pkcs8::der::asn1::UtcTime;
 use ethers::prelude::*;
 use ethers::utils::format_ether;
 use ethers::utils::hex;
@@ -922,6 +927,54 @@ async fn main() -> Result<(), AlignedError> {
                 return Ok(());
             };
 
+            let unlock_block_time = match get_unlock_block_time(
+                wallet.address(),
+                &eth_rpc_url,
+                args.network.clone().into(),
+            )
+            .await
+            {
+                Ok(value) => value,
+                Err(e) => {
+                    error!("Failed to get : {:?}", e);
+                    return Ok(());
+                }
+            };
+
+            let current_timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs();
+
+            let unlock_time = UtcTime::from_unix_duration(Duration::from_secs(unlock_block_time))
+                .expect("invalid unlock time");
+            let now_time =
+                UtcTime::from_system_time(SystemTime::now()).expect("invalid system time");
+
+            let retry_after_minutes = if unlock_block_time > current_timestamp {
+                (unlock_block_time - current_timestamp) / 60
+            } else {
+                0
+            };
+
+            if unlock_block_time == 0 {
+                error!("Funds are locked, you need to unlock them first.");
+                return Ok(());
+            }
+
+            if unlock_block_time > current_timestamp {
+                warn!(
+                    "Funds are still locked. You need to wait {} minutes before being able to withdraw after unlocking the funds.\n\
+                    Unlocks in block time: {}\n\
+                    Current time: {}",
+                    retry_after_minutes,
+                    format_utc_time(unlock_time),
+                    format_utc_time(now_time)
+                );
+
+                return Ok(());
+            }
+
             let chain_id = get_chain_id(eth_rpc_url.as_str()).await?;
             wallet = wallet.with_chain_id(chain_id);
 
@@ -1207,4 +1260,18 @@ pub async fn get_user_balance(
             "Invalid response from contract".to_string(),
         ))
     }
+}
+
+fn format_utc_time(date: UtcTime) -> String {
+    let dt = date.to_date_time();
+
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}Z",
+        dt.year(),
+        dt.month(),
+        dt.day(),
+        dt.hour(),
+        dt.minutes(),
+        dt.seconds()
+    )
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -936,7 +936,7 @@ async fn main() -> Result<(), AlignedError> {
             {
                 Ok(value) => value,
                 Err(e) => {
-                    error!("Failed to get : {:?}", e);
+                    error!("Failed to get unlock time: {:?}", e);
                     return Ok(());
                 }
             };

--- a/crates/sdk/src/eth/batcher_payment_service.rs
+++ b/crates/sdk/src/eth/batcher_payment_service.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ethers::prelude::*;
+use ethers::{core::k256::ecdsa::SigningKey, prelude::*};
 
 use crate::common::errors::VerificationError;
 
@@ -10,6 +10,9 @@ abigen!(
 );
 
 pub type BatcherPaymentService = BatcherPaymentServiceContract<Provider<Http>>;
+
+pub type SignerMiddlewareT = SignerMiddleware<Provider<Http>, Wallet<SigningKey>>;
+pub type BatcherPaymentServiceWithSigner = BatcherPaymentServiceContract<SignerMiddlewareT>;
 
 pub async fn batcher_payment_service(
     provider: Provider<Http>,

--- a/crates/sdk/src/verification_layer/mod.rs
+++ b/crates/sdk/src/verification_layer/mod.rs
@@ -5,7 +5,7 @@ use crate::{
             DEFAULT_MAX_FEE_BATCH_SIZE, GAS_PRICE_PERCENTAGE_MULTIPLIER,
             INSTANT_MAX_FEE_BATCH_SIZE, PERCENTAGE_DIVIDER,
         },
-        errors::{self, GetNonceError},
+        errors::{self, GetNonceError, PaymentError},
         types::{
             AlignedVerificationData, ClientMessage, FeeEstimationType, GetNonceResponseMessage,
             Network, ProvingSystemId, VerificationData,
@@ -19,7 +19,7 @@ use crate::{
     },
     eth::{
         aligned_service_manager::aligned_service_manager,
-        batcher_payment_service::batcher_payment_service,
+        batcher_payment_service::{batcher_payment_service, BatcherPaymentServiceWithSigner},
     },
 };
 
@@ -747,6 +747,73 @@ pub async fn get_balance_in_aligned(
             Ok(result)
         }
         Err(e) => Err(errors::BalanceError::EthereumCallError(e.to_string())),
+    }
+}
+
+pub async fn unlock_balance_in_aligned(
+    signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
+    network: Network,
+) -> Result<ethers::types::TransactionReceipt, errors::PaymentError> {
+    let payment_service_address = network.get_batcher_payment_service_address();
+    let payment_service =
+        BatcherPaymentServiceWithSigner::new(payment_service_address, signer.clone().into());
+
+    let receipt = payment_service
+        .unlock()
+        .send()
+        .await
+        .map_err(|e| PaymentError::SendError(e.to_string()))?
+        .await
+        .map_err(|e| PaymentError::SubmitError(e.to_string()))?;
+
+    match receipt {
+        Some(hash) => Ok(hash),
+        None => Err(PaymentError::SubmitError("".into())),
+    }
+}
+
+pub async fn lock_balance_in_aligned(
+    signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
+    network: Network,
+) -> Result<ethers::types::TransactionReceipt, errors::PaymentError> {
+    let payment_service_address = network.get_batcher_payment_service_address();
+    let payment_service =
+        BatcherPaymentServiceWithSigner::new(payment_service_address, signer.clone().into());
+
+    let receipt = payment_service
+        .lock()
+        .send()
+        .await
+        .map_err(|e| PaymentError::SendError(e.to_string()))?
+        .await
+        .map_err(|e| PaymentError::SubmitError(e.to_string()))?;
+
+    match receipt {
+        Some(hash) => Ok(hash),
+        None => Err(PaymentError::SubmitError("".into())),
+    }
+}
+
+pub async fn withdraw_balance_from_aligned(
+    signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
+    network: Network,
+    amount: U256,
+) -> Result<ethers::types::TransactionReceipt, errors::PaymentError> {
+    let payment_service_address = network.get_batcher_payment_service_address();
+    let payment_service =
+        BatcherPaymentServiceWithSigner::new(payment_service_address, signer.clone().into());
+
+    let receipt = payment_service
+        .withdraw(amount)
+        .send()
+        .await
+        .map_err(|e| PaymentError::SendError(e.to_string()))?
+        .await
+        .map_err(|e| PaymentError::SubmitError(e.to_string()))?;
+
+    match receipt {
+        Some(hash) => Ok(hash),
+        None => Err(PaymentError::SubmitError("".into())),
     }
 }
 

--- a/crates/sdk/src/verification_layer/mod.rs
+++ b/crates/sdk/src/verification_layer/mod.rs
@@ -750,6 +750,22 @@ pub async fn get_balance_in_aligned(
     }
 }
 
+/// Unlocks the balance of a user in the Aligned payment service.
+///
+/// This function initiates an unlock request for the user's balance. After calling this function,
+/// the user's balance will be locked for a certain period before it can be withdrawn.
+/// Use [`get_unlock_block_time`] to check when the balance can be withdrawn.
+///
+/// # Arguments
+/// * `signer` - The signer middleware containing the user's wallet and provider.
+/// * `network` - The network on which the unlock operation will be performed.
+///
+/// # Returns
+/// * The transaction receipt of the unlock operation.
+///
+/// # Errors
+/// * `SendError` if there is an error sending the transaction.
+/// * `SubmitError` if there is an error submitting the transaction.
 pub async fn unlock_balance_in_aligned(
     signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
     network: Network,
@@ -772,6 +788,22 @@ pub async fn unlock_balance_in_aligned(
     }
 }
 
+/// Locks the balance of a user in the Aligned payment service.
+///
+/// This function locks the user's balance, preventing it from being withdrawn.
+/// Locked balances can be used for proof verification payments but cannot be withdrawn
+/// until they are unlocked using [`unlock_balance_in_aligned`] and the unlock period expires.
+///
+/// # Arguments
+/// * `signer` - The signer middleware containing the user's wallet and provider.
+/// * `network` - The network on which the lock operation will be performed.
+///
+/// # Returns
+/// * The transaction receipt of the lock operation.
+///
+/// # Errors
+/// * `SendError` if there is an error sending the transaction.
+/// * `SubmitError` if there is an error submitting the transaction.
 pub async fn lock_balance_in_aligned(
     signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
     network: Network,
@@ -794,6 +826,22 @@ pub async fn lock_balance_in_aligned(
     }
 }
 
+/// Returns the timestamp when a user's balance will be unlocked and available for withdrawal.
+///
+/// After calling [`unlock_balance_in_aligned`], users must wait for the lock period
+/// before they can withdraw their funds using [`withdraw_balance_from_aligned`].
+///
+/// # Arguments
+/// * `user` - The address of the user to check the unlock time for.
+/// * `eth_rpc_url` - The URL of the Ethereum RPC node.
+/// * `network` - The network on which to check the unlock time.
+///
+/// # Returns
+/// * The timestamp when the user's balance will be unlocked (as u64).
+///
+/// # Errors
+/// * `EthereumProviderError` if there is an error in the connection with the RPC provider.
+/// * `EthereumCallError` if there is an error in the Ethereum call.
 pub async fn get_unlock_block_time(
     user: Address,
     eth_rpc_url: &str,
@@ -819,6 +867,22 @@ pub async fn get_unlock_block_time(
     }
 }
 
+/// Withdraws a specified amount from the user's balance in the Aligned payment service.
+///
+/// This function can only be called after the balance has been unlocked using [`unlock_balance_in_aligned`]
+/// and the lock period has expired. Use [`get_unlock_block_time`] to check when the withdrawal becomes available.
+///
+/// # Arguments
+/// * `signer` - The signer middleware containing the user's wallet and provider.
+/// * `network` - The network on which the withdrawal will be performed.
+/// * `amount` - The amount to withdraw from the user's balance.
+///
+/// # Returns
+/// * The transaction receipt of the withdrawal operation.
+///
+/// # Errors
+/// * `SendError` if there is an error sending the transaction.
+/// * `SubmitError` if there is an error submitting the transaction.
 pub async fn withdraw_balance_from_aligned(
     signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
     network: Network,

--- a/crates/sdk/src/verification_layer/mod.rs
+++ b/crates/sdk/src/verification_layer/mod.rs
@@ -794,6 +794,31 @@ pub async fn lock_balance_in_aligned(
     }
 }
 
+pub async fn get_unlock_block_time(
+    user: Address,
+    eth_rpc_url: &str,
+    network: Network,
+) -> Result<u64, errors::BalanceError> {
+    let eth_rpc_provider = Provider::<Http>::try_from(eth_rpc_url)
+        .map_err(|e| errors::BalanceError::EthereumProviderError(e.to_string()))?;
+
+    let payment_service_address = network.get_batcher_payment_service_address();
+
+    match batcher_payment_service(eth_rpc_provider, payment_service_address).await {
+        Ok(batcher_payment_service) => {
+            let call = batcher_payment_service.user_unlock_block(user);
+
+            let result = call
+                .call()
+                .await
+                .map_err(|e| errors::BalanceError::EthereumCallError(e.to_string()))?;
+
+            Ok(result.as_u64())
+        }
+        Err(e) => Err(errors::BalanceError::EthereumCallError(e.to_string())),
+    }
+}
+
 pub async fn withdraw_balance_from_aligned(
     signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
     network: Network,

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -432,6 +432,126 @@ pub async fn get_balance_in_aligned(
 - `EthereumProviderError` if there is an error in the connection with the RPC provider.
 - `EthereumCallError` if there is an error in the Ethereum call.
 
+### `lock_balance_in_aligned`
+
+Locks the balance of a user in the Aligned payment service.
+
+```rust
+pub async fn lock_balance_in_aligned(
+    signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
+    network: Network,
+) -> Result<ethers::types::TransactionReceipt, errors::PaymentError>
+```
+
+#### Arguments
+
+- `signer` - The signer middleware containing the user's wallet and provider.
+- `network` - The network on which the lock operation will be performed.
+
+#### Returns
+
+- `Result<ethers::types::TransactionReceipt, errors::PaymentError>` - The transaction receipt of the lock operation.
+
+#### Description
+
+This function locks the user's balance, preventing it from being withdrawn. Locked balances can be used for proof verification payments but cannot be withdrawn until they are unlocked using `unlock_balance_in_aligned` and the lock period expires.
+
+#### Errors
+
+- `SendError` if there is an error sending the transaction.
+- `SubmitError` if there is an error submitting the transaction.
+
+### `unlock_balance_in_aligned`
+
+Unlocks the balance of a user in the Aligned payment service.
+
+```rust
+pub async fn unlock_balance_in_aligned(
+    signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
+    network: Network,
+) -> Result<ethers::types::TransactionReceipt, errors::PaymentError>
+```
+
+#### Arguments
+
+- `signer` - The signer middleware containing the user's wallet and provider.
+- `network` - The network on which the unlock operation will be performed.
+
+#### Returns
+
+- `Result<ethers::types::TransactionReceipt, errors::PaymentError>` - The transaction receipt of the unlock operation.
+
+#### Description
+
+This function initiates an unlock request for the user's balance. After calling this function, the user's balance will be locked for a certain period before it can be withdrawn. Use `get_unlock_block_time` to check when the balance can be withdrawn.
+
+#### Errors
+
+- `SendError` if there is an error sending the transaction.
+- `SubmitError` if there is an error submitting the transaction.
+
+### `get_unlock_block_time`
+
+Returns the timestamp when a user's balance will be unlocked and available for withdrawal.
+
+```rust
+pub async fn get_unlock_block_time(
+    user: Address,
+    eth_rpc_url: &str,
+    network: Network,
+) -> Result<u64, errors::BalanceError>
+```
+
+#### Arguments
+
+- `user` - The address of the user to check the unlock time for.
+- `eth_rpc_url` - The URL of the Ethereum RPC node.
+- `network` - The network on which to check the unlock time.
+
+#### Returns
+
+- `Result<u64, errors::BalanceError>` - The timestamp when the user's balance will be unlocked (as u64).
+
+#### Description
+
+After calling `unlock_balance_in_aligned`, users must wait for the lock period before they can withdraw their funds using `withdraw_balance_from_aligned`.
+
+#### Errors
+
+- `EthereumProviderError` if there is an error in the connection with the RPC provider.
+- `EthereumCallError` if there is an error in the Ethereum call.
+
+### `withdraw_balance_from_aligned`
+
+Withdraws a specified amount from the user's balance in the Aligned payment service.
+
+```rust
+pub async fn withdraw_balance_from_aligned(
+    signer: &SignerMiddleware<Provider<Http>, LocalWallet>,
+    network: Network,
+    amount: U256,
+) -> Result<ethers::types::TransactionReceipt, errors::PaymentError>
+```
+
+#### Arguments
+
+- `signer` - The signer middleware containing the user's wallet and provider.
+- `network` - The network on which the withdrawal will be performed.
+- `amount` - The amount to withdraw from the user's balance.
+
+#### Returns
+
+- `Result<ethers::types::TransactionReceipt, errors::PaymentError>` - The transaction receipt of the withdrawal operation.
+
+#### Description
+
+This function can only be called after the balance has been unlocked using `unlock_balance_in_aligned` and the lock period has expired. Use `get_unlock_block_time` to check when the withdrawal becomes available.
+
+#### Errors
+
+- `SendError` if there is an error sending the transaction.
+- `SubmitError` if there is an error submitting the transaction.
+
 ### `get_vk_commitment`
 
 Returns the commitment for the verification key, taking into account the corresponding proving system.

--- a/docs/3_guides/1.2_SDK_api_reference.md
+++ b/docs/3_guides/1.2_SDK_api_reference.md
@@ -510,7 +510,7 @@ pub async fn get_unlock_block_time(
 
 #### Returns
 
-- `Result<u64, errors::BalanceError>` - The timestamp when the user's balance will be unlocked (as u64).
+- `Result<u64, errors::BalanceError>` - The timestamp when the user's balance will be unlocked.
 
 #### Description
 

--- a/docs/3_guides/9_aligned_cli.md
+++ b/docs/3_guides/9_aligned_cli.md
@@ -392,8 +392,8 @@ Locks funds in the batcher. Locked balances can be used for proof verification p
 
 ```bash
 aligned lock-funds \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com \
 --keystore_path <KEYSTORE_PATH>
 ```
 
@@ -432,8 +432,8 @@ Unlocks funds from the batcher. After calling this command, users must wait for 
 
 ```bash
 aligned unlock-funds \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com \
 --keystore_path <KEYSTORE_PATH>
 ```
 
@@ -473,8 +473,8 @@ Withdraws a specified amount from the user's balance in the batcher. This comman
 
 ```bash
 aligned withdraw-funds \
---network holesky \
---rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--network hoodi \
+--rpc_url https://ethereum-hoodi-rpc.publicnode.com \
 --amount 0.5ether \
 --keystore_path <KEYSTORE_PATH>
 ```

--- a/docs/3_guides/9_aligned_cli.md
+++ b/docs/3_guides/9_aligned_cli.md
@@ -359,6 +359,128 @@ aligned get-user-amount-of-queued-proofs  \
 
 ---
 
+### **lock-funds**
+
+#### Description:
+
+Locks funds in the batcher. Locked balances can be used for proof verification payments but cannot be withdrawn until they are unlocked and the lock period expires.
+
+#### Command:
+
+`lock-funds [OPTIONS]`
+
+#### Options:
+
+- `--keystore_path <path_to_local_keystore>`: Path to the local keystore.
+- `--private_key <private_key>`: User's wallet private key.
+- `--rpc_url <RPC_provider_url>`: User's Ethereum RPC provider connection address. 
+  - Default: `http://localhost:8545`
+  - Mainnet: `https://ethereum-rpc.publicnode.com`
+  - Holesky: `https://ethereum-holesky-rpc.publicnode.com`
+  - Hoodi: `https://ethereum-hoodi-rpc.publicnode.com`
+  - Also, you can use your own Ethereum RPC providers.
+- One of the following, to specify which Network to interact with:
+  - `--network <working_network_name>`: Network name to interact with.  
+    - Default: `devnet`  
+    - Possible values: `devnet`, `holesky`, `mainnet`, `hoodi`
+  - For a custom Network, you must specify the following parameters:
+    - `--aligned_service_manager <aligned_service_manager_contract_address>`
+    - `--batcher_payment_service <batcher_payment_service_contract_address>`
+    - `--batcher_url <batcher_websocket_url>`
+
+#### Example:
+
+```bash
+aligned lock-funds \
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--keystore_path <KEYSTORE_PATH>
+```
+
+---
+
+### **unlock-funds**
+
+#### Description:
+
+Unlocks funds from the batcher. After calling this command, users must wait for the lock period before they can withdraw their funds using `withdraw-funds`.
+
+#### Command:
+
+`unlock-funds [OPTIONS]`
+
+#### Options:
+
+- `--keystore_path <path_to_local_keystore>`: Path to the local keystore.
+- `--private_key <private_key>`: User's wallet private key.
+- `--rpc_url <RPC_provider_url>`: User's Ethereum RPC provider connection address. 
+  - Default: `http://localhost:8545`
+  - Mainnet: `https://ethereum-rpc.publicnode.com`
+  - Holesky: `https://ethereum-holesky-rpc.publicnode.com`
+  - Hoodi: `https://ethereum-hoodi-rpc.publicnode.com`
+  - Also, you can use your own Ethereum RPC providers.
+- One of the following, to specify which Network to interact with:
+  - `--network <working_network_name>`: Network name to interact with.  
+    - Default: `devnet`  
+    - Possible values: `devnet`, `holesky`, `mainnet`, `hoodi`
+  - For a custom Network, you must specify the following parameters:
+    - `--aligned_service_manager <aligned_service_manager_contract_address>`
+    - `--batcher_payment_service <batcher_payment_service_contract_address>`
+    - `--batcher_url <batcher_websocket_url>`
+
+#### Example:
+
+```bash
+aligned unlock-funds \
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--keystore_path <KEYSTORE_PATH>
+```
+
+---
+
+### **withdraw-funds**
+
+#### Description:
+
+Withdraws a specified amount from the user's balance in the batcher. This command can only be used after the balance has been unlocked using `unlock-funds` and the lock period has expired.
+
+#### Command:
+
+`withdraw-funds [OPTIONS] --amount <amount_to_withdraw>`
+
+#### Options:
+
+- `--keystore_path <path_to_local_keystore>`: Path to the local keystore.
+- `--private_key <private_key>`: User's wallet private key.
+- `--rpc_url <RPC_provider_url>`: User's Ethereum RPC provider connection address. 
+  - Default: `http://localhost:8545`
+  - Mainnet: `https://ethereum-rpc.publicnode.com`
+  - Holesky: `https://ethereum-holesky-rpc.publicnode.com`
+  - Hoodi: `https://ethereum-hoodi-rpc.publicnode.com`
+  - Also, you can use your own Ethereum RPC providers.
+- `--amount <amount (ether)>`: Amount of Ether to withdraw.
+- One of the following, to specify which Network to interact with:
+  - `--network <working_network_name>`: Network name to interact with.  
+    - Default: `devnet`  
+    - Possible values: `devnet`, `holesky`, `mainnet`, `hoodi`
+  - For a custom Network, you must specify the following parameters:
+    - `--aligned_service_manager <aligned_service_manager_contract_address>`
+    - `--batcher_payment_service <batcher_payment_service_contract_address>`
+    - `--batcher_url <batcher_websocket_url>`
+
+#### Example:
+
+```bash
+aligned withdraw-funds \
+--network holesky \
+--rpc_url https://ethereum-holesky-rpc.publicnode.com \
+--amount 0.5ether \
+--keystore_path <KEYSTORE_PATH>
+```
+
+---
+
 ### **verify-agg-proof**
 
 #### Description:


### PR DESCRIPTION
## Description

Adds `unlock`, `lock` and `withdraw` funds from aligned in sdk and cli.

**How to test**

1. Start anvil:
```shell
make anvil_start
```

2. Deposit in aligned (for example with a anvil rich account):
```shell
cd crates/cli
cargo run --release -- deposit-to-batcher \
    --amount 1ether \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
    --network devnet \
    --rpc_url http://localhost:8545
```

3. Try to withdraw:
```shell
cd crates/cli
cargo run --release -- withdraw-funds \
    --amount 1ether \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
    --network devnet \
    --rpc_url http://localhost:8545
```

You should see that the cli tells you that you need to unlock your funds first.

4. Unlock your funds:
```shell
cargo run --release -- unlock-funds \
    --network devnet \
    --rpc_url http://localhost:8545 \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97
```

5. Try to withdraw again:
```shell
cd crates/cli
cargo run --release -- withdraw-funds \
    --amount 1ether \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
    --network devnet \
    --rpc_url http://localhost:8545
```

You should see that the cli shows the minutes needed to wait to withdraw

6. Advance blocks:
```shell
 curl http://localhost:8545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[20000],"id":1}'
```

7. Withdraw your funds:
```shell
cd crates/cli
cargo run --release -- withdraw-funds \
    --amount 1ether \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97 \
    --network devnet \
    --rpc_url http://localhost:8545
```

8. Verify your funds have been withdrawn:
```shell
cargo run --release -- get-user-balance --network devnet --user_addr 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f
```


You can also test locking your funds after unlocking them:
```shell
cargo run --release -- funds \
    --network devnet \
    --rpc_url http://localhost:8545 \
    --private_key 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97
```



## Type of change

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
