### PR TITLE
chore(batcher): add disabled verifiers to the batcher config

### DIFF
--- a/config-files/config-batcher-docker.yaml
+++ b/config-files/config-batcher-docker.yaml
@@ -29,6 +29,7 @@ batcher:
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
   # The specific name for each verifier should match the ProvingSystemId string representation
+  # Possible values: GnarkPlonkBls12_381, GnarkPlonkBn254, GnarkGroth16Bn254, SP1, Risc0, CircomGroth16Bn256, Mina, MinaAccount
   disabled_verifiers: []
   non_paying:
     address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9

--- a/config-files/config-batcher-docker.yaml
+++ b/config-files/config-batcher-docker.yaml
@@ -28,6 +28,8 @@ batcher:
   pre_verification_is_enabled: true
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
+  # The specific name for each verifier should match the ProvingSystemId string representation
+  disabled_verifiers: []
   non_paying:
     address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9
     replacement_private_key: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 # Anvil address 1

--- a/config-files/config-batcher-ethereum-package.yaml
+++ b/config-files/config-batcher-ethereum-package.yaml
@@ -27,6 +27,7 @@ batcher:
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
   # The specific name for each verifier should match the ProvingSystemId string representation
+  # Possible values: GnarkPlonkBls12_381, GnarkPlonkBn254, GnarkGroth16Bn254, SP1, Risc0, CircomGroth16Bn256, Mina, MinaAccount
   disabled_verifiers: []
   non_paying:
     address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9

--- a/config-files/config-batcher-ethereum-package.yaml
+++ b/config-files/config-batcher-ethereum-package.yaml
@@ -26,6 +26,8 @@ batcher:
   pre_verification_is_enabled: true
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
+  # The specific name for each verifier should match the ProvingSystemId string representation
+  disabled_verifiers: []
   non_paying:
     address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9
     replacement_private_key: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 # Anvil address 1

--- a/config-files/config-batcher.yaml
+++ b/config-files/config-batcher.yaml
@@ -28,6 +28,8 @@ batcher:
   pre_verification_is_enabled: true
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
+  # The specific name for each verifier should match the ProvingSystemId string representation
+  disabled_verifiers: ["CircomGroth16Bn256"]
   non_paying:
     address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9
     replacement_private_key: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 # Anvil address 1

--- a/config-files/config-batcher.yaml
+++ b/config-files/config-batcher.yaml
@@ -29,6 +29,7 @@ batcher:
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
   # The specific name for each verifier should match the ProvingSystemId string representation
+  # Possible values: GnarkPlonkBls12_381, GnarkPlonkBn254, GnarkGroth16Bn254, SP1, Risc0, CircomGroth16Bn256, Mina, MinaAccount
   disabled_verifiers: []
   non_paying:
     address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9

--- a/config-files/config-batcher.yaml
+++ b/config-files/config-batcher.yaml
@@ -29,7 +29,7 @@ batcher:
   metrics_port: 9093
   telemetry_ip_port_address: localhost:4001
   # The specific name for each verifier should match the ProvingSystemId string representation
-  disabled_verifiers: ["CircomGroth16Bn256"]
+  disabled_verifiers: []
   non_paying:
     address: '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720' # Anvil address 9
     replacement_private_key: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 # Anvil address 1

--- a/crates/batcher/src/config/mod.rs
+++ b/crates/batcher/src/config/mod.rs
@@ -1,3 +1,4 @@
+use aligned_sdk::common::types::ProvingSystemId;
 use ethers::{core::k256::ecdsa::SigningKey, signers::Wallet, types::Address};
 use serde::Deserialize;
 
@@ -54,7 +55,7 @@ pub struct BatcherConfigFromYaml {
     pub amount_of_proofs_for_min_max_fee: usize,
     pub min_bump_percentage: u64,
     pub balance_unlock_polling_interval_seconds: u64,
-    pub disabled_verifiers: Vec<String>,
+    pub disabled_verifiers: Vec<ProvingSystemId>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/batcher/src/config/mod.rs
+++ b/crates/batcher/src/config/mod.rs
@@ -54,6 +54,7 @@ pub struct BatcherConfigFromYaml {
     pub amount_of_proofs_for_min_max_fee: usize,
     pub min_bump_percentage: u64,
     pub balance_unlock_polling_interval_seconds: u64,
+    pub disabled_verifiers: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -1491,6 +1491,13 @@ impl Batcher {
     }
 
     async fn is_verifier_disabled(&self, verifier: ProvingSystemId) -> bool {
+        // Check if the verifier is disabled in the configuration first
+        if self
+            .config_disabled_verifiers
+            .contains(&verifier.to_string())
+        {
+            return true;
+        }
         let disabled_verifiers = self.disabled_verifiers.lock().await;
         zk_utils::is_verifier_disabled(*disabled_verifiers, verifier)
     }

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -309,6 +309,10 @@ impl Batcher {
         .expect("Failed to get disabled verifiers");
 
         let config_disabled_verifiers = config.batcher.disabled_verifiers.clone();
+        info!(
+            "Disabled verifiers from config: {:?}",
+            config_disabled_verifiers
+        );
 
         let telemetry = TelemetrySender::new(format!(
             "http://{}",

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -134,6 +134,10 @@ pub struct Batcher {
 
     disabled_verifiers: Mutex<U256>,
 
+    // The list of disabled verifiers from the config file. Note that this is separate from the
+    // contract's disabled verifiers, and is updated only when the batcher is restarted.
+    config_disabled_verifiers: Vec<String>,
+
     // Observability and monitoring
     pub metrics: metrics::BatcherMetrics,
     pub telemetry: TelemetrySender,
@@ -298,11 +302,13 @@ impl Batcher {
             None
         };
 
-        let disabled_verifiers = match service_manager.disabled_verifiers().call().await {
-            Ok(disabled_verifiers) => Ok(disabled_verifiers),
+        let contract_disabled_verifiers = match service_manager.disabled_verifiers().call().await {
+            Ok(contract_disabled_verifiers) => Ok(contract_disabled_verifiers),
             Err(_) => service_manager_fallback.disabled_verifiers().call().await,
         }
         .expect("Failed to get disabled verifiers");
+
+        let config_disabled_verifiers = config.batcher.disabled_verifiers.clone();
 
         let telemetry = TelemetrySender::new(format!(
             "http://{}",
@@ -347,7 +353,8 @@ impl Batcher {
             posting_batch: Mutex::new(false),
             batch_state: Mutex::new(batch_state),
             user_states,
-            disabled_verifiers: Mutex::new(disabled_verifiers),
+            disabled_verifiers: Mutex::new(contract_disabled_verifiers),
+            config_disabled_verifiers: config_disabled_verifiers,
             current_min_max_fee: RwLock::new(U256::zero()),
             metrics,
             telemetry,

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -354,7 +354,7 @@ impl Batcher {
             batch_state: Mutex::new(batch_state),
             user_states,
             disabled_verifiers: Mutex::new(contract_disabled_verifiers),
-            config_disabled_verifiers: config_disabled_verifiers,
+            config_disabled_verifiers,
             current_min_max_fee: RwLock::new(U256::zero()),
             metrics,
             telemetry,

--- a/crates/batcher/src/lib.rs
+++ b/crates/batcher/src/lib.rs
@@ -136,7 +136,7 @@ pub struct Batcher {
 
     // The list of disabled verifiers from the config file. Note that this is separate from the
     // contract's disabled verifiers, and is updated only when the batcher is restarted.
-    config_disabled_verifiers: Vec<String>,
+    config_disabled_verifiers: Vec<ProvingSystemId>,
 
     // Observability and monitoring
     pub metrics: metrics::BatcherMetrics,
@@ -1492,10 +1492,7 @@ impl Batcher {
 
     async fn is_verifier_disabled(&self, verifier: ProvingSystemId) -> bool {
         // Check if the verifier is disabled in the configuration first
-        if self
-            .config_disabled_verifiers
-            .contains(&verifier.to_string())
-        {
+        if self.config_disabled_verifiers.contains(&verifier) {
             return true;
         }
         let disabled_verifiers = self.disabled_verifiers.lock().await;

--- a/crates/sdk/src/common/types.rs
+++ b/crates/sdk/src/common/types.rs
@@ -70,6 +70,24 @@ impl Display for ProvingSystemId {
     }
 }
 
+impl FromStr for ProvingSystemId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GnarkPlonkBls12_381" => Ok(ProvingSystemId::GnarkPlonkBls12_381),
+            "GnarkPlonkBn254" => Ok(ProvingSystemId::GnarkPlonkBn254),
+            "GnarkGroth16Bn254" => Ok(ProvingSystemId::GnarkGroth16Bn254),
+            "SP1" => Ok(ProvingSystemId::SP1),
+            "Risc0" => Ok(ProvingSystemId::Risc0),
+            "CircomGroth16Bn256" => Ok(ProvingSystemId::CircomGroth16Bn256),
+            "Mina" => Ok(ProvingSystemId::Mina),
+            "MinaAccount" => Ok(ProvingSystemId::MinaAccount),
+            _ => Err(format!("Invalid ProvingSystemId: {}", s)),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct VerificationData {
     pub proving_system: ProvingSystemId,


### PR DESCRIPTION
## Description

This PR adds a disabled verifiers array to the batcher YAML config file. The strings in the disabled array should match the ones in the method to serialize the ProvingSystemID to a String (you can see them [here](https://github.com/yetanotherco/aligned_layer/blob/21f45f818ac567494c73ceeb04747c50844ecc97/crates/sdk/src/common/types.rs#L56-L67)).

## How to test

1. Deploy the aligned contracts with `make anvil_start`.
2. Add "CircomGroth16Bn256" to the disabled_verifier array in `config-files/config-batcher.yaml`.
3. Start the batcher with `make batcher_start_local ENVIRONMENT=devnet`.
4. Try sending a CircomGroth16Bn256 proof with `make batcher_send_circom_groth16_bn256_task`.

You should see an error message saying that the CircomGroth16Bn256 verifier is disabled.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
