### PR TITLE
fix(zkquiz): use compressed mode for sp1

### DIFF
--- a/docs/3_guides/2_build_your_first_aligned_application.md
+++ b/docs/3_guides/2_build_your_first_aligned_application.md
@@ -237,7 +237,7 @@ println!("Generating Proof ");
 let client = ProverClient::new();
 let (pk, vk) = client.setup(ELF);
 
-let Ok(proof) = client.prove(&pk, stdin).run() else {
+let Ok(proof) = client.prove(&pk, stdin).compressed().run() else {
     println!("Incorrect answers!");
     return;
 };

--- a/examples/zkquiz/quiz/script/src/main.rs
+++ b/examples/zkquiz/quiz/script/src/main.rs
@@ -183,7 +183,7 @@ async fn main() {
     let client = ProverClient::from_env();
     let (pk, vk) = client.setup(ELF);
 
-    let Ok(proof) = client.prove(&pk, &stdin).run() else {
+    let Ok(proof) = client.prove(&pk, &stdin).compressed().run() else {
         println!("Incorrect answers!");
         return;
     };


### PR DESCRIPTION
# fix(zkquiz): use compressed mode for sp1

## Description

The non-compressed proof is bigger than the max size allowed by the batcher

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
