### PR TITLE
fix: check proof length in gnark

### DIFF
--- a/config-files/config-operator-1-ethereum-package.yaml
+++ b/config-files/config-operator-1-ethereum-package.yaml
@@ -31,6 +31,7 @@ operator:
   enable_metrics: true
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator-1.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 

--- a/config-files/config-operator-1.yaml
+++ b/config-files/config-operator-1.yaml
@@ -31,6 +31,7 @@ operator:
   enable_metrics: true
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator-1.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 

--- a/config-files/config-operator-2.yaml
+++ b/config-files/config-operator-2.yaml
@@ -29,6 +29,7 @@ operator:
   staker_opt_out_window_blocks: 0
   metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator-2.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 

--- a/config-files/config-operator-3.yaml
+++ b/config-files/config-operator-3.yaml
@@ -29,6 +29,7 @@ operator:
   staker_opt_out_window_blocks: 0
   metadata_url: 'https://yetanotherco.github.io/operator_metadata/metadata.json'
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator-3.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 

--- a/config-files/config-operator-docker.yaml
+++ b/config-files/config-operator-docker.yaml
@@ -31,6 +31,7 @@ operator:
   enable_metrics: true
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: config-files/operator.last_processed_batch.json
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified
 # Operators variables needed for register it in EigenLayer

--- a/config-files/config-operator-holesky.yaml
+++ b/config-files/config-operator-holesky.yaml
@@ -31,5 +31,6 @@ operator:
   enable_metrics: true
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified

--- a/config-files/config-operator-hoodi.yaml
+++ b/config-files/config-operator-hoodi.yaml
@@ -31,5 +31,6 @@ operator:
   enable_metrics: true
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified

--- a/config-files/config-operator-mainnet.yaml
+++ b/config-files/config-operator-mainnet.yaml
@@ -31,5 +31,6 @@ operator:
   enable_metrics: true
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified

--- a/config-files/config-operator-sepolia.yaml
+++ b/config-files/config-operator-sepolia.yaml
@@ -31,5 +31,6 @@ operator:
   enable_metrics: true
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified

--- a/config-files/config-operator.yaml
+++ b/config-files/config-operator.yaml
@@ -31,5 +31,6 @@ operator:
   enable_metrics: true
   metrics_ip_port_address: localhost:9092
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: 'config-files/operator.last_processed_batch.json'
   poll_latest_batch_interval: 20s # Optional: The interval to poll for latest batches. Default: 20s if not specified

--- a/core/config/operator.go
+++ b/core/config/operator.go
@@ -27,6 +27,7 @@ type OperatorConfig struct {
 		EnableMetrics                 bool
 		MetricsIpPortAddress          string
 		MaxBatchSize                  int64
+		MaxProofSize                  uint32
 		LastProcessedBatchFilePath    string
 		PollLatestBatchInterval       time.Duration
 	}
@@ -45,6 +46,7 @@ type OperatorConfigFromYaml struct {
 		EnableMetrics                 bool           `yaml:"enable_metrics"`
 		MetricsIpPortAddress          string         `yaml:"metrics_ip_port_address"`
 		MaxBatchSize                  int64          `yaml:"max_batch_size"`
+		MaxProofSize                  uint32         `yaml:"max_proof_size"`
 		LastProcessedBatchFilePath    string         `yaml:"last_processed_batch_filepath"`
 		PollLatestBatchInterval       string         `yaml:"poll_latest_batch_interval"`
 	} `yaml:"operator"`
@@ -80,6 +82,11 @@ func NewOperatorConfig(configFilePath string) *OperatorConfig {
 		}
 	}
 
+	maxProofSize := uint32(10 * 1024 * 1024) // 10MB default
+	if operatorConfigFromYaml.Operator.MaxProofSize > 0 {
+		maxProofSize = operatorConfigFromYaml.Operator.MaxProofSize
+	}
+
 	return &OperatorConfig{
 		BaseConfig:                   baseConfig,
 		BlsConfig:                    blsConfig,
@@ -96,6 +103,7 @@ func NewOperatorConfig(configFilePath string) *OperatorConfig {
 			EnableMetrics                 bool
 			MetricsIpPortAddress          string
 			MaxBatchSize                  int64
+			MaxProofSize                  uint32
 			LastProcessedBatchFilePath    string
 			PollLatestBatchInterval       time.Duration
 		}{
@@ -110,6 +118,7 @@ func NewOperatorConfig(configFilePath string) *OperatorConfig {
 			EnableMetrics:                 operatorConfigFromYaml.Operator.EnableMetrics,
 			MetricsIpPortAddress:          operatorConfigFromYaml.Operator.MetricsIpPortAddress,
 			MaxBatchSize:                  operatorConfigFromYaml.Operator.MaxBatchSize,
+			MaxProofSize:                  maxProofSize,
 			LastProcessedBatchFilePath:    operatorConfigFromYaml.Operator.LastProcessedBatchFilePath,
 			PollLatestBatchInterval:       pollInterval,
 		},

--- a/crates/batcher/go_verifiers_lib/verifier.go
+++ b/crates/batcher/go_verifiers_lib/verifier.go
@@ -13,8 +13,10 @@ import "C"
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 
 	"log"
@@ -27,6 +29,8 @@ import (
 	"github.com/iden3/go-rapidsnark/types"
 	"github.com/iden3/go-rapidsnark/verifier"
 )
+
+const MaxProofSize = 10 * 1024 * 1024 // 10 MB
 
 func listRefToBytes(listRef C.ListRef) []byte {
 
@@ -54,11 +58,32 @@ func VerifyGnarkGroth16ProofBN254(proofBytes C.ListRef, pubInputBytes C.ListRef,
 	return verifyGnarkGroth16Proof(proofBytes, pubInputBytes, verificationKeyBytes, ecc.BN254)
 }
 
+func gnarkProofLength(proofBytes []byte) (uint32, error) {
+	const HeaderSize = 4
+	r := bytes.NewReader(proofBytes)
+	var buf [HeaderSize]byte
+	if read, err := io.ReadFull(r, buf[:HeaderSize]); err != nil {
+		return uint32(read), err
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:HeaderSize])
+	return sliceLen, nil
+}
+
 // verifyGnarkPlonkProof contains the common proof verification logic.
 func verifyGnarkPlonkProof(proofBytesRef C.ListRef, pubInputBytesRef C.ListRef, verificationKeyBytesRef C.ListRef, curve ecc.ID) bool {
 	proofBytes := listRefToBytes(proofBytesRef)
 	pubInputBytes := listRefToBytes(pubInputBytesRef)
 	verificationKeyBytes := listRefToBytes(verificationKeyBytesRef)
+
+	proofLength, err := gnarkProofLength(proofBytes)
+	if err != nil {
+		log.Printf("Could not determine proof length: %v", err)
+		return false
+	}
+	if proofLength > MaxProofSize {
+		log.Printf("Proof size exceeds maximum limit of %d bytes", MaxProofSize)
+		return false
+	}
 
 	proofReader := bytes.NewReader(proofBytes)
 	proof := plonk.NewProof(curve)
@@ -94,6 +119,16 @@ func verifyGnarkGroth16Proof(proofBytesRef C.ListRef, pubInputBytesRef C.ListRef
 	proofBytes := listRefToBytes(proofBytesRef)
 	pubInputBytes := listRefToBytes(pubInputBytesRef)
 	verificationKeyBytes := listRefToBytes(verificationKeyBytesRef)
+
+	proofLength, err := gnarkProofLength(proofBytes)
+	if err != nil {
+		log.Printf("Could not determine proof length: %v", err)
+		return false
+	}
+	if proofLength > MaxProofSize {
+		log.Printf("Proof size exceeds maximum limit of %d bytes", MaxProofSize)
+		return false
+	}
 
 	proofReader := bytes.NewReader(proofBytes)
 	proof := groth16.NewProof(curve)

--- a/infra/ansible/playbooks/templates/config-files/config-operator.yaml.j2
+++ b/infra/ansible/playbooks/templates/config-files/config-operator.yaml.j2
@@ -31,4 +31,5 @@ operator:
   enable_metrics: {{ enable_metrics }}
   metrics_ip_port_address: "{{ metrics_ip_port_address }}"
   max_batch_size: 268435456 # 256 MiB
+  max_proof_size: 10485760 # 10 MiB (default if not specified)
   last_processed_batch_filepath: "{{ last_processed_batch_filepath }}"

--- a/operator/pkg/operator.go
+++ b/operator/pkg/operator.go
@@ -3,9 +3,11 @@ package operator
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"math/big"
 	"net/http"
@@ -72,6 +74,17 @@ const (
 	BatchDownloadRetryDelay = 5 * time.Second
 	UnverifiedBatchOffset   = 100
 )
+
+func gnarkProofLength(proofBytes []byte) (uint32, error) {
+	const HeaderSize = 4
+	r := bytes.NewReader(proofBytes)
+	var buf [HeaderSize]byte
+	if read, err := io.ReadFull(r, buf[:HeaderSize]); err != nil {
+		return uint32(read), err
+	}
+	sliceLen := binary.BigEndian.Uint32(buf[:HeaderSize])
+	return sliceLen, nil
+}
 
 func NewOperatorFromConfig(configuration config.OperatorConfig) (*Operator, error) {
 	logger := configuration.BaseConfig.Logger
@@ -457,6 +470,16 @@ func (o *Operator) verifyGnarkGroth16ProofBN254(proofBytes []byte, pubInputBytes
 
 // verifyGnarkPlonkProof contains the common proof verification logic.
 func (o *Operator) verifyGnarkPlonkProof(proofBytes []byte, pubInputBytes []byte, verificationKeyBytes []byte, curve ecc.ID) bool {
+	proofLength, err := gnarkProofLength(proofBytes)
+	if err != nil {
+		o.Logger.Infof("Could not determine proof length: %v", err)
+		return false
+	}
+	if proofLength > o.Config.Operator.MaxProofSize {
+		o.Logger.Infof("Proof size exceeds maximum limit of %d bytes", o.Config.Operator.MaxProofSize)
+		return false
+	}
+
 	proofReader := bytes.NewReader(proofBytes)
 	proof := plonk.NewProof(curve)
 	if _, err := proof.ReadFrom(proofReader); err != nil {
@@ -488,6 +511,16 @@ func (o *Operator) verifyGnarkPlonkProof(proofBytes []byte, pubInputBytes []byte
 
 // verifyGnarkGroth16Proof contains the common proof verification logic.
 func (o *Operator) verifyGnarkGroth16Proof(proofBytes []byte, pubInputBytes []byte, verificationKeyBytes []byte, curve ecc.ID) bool {
+	proofLength, err := gnarkProofLength(proofBytes)
+	if err != nil {
+		o.Logger.Infof("Could not determine proof length: %v", err)
+		return false
+	}
+	if proofLength > o.Config.Operator.MaxProofSize {
+		o.Logger.Infof("Proof size exceeds maximum limit of %d bytes", o.Config.Operator.MaxProofSize)
+		return false
+	}
+
 	proofReader := bytes.NewReader(proofBytes)
 	proof := groth16.NewProof(curve)
 	if _, err := proof.ReadFrom(proofReader); err != nil {


### PR DESCRIPTION
# fix: check proof length in gnark

## Description

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
