### PR TITLE
fix: update periodic sender script conditions

### DIFF
--- a/alerts/periodic_sender.sh
+++ b/alerts/periodic_sender.sh
@@ -53,43 +53,43 @@ while true; do
         # Between 1 and 3 elapsed intervals (5 to 15 minutes), if gas price is below 1.5 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        send_proof_background()
+        send_proof_background
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 3 ] && [ $elapsed_intervals -lt 6 ] && [ $current_gas_price -lt 4500000000 ]; }; then
         # Between 3 and 6 elapsed intervals (15 to 30 minutes), if gas price is below 4.5 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        send_proof_background()
+        send_proof_background
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 6 ] && [ $elapsed_intervals -lt 12 ] && [ $current_gas_price -lt 9000000000 ]; }; then
         # Between 6 and 12 elapsed intervals (30 minutes to 1 hour), if gas price is below 9 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        send_proof_background()
+        send_proof_background
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 12 ] && [ $elapsed_intervals -lt 24 ] && [ $current_gas_price -lt 24000000000 ]; }; then
         # Between 12 and 24 elapsed intervals (1 to 2 hours), if gas price is below 24 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        send_proof_background()
+        send_proof_background
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 24 ] && [ $elapsed_intervals -lt 48 ] && [ $current_gas_price -lt 48000000000 ]; }; then
         # Between 24 and 48 elapsed intervals (2 to 4 hours), if gas price is below 48 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        send_proof_background()
+        send_proof_background
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 48 ] && [ $elapsed_intervals -lt 96 ] && [ $current_gas_price -lt 96000000000 ]; }; then
         # Between 48 and 96 elapsed intervals (4 to 8 hours), if gas price is below 96 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        send_proof_background()
+        send_proof_background
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 96 ] && [ $current_gas_price -lt 192000000000 ]; }; then
         # After 96 elapsed intervals (8 hours), if gas price is below 192 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        send_proof_background()
+        send_proof_background
         elapsed_intervals=0
     fi
 

--- a/alerts/periodic_sender.sh
+++ b/alerts/periodic_sender.sh
@@ -11,7 +11,7 @@ if [[ -z "$ENV_FILE" ]]; then
 fi
 
 function send_proof_background() {
-    ./alerts/sender_with_alert.sh "$ENV_FILE"
+    ./alerts/sender_with_alert.sh "$ENV_FILE" &
 }
 
 # Fetches the current ETH gas price

--- a/alerts/periodic_sender.sh
+++ b/alerts/periodic_sender.sh
@@ -23,8 +23,8 @@ function fetch_gas_price() {
 
 source "$ENV_FILE"
 
-# Each elapsed interval lasts for 30 minutes
-sleep_time=1800
+# Each elapsed interval lasts for 5 minutes
+sleep_time=300
 elapsed_intervals=0
 
 ./alerts/sender_with_alert.sh "$ENV_FILE"
@@ -45,26 +45,44 @@ while true; do
     echo "Current gas price: $current_gas_price wei"
 
     # In case current and gas price meet the criteria, send a proof and reset counter
-    if { [ $elapsed_intervals -ge 10 ] && [ $elapsed_intervals -lt 14 ] && [ $current_gas_price -lt 2000000000 ]; }; then
-        # Between 10 and 14 elapsed intervals (5 to 7 hours), if gas price is below 2 gwei, send a proof
+    if { [ $elapsed_intervals -ge 1 ] && [ $elapsed_intervals -lt 3 ] && [ $current_gas_price -lt 1500000000 ]; }; then
+        # Between 1 and 3 elapsed intervals (5 to 15 minutes), if gas price is below 1.5 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
         ./alerts/sender_with_alert.sh "$ENV_FILE"
         elapsed_intervals=0
-    elif { [ $elapsed_intervals -ge 14 ] && [ $elapsed_intervals -lt 16 ] && [ $current_gas_price -lt 5000000000 ]; }; then
-        # Between 14 and 16 elapsed intervals (7 to 8 hours), if gas price is below 5 gwei, send a proof
+    elif { [ $elapsed_intervals -ge 3 ] && [ $elapsed_intervals -lt 6 ] && [ $current_gas_price -lt 4500000000 ]; }; then
+        # Between 3 and 6 elapsed intervals (15 to 30 minutes), if gas price is below 4.5 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
         ./alerts/sender_with_alert.sh "$ENV_FILE"
         elapsed_intervals=0
-    elif { [ $elapsed_intervals -ge 16 ] && [ $elapsed_intervals -lt 24 ] && [ $current_gas_price -lt 15000000000 ]; }; then
-        # Between 16 and 24 elapsed intervals (8 to 12 hours), if gas price is below 15 gwei, send a proof
+    elif { [ $elapsed_intervals -ge 6 ] && [ $elapsed_intervals -lt 12 ] && [ $current_gas_price -lt 9000000000 ]; }; then
+        # Between 6 and 12 elapsed intervals (30 minutes to 1 hour), if gas price is below 9 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
         ./alerts/sender_with_alert.sh "$ENV_FILE"
         elapsed_intervals=0
-    elif { [ $elapsed_intervals -ge 50 ]; }; then
-        # After 50 elapsed intervals (25 hours) send a proof
+    elif { [ $elapsed_intervals -ge 12 ] && [ $elapsed_intervals -lt 24 ] && [ $current_gas_price -lt 24000000000 ]; }; then
+        # Between 12 and 24 elapsed intervals (1 to 2 hours), if gas price is below 24 gwei, send a proof
+        message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
+        echo "$message"
+        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        elapsed_intervals=0
+    elif { [ $elapsed_intervals -ge 24 ] && [ $elapsed_intervals -lt 48 ] && [ $current_gas_price -lt 48000000000 ]; }; then
+        # Between 24 and 48 elapsed intervals (2 to 4 hours), if gas price is below 48 gwei, send a proof
+        message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
+        echo "$message"
+        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        elapsed_intervals=0
+    elif { [ $elapsed_intervals -ge 48 ] && [ $elapsed_intervals -lt 96 ] && [ $current_gas_price -lt 96000000000 ]; }; then
+        # Between 48 and 96 elapsed intervals (4 to 8 hours), if gas price is below 96 gwei, send a proof
+        message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
+        echo "$message"
+        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        elapsed_intervals=0
+    elif { [ $elapsed_intervals -ge 96 ] && [ $current_gas_price -lt 192000000000 ]; }; then
+        # After 96 elapsed intervals (8 hours), if gas price is below 192 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
         ./alerts/sender_with_alert.sh "$ENV_FILE"

--- a/alerts/periodic_sender.sh
+++ b/alerts/periodic_sender.sh
@@ -10,6 +10,10 @@ if [[ -z "$ENV_FILE" ]]; then
     exit 1
 fi
 
+function send_proof_background() {
+    ./alerts/sender_with_alert.sh "$ENV_FILE"
+}
+
 # Fetches the current ETH gas price
 function fetch_gas_price() {
     gas_price=$(cast gas-price --rpc-url $RPC_URL)
@@ -49,43 +53,43 @@ while true; do
         # Between 1 and 3 elapsed intervals (5 to 15 minutes), if gas price is below 1.5 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        send_proof_background()
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 3 ] && [ $elapsed_intervals -lt 6 ] && [ $current_gas_price -lt 4500000000 ]; }; then
         # Between 3 and 6 elapsed intervals (15 to 30 minutes), if gas price is below 4.5 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        send_proof_background()
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 6 ] && [ $elapsed_intervals -lt 12 ] && [ $current_gas_price -lt 9000000000 ]; }; then
         # Between 6 and 12 elapsed intervals (30 minutes to 1 hour), if gas price is below 9 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        send_proof_background()
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 12 ] && [ $elapsed_intervals -lt 24 ] && [ $current_gas_price -lt 24000000000 ]; }; then
         # Between 12 and 24 elapsed intervals (1 to 2 hours), if gas price is below 24 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        send_proof_background()
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 24 ] && [ $elapsed_intervals -lt 48 ] && [ $current_gas_price -lt 48000000000 ]; }; then
         # Between 24 and 48 elapsed intervals (2 to 4 hours), if gas price is below 48 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        send_proof_background()
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 48 ] && [ $elapsed_intervals -lt 96 ] && [ $current_gas_price -lt 96000000000 ]; }; then
         # Between 48 and 96 elapsed intervals (4 to 8 hours), if gas price is below 96 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        send_proof_background()
         elapsed_intervals=0
     elif { [ $elapsed_intervals -ge 96 ] && [ $current_gas_price -lt 192000000000 ]; }; then
         # After 96 elapsed intervals (8 hours), if gas price is below 192 gwei, send a proof
         message="Sending proof at $elapsed_intervals with gas price $current_gas_price wei"
         echo "$message"
-        ./alerts/sender_with_alert.sh "$ENV_FILE"
+        send_proof_background()
         elapsed_intervals=0
     fi
 

--- a/alerts/sender_with_alert.sh
+++ b/alerts/sender_with_alert.sh
@@ -100,6 +100,9 @@ x=$((nonce + 1)) # So we don't have any issues with nonce = 0
 echo "Generating proof $x != 0, nonce: $nonce"
 go run ./scripts/test_files/gnark_groth16_bn254_infinite_script/cmd/main.go $x
 
+verification_data_dir="./aligned_verification_data_$x"
+mkdir -p $verification_data_dir
+
 ## Send Proof
 echo "Submitting $REPETITIONS proofs $x != 0"
 submit=$(aligned submit \
@@ -113,6 +116,7 @@ submit=$(aligned submit \
   --network $NETWORK \
   --max_fee 0.004ether \
   --random_address \
+  --aligned_verification_data_path $verification_data_dir \
   2>&1)
 
 echo "$submit"
@@ -221,6 +225,6 @@ send_slack_message "$slack_message"
 
 ## Remove Proof Data
 rm -rf ./scripts/test_files/gnark_groth16_bn254_infinite_script/infinite_proofs/*
-rm -rf ./aligned_verification_data/*
+rm -rf ./aligned_verification_data_$x
 
 exit 0


### PR DESCRIPTION
## Description

This PR updates the periodic sender script conditions. The new conditions are the ones described in the table:

Max Gas Price (Gwei) | Time Elapsed
-- | --
1.5 | 5 min
4.5 | 15 min
9 | 30 min
24 | 1h
48 | 2h
96 | 4h
192 | 8h

This table can be read this way (taking the first column as an example): `After 5 minutes, if the network's gas price is lower than 1.5 Gwei, then send a proof`.

## How to test

We are using devnet to test the feature. You can use your own wallet or the one used in the alerts/.env.devnet file.

If you are using a local wallet, fund it using:

```
cast send <address> --value 10ether --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --rpc-url http://localhost:8545/
```

Deposit into Aligned using the following CLI command:

```
aligned deposit-to-batcher \
--network devnet \
--rpc_url http://localhost:8545 \
--amount 5ether \
--keystore_path <KEYSTORE_PATH>
```

Or use the `--private_key` flag with the private key used in the .env.devnet file.

Now, you can run the script, but since the sleep time between intervals is 30 minutes, you'll have to reduce it, for example, to 10 seconds.

### Add gas cost variations

Since the gas cost won't vary much during the testing interval, we have to modify the gas cost of the network manually.

Do it with the following command:

```
curl -s http://localhost:8545/ -H "Content-Type: application/json" -d '{
"jsonrpc":"2.0","id":1,
"method":"anvil_setNextBlockBaseFeePerGas",
"params":["0x3b9aca00"]   // 1 Gwei in hex
}'
```

Change the Gwei amount in hex for the one you want to test. Some sample values:
- "0x3b9aca00" - 1 Gwei
- "0x9502F900" - 2.5 Gwei
- "0x165A0BC00" - 6 Gwei
- "0x41314CF00" - 17.5 Gwei
- "0xBA43B7400" - 50 Gwei

Note that once it's set, the value decreases over time, so I recommend setting it to a high value and waiting for the time to pass.

Note: You'll see a log like the following

```
curl: (2) no URL specified
curl: try 'curl --help' or 'curl --manual' for more information
```

This is logged because it tries to connect to Slack via curl, but we have not set the Slack URL variable, as it's not relevant for this test.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
