### PR TITLE
fix ethereum_package_start ERROR-Failed to build beacon chain: Head block not found in store

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -48,7 +48,7 @@ network_params:
   # Maximum number of blobs per block
   #  max_blobs_per_block: 6
 
-  preset: "minimal"
+#  preset: "minimal"
   devnet_repo: ethpandaops
 
   # Prefunded Accounts


### PR DESCRIPTION
# 'preset:minimal' cause error:'Failed to build beacon chain: Head block not found in store'

## Description

'`preset:minimal`' cause error:'Failed to build beacon chain: Head block not found in store' when exec '`make ethereum_package_start`' as per issue #2167 . 
The _default_ configuration of `preset:minimal` clashes with the custom network parameters, like 'seconds_per_slot', 'genesis_delay', etc.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - #2167  
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
