### PR TITLE
fix(aggregation-mode): send blob sidecars in transactions with eip_7594

### DIFF
--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.86.0
+          toolchain: 1.88.0
           components: rustfmt, clippy
           override: true
 

--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Run Clippy
         run: |
           cd crates
-          cargo clippy --all -- -D warnings
+          # TODO: solve this issues instead of ignoring
+          cargo clippy --all -- -D warnings -A clippy::uninlined_format_args
 
       - name: Build Batcher
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1444,7 +1444,7 @@ ansible_telemetry_deploy: ## Deploy the Telemetry. Parameters: INVENTORY
 __ETHEREUM_PACKAGE__:  ## ____
 
 ethereum_package_start: ## Starts the ethereum_package environment
-	kurtosis run --enclave aligned github.com/ethpandaops/ethereum-package@5.0.1 --args-file network_params.yaml
+	kurtosis run --enclave aligned github.com/ethpandaops/ethereum-package@905bf4fe7e558ce4fa3dd843fb6dbe711fdc3049 --args-file network_params.yaml
 
 ethereum_package_inspect: ## Prints detailed information about the net
 	kurtosis enclave inspect aligned

--- a/aggregation_mode/Cargo.lock
+++ b/aggregation_mode/Cargo.lock
@@ -107,41 +107,25 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b064bd1cea105e70557a258cd2b317731896753ec08edf51da2d1fced587b05"
+checksum = "a83b2001153fdb12999f808b53068ba36902ca59bf32ad979bb176d03f8f8772"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-contract 0.15.11",
+ "alloy-consensus",
+ "alloy-contract",
  "alloy-core",
- "alloy-eips 0.15.11",
+ "alloy-eips",
  "alloy-genesis",
- "alloy-network 0.15.11",
- "alloy-provider 0.15.11",
- "alloy-rpc-client 0.15.11",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde 0.15.11",
- "alloy-signer 0.15.11",
- "alloy-signer-local 0.15.11",
- "alloy-transport 0.15.11",
- "alloy-transport-http 0.15.11",
-]
-
-[[package]]
-name = "alloy"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754e8b511978ec78b3bf71140d2692fa8b67a09e44a9742487ab21dec616f953"
-dependencies = [
- "alloy-consensus 1.0.29",
- "alloy-contract 1.0.29",
- "alloy-core",
- "alloy-eips 1.0.29",
- "alloy-network 1.0.29",
- "alloy-provider 1.0.29",
- "alloy-rpc-client 1.0.29",
- "alloy-transport 1.0.29",
- "alloy-transport-http 1.0.29",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-trie",
 ]
 
 [[package]]
@@ -157,41 +141,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c3f3bc4f2a6b725970cd354e78e9738ea1e8961a91898f57bf6317970b1915"
+checksum = "ad704069c12f68d0c742d0cad7e0a03882b42767350584627fbf8a47b1bf1846"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.15.11",
- "alloy-trie 0.8.1",
- "auto_impl",
- "c-kzg",
- "derive_more 2.0.1",
- "either",
- "k256",
- "once_cell",
- "rand 0.8.5",
- "secp256k1",
- "serde",
- "serde_with",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "alloy-consensus"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1816584b0c17e3ab5781d7044b07d5b884cf8fe005811b4ae2cded266e0e8c87"
-dependencies = [
- "alloy-eips 1.0.29",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.0.29",
- "alloy-trie 0.9.1",
+ "alloy-serde",
+ "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
@@ -200,75 +161,41 @@ dependencies = [
  "rand 0.8.5",
  "secp256k1",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda014fb5591b8d8d24cab30f52690117d238e52254c6fb40658e91ea2ccd6c3"
+checksum = "bc374f640a5062224d7708402728e3d6879a514ba10f377da62e7dfb14c673e6"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.15.11",
- "serde",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb74c249b00a0e5005efc2aa3ef48c805b278cad848b544d5f53cb266f45976"
-dependencies = [
- "alloy-consensus 1.0.29",
- "alloy-eips 1.0.29",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.0.29",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9668ce1176f0b87a5e5fc805b3d198954f495de2e99b70a44bed691ba2b0a9d8"
+checksum = "15c493b2812943f7b58191063a8d13ea97c76099900869c08231e8eba3bf2f92"
 dependencies = [
- "alloy-consensus 0.15.11",
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network 0.15.11",
- "alloy-network-primitives 0.15.11",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-provider 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
- "alloy-transport 0.15.11",
- "futures",
- "futures-util",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "alloy-contract"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5cabcc7fdf60c92df94889d6e1b73814ecf47e99a6554f6dd7f75b45aa9d7fa"
-dependencies = [
- "alloy-consensus 1.0.29",
- "alloy-dyn-abi",
- "alloy-json-abi",
- "alloy-network 1.0.29",
- "alloy-network-primitives 1.0.29",
- "alloy-primitives",
- "alloy-provider 1.0.29",
- "alloy-rpc-types-eth 1.0.29",
- "alloy-sol-types",
- "alloy-transport 1.0.29",
+ "alloy-transport",
  "futures",
  "futures-util",
  "serde_json",
@@ -277,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe6c56d58fbfa9f0f6299376e8ce33091fc6494239466814c3f54b55743cb09"
+checksum = "5ca96214615ec8cf3fa2a54b32f486eb49100ca7fe7eb0b8c1137cd316e7250a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -290,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f56873f3cac7a2c63d8e98a4314b8311aa96adb1a0f82ae923eb2119809d2c"
+checksum = "3fdff496dd4e98a81f4861e66f7eaf5f2488971848bb42d9c892f871730245c8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -319,60 +246,43 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
  "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7b2f7010581f29bcace81776cf2f0e022008d05a7d326884763f16f3044620"
+checksum = "7e867b5fd52ed0372a95016f3a37cbff95a9d5409230fbaef2d8ea00e8618098"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.15.11",
+ "alloy-serde",
  "auto_impl",
- "c-kzg",
- "derive_more 2.0.1",
- "either",
- "serde",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "alloy-eips"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cee87eceefee136d68bba6d7202745c218346f28f0b96ce83b8061c991ddad"
-dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.0.29",
- "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
@@ -384,22 +294,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f723856b1c4ad5473f065650ab9be557c96fbc77e89180fbdac003e904a8d6"
+checksum = "b90be17e9760a6ba6d13cebdb049cea405ebc8bf57d90664ed708cc5bc348342"
 dependencies = [
- "alloy-eips 0.15.11",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 0.15.11",
- "alloy-trie 0.8.1",
+ "alloy-serde",
+ "alloy-trie",
+ "borsh",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125a1c373261b252e53e04d6e92c37d881833afc1315fceab53fd46045695640"
+checksum = "5513d5e6bd1cba6bdcf5373470f559f320c05c8c59493b6e98912fbe6733943f"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -409,23 +321,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1e31b50f4ed9a83689ae97263d366b15b935a67c4acb5dd46d5b1c3b27e8e6"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "tracing",
-]
-
-[[package]]
-name = "alloy-json-rpc"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc62df1be5c5f103f66ac8f25bf4d34e7b812e642159918466bb4c0f8e9a9"
+checksum = "dcab4c51fb1273e3b0f59078e0cdf8aa99f697925b09f0d2055c18be46b4d48c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -438,46 +336,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879afc0f4a528908c8fe6935b2ab0bc07f77221a989186f71583f7592831689e"
+checksum = "196d7fd3f5d414f7bbd5886a628b7c42bd98d1b126f9a7cff69dbfd72007b39c"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-consensus-any 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-json-rpc 0.15.11",
- "alloy-network-primitives 0.15.11",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-any 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-serde 0.15.11",
- "alloy-signer 0.15.11",
- "alloy-sol-types",
- "async-trait",
- "auto_impl",
- "derive_more 2.0.1",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "alloy-network"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e07a4331293a40c1a2fff58739c6da826cd86e3e76cd339af5d99b5e085344"
-dependencies = [
- "alloy-consensus 1.0.29",
- "alloy-consensus-any 1.0.29",
- "alloy-eips 1.0.29",
- "alloy-json-rpc 1.0.29",
- "alloy-network-primitives 1.0.29",
- "alloy-primitives",
- "alloy-rpc-types-any 1.0.29",
- "alloy-rpc-types-eth 1.0.29",
- "alloy-serde 1.0.29",
- "alloy-signer 1.0.29",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -490,43 +362,30 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec185bac9d32df79c1132558a450d48f6db0bfb5adef417dbb1a0258153f879b"
+checksum = "0d3ae2777e900a7a47ad9e3b8ab58eff3d93628265e73bbdee09acf90bf68f75"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 0.15.11",
- "serde",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237f507e38aac68d95389fbfba451a8d18cbdb51c971bc78f643de54bb15e395"
-dependencies = [
- "alloy-consensus 1.0.29",
- "alloy-eips 1.0.29",
- "alloy-primitives",
- "alloy-serde 1.0.29",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9485c56de23438127a731a6b4c87803d49faf1a7068dcd1d8768aca3a9edb9"
+checksum = "355bf68a433e0fd7f7d33d5a9fc2583fde70bf5c530f63b80845f8da5505cf28"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more 2.0.1",
- "foldhash",
- "hashbrown 0.15.5",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.0",
  "indexmap 2.11.0",
  "itoa",
  "k256",
@@ -543,23 +402,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d918534afe9cc050eabd8309c107dafd161aa77357782eca4f218bef08a660"
+checksum = "9f9bf40c9b2a90c7677f9c39bccd9f06af457f35362439c0497a706f16557703"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-json-rpc 0.15.11",
- "alloy-network 0.15.11",
- "alloy-network-primitives 0.15.11",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-client 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-signer 0.15.11",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
  "alloy-sol-types",
- "alloy-transport 0.15.11",
- "alloy-transport-http 0.15.11",
+ "alloy-transport",
+ "alloy-transport-http",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -577,42 +436,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-provider"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040b10bb781540585e87a1e9f9a0c4f54f49674114f33aa05c9a50cf3c92e26c"
-dependencies = [
- "alloy-chains",
- "alloy-consensus 1.0.29",
- "alloy-eips 1.0.29",
- "alloy-json-rpc 1.0.29",
- "alloy-network 1.0.29",
- "alloy-network-primitives 1.0.29",
- "alloy-primitives",
- "alloy-rpc-client 1.0.29",
- "alloy-rpc-types-eth 1.0.29",
- "alloy-signer 1.0.29",
- "alloy-sol-types",
- "alloy-transport 1.0.29",
- "async-stream",
- "async-trait",
- "auto_impl",
- "dashmap",
- "either",
- "futures",
- "futures-utils-wasm",
- "lru 0.13.0",
- "parking_lot",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "tokio",
- "tracing",
  "wasmtimer",
 ]
 
@@ -640,15 +463,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e30dcada47c04820b64f63de2423506c5c74f9ab59b115277ef5ad595a6fc"
+checksum = "e7c2630fde9ff6033a780635e1af6ef40e92d74a9cacb8af3defc1b15cfebca5"
 dependencies = [
- "alloy-json-rpc 0.15.11",
+ "alloy-json-rpc",
  "alloy-primitives",
- "alloy-transport 0.15.11",
- "alloy-transport-http 0.15.11",
- "async-stream",
+ "alloy-transport",
+ "alloy-transport-http",
  "futures",
  "pin-project",
  "reqwest 0.12.23",
@@ -658,77 +480,45 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
- "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
-name = "alloy-rpc-client"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c353b166a2cfb39167ead4f8ec335acdb439ad2a436245bccc218022fe28ca65"
-dependencies = [
- "alloy-json-rpc 1.0.29",
- "alloy-primitives",
- "alloy-transport 1.0.29",
- "futures",
- "pin-project",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower 0.5.2",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
 name = "alloy-rpc-types"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa10e26554ad7f79a539a6a8851573aedec5289f1f03244aad0bdbc324bfe5c"
+checksum = "ad098153a12382c22a597e865530033f5e644473742d6c733562d448125e02a2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-serde 0.15.11",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a8f1efd77116915dad61092f9ef9295accd0b0b251062390d9c4e81599344"
+checksum = "50b8429b5b62d21bf3691eb1ae12aaae9bb496894d5a114e3cc73e27e6800ec8"
 dependencies = [
- "alloy-consensus-any 0.15.11",
- "alloy-rpc-types-eth 0.15.11",
- "alloy-serde 0.15.11",
-]
-
-[[package]]
-name = "alloy-rpc-types-any"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f81c39d47eac1904e378a8079e2903bc1ddb3d9e73d5461c0db6c215d9d7ec1"
-dependencies = [
- "alloy-consensus-any 1.0.29",
- "alloy-rpc-types-eth 1.0.29",
- "alloy-serde 1.0.29",
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246c225f878dbcb8ad405949a30c403b3bb43bdf974f7f0331b276f835790a5e"
+checksum = "9981491bb98e76099983f516ec7de550db0597031f5828c994961eb4bb993cce"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-eips 0.15.11",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.15.11",
+ "alloy-serde",
  "derive_more 2.0.1",
  "rand 0.8.5",
  "serde",
@@ -737,37 +527,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1323310d87f9d950fb3ff58d943fdf832f5e10e6f902f405c0eaa954ffbaf1"
+checksum = "29031a6bf46177d65efce661f7ab37829ca09dd341bc40afb5194e97600655cc"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-consensus-any 0.15.11",
- "alloy-eips 0.15.11",
- "alloy-network-primitives 0.15.11",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.15.11",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a21e2b9b9da3f21351b9a34f820aa0580d5709aa821e8bfd26411649750f34"
-dependencies = [
- "alloy-consensus 1.0.29",
- "alloy-consensus-any 1.0.29",
- "alloy-eips 1.0.29",
- "alloy-network-primitives 1.0.29",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.0.29",
+ "alloy-serde",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -778,20 +548,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05ace2ef3da874544c3ffacfd73261cdb1405d8631765deb991436a53ec6069"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432bbb99cfa037b8a50deb4128da7bfc3d094a6b2ac6e9220bf89b1408c5e269"
+checksum = "01e856112bfa0d9adc85bd7c13db03fad0e71d1d6fb4c2010e475b6718108236"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -800,24 +559,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fdabad99ad3c71384867374c60bcd311fc1bb90ea87f5f9c779fd8c7ec36aa"
-dependencies = [
- "alloy-primitives",
- "async-trait",
- "auto_impl",
- "either",
- "elliptic-curve",
- "k256",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "alloy-signer"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b97ec9efdf375ada378d03404e8515c4e04694481fbb8c9e636313130fd734"
+checksum = "66a4f629da632d5279bbc5731634f0f5c9484ad9c4cad0cd974d9669dc1f46d6"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -834,10 +578,10 @@ version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8b4eb19ae08377f376dc531a9152fbacbbc4c5494b11a26448c7c1b4fdbaee"
 dependencies = [
- "alloy-consensus 1.0.29",
- "alloy-network 1.0.29",
+ "alloy-consensus",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 1.0.29",
+ "alloy-signer",
  "async-trait",
  "aws-sdk-kms",
  "k256",
@@ -848,14 +592,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb3f4e72378566b189624d54618c8adf07afbcf39d5f368f4486e35a66725b3"
+checksum = "76c8950810dc43660c0f22883659c4218e090a5c75dce33fa4ca787715997b7b"
 dependencies = [
- "alloy-consensus 0.15.11",
- "alloy-network 0.15.11",
+ "alloy-consensus",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 0.15.11",
+ "alloy-signer",
  "async-trait",
  "eth-keystore",
  "k256",
@@ -864,26 +608,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-signer-local"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e6e5b61817be1dfca20a7738eb09c9a85c333ef34ed0ae6946bdff077245fa"
-dependencies = [
- "alloy-consensus 1.0.29",
- "alloy-network 1.0.29",
- "alloy-primitives",
- "alloy-signer 1.0.29",
- "async-trait",
- "k256",
- "rand 0.8.5",
- "thiserror 2.0.16",
-]
-
-[[package]]
 name = "alloy-sol-macro"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20d867dcf42019d4779519a1ceb55eba8d7f3d0e4f0a89bcba82b8f9eb01e48"
+checksum = "f3ce480400051b5217f19d6e9a82d9010cdde20f1ae9c00d53591e4a1afbb312"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -895,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74e91b0b553c115d14bd0ed41898309356dc85d0e3d4b9014c4e7715e48c8ad"
+checksum = "6d792e205ed3b72f795a8044c52877d2e6b6e9b1d13f431478121d8d4eaa9028"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -914,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84194d31220803f5f62d0a00f583fd3a062b36382e2bea446f1af96727754565"
+checksum = "0bd1247a8f90b465ef3f1207627547ec16940c35597875cdc09c49d58b19693c"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -932,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8c27b3cf6b2bb8361904732f955bc7c05e00be5f469cec7e2280b6167f3ff0"
+checksum = "954d1b2533b9b2c7959652df3076954ecb1122a28cc740aa84e7b0a49f6ac0a9"
 dependencies = [
  "serde",
  "winnow 0.7.13",
@@ -942,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5383d34ea00079e6dd89c652bcbdb764db160cef84e6250926961a0b2295d04"
+checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -954,35 +682,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6964d85cd986cfc015b96887b89beed9e06d0d015b75ee2b7bfbd64341aab874"
+checksum = "fe215a2f9b51d5f1aa5c8cf22c8be8cdb354934de09c9a4e37aefb79b77552fd"
 dependencies = [
- "alloy-json-rpc 0.15.11",
- "alloy-primitives",
- "base64 0.22.1",
- "derive_more 2.0.1",
- "futures",
- "futures-utils-wasm",
- "parking_lot",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "tokio",
- "tower 0.5.2",
- "tracing",
- "url",
- "wasmtimer",
-]
-
-[[package]]
-name = "alloy-transport"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ab8f6beec1d32754043ad3b4da077e80ba78fd762acfb16a8460336887a2"
-dependencies = [
- "alloy-json-rpc 1.0.29",
- "alloy-primitives",
+ "alloy-json-rpc",
  "auto_impl",
  "base64 0.22.1",
  "derive_more 2.0.1",
@@ -1001,43 +705,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.15.11"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7c5ea7bda4497abe4ea92dcb8c76e9f052c178f3c82aa6976bcb264675f73c"
+checksum = "dc1b37b1a30d23deb3a8746e882c70b384c574d355bc2bbea9ea918b0c31366e"
 dependencies = [
- "alloy-json-rpc 0.15.11",
- "alloy-transport 0.15.11",
+ "alloy-json-rpc",
+ "alloy-transport",
  "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-transport-http"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e6b0b1188a87bbfbb5adf5ad7dcd0744e03fe3184e8ef683ec29846d884bee"
-dependencies = [
- "alloy-transport 1.0.29",
- "url",
-]
-
-[[package]]
-name = "alloy-trie"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "arrayvec",
- "derive_more 2.0.1",
- "nybbles 0.3.4",
- "serde",
- "smallvec",
- "tracing",
 ]
 
 [[package]]
@@ -1050,7 +728,7 @@ dependencies = [
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
- "nybbles 0.4.3",
+ "nybbles",
  "serde",
  "smallvec",
  "tracing",
@@ -1058,11 +736,10 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.29"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81901009f4ebb0fa0d2b37328ddec6ca420ca06289dddd714bc7ee9be3c86d4b"
+checksum = "7ccf423f6de62e8ce1d6c7a11fb7508ae3536d02e0d68aaeb05c8669337d0937"
 dependencies = [
- "alloy-primitives",
  "darling 0.21.3",
  "proc-macro2",
  "quote",
@@ -4177,6 +3854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4635,7 +4318,16 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash 0.2.0",
  "serde",
 ]
 
@@ -6069,19 +5761,6 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
-dependencies = [
- "alloy-rlp",
- "const-hex",
- "proptest",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "nybbles"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63cb50036b1ad148038105af40aaa70ff24d8a14fbc44ae5c914e1348533d12e"
@@ -6933,7 +6612,7 @@ name = "proof_aggregator"
 version = "0.1.0"
 dependencies = [
  "aligned-sdk",
- "alloy 0.15.11",
+ "alloy",
  "backon",
  "bincode",
  "c-kzg",
@@ -7767,7 +7446,7 @@ name = "risc0-ethereum-contracts"
 version = "3.0.0"
 source = "git+https://github.com/risc0/risc0-ethereum/?tag=v3.0.0#32aa0b6f23ddd02dd93fc71717667606e5c7db86"
 dependencies = [
- "alloy 1.0.29",
+ "alloy",
  "alloy-sol-types",
  "anyhow",
  "cfg-if",
@@ -8606,10 +8285,11 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -8623,10 +8303,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9334,9 +9023,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ed77ad8133ef4d915ad55ce700b53cd32a72fc3829ae4ad0fdf4db1982c983a"
 dependencies = [
  "alloy-primitives",
- "alloy-signer 1.0.29",
+ "alloy-signer",
  "alloy-signer-aws",
- "alloy-signer-local 1.0.29",
+ "alloy-signer-local",
  "alloy-sol-types",
  "anyhow",
  "async-trait",
@@ -9626,9 +9315,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b198d366dbec045acfcd97295eb653a7a2b40e4dc764ef1e79aafcad439d3c"
+checksum = "ff790eb176cc81bb8936aed0f7b9f14fc4670069a2d371b3e3b0ecce908b2cb3"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -10201,8 +9890,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]

--- a/aggregation_mode/Cargo.toml
+++ b/aggregation_mode/Cargo.toml
@@ -9,7 +9,7 @@ serde_json = "1.0.117"
 serde_yaml = "0.9"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
-alloy = { version = "0.15", features = ["default", "signer-keystore", "kzg"] }
+alloy = { version = "1.1.1", features = ["default", "signer-keystore", "kzg"] }
 c-kzg = "2.1.1"
 bincode = "1.3.3"
 tokio = { version = "1", features = ["time"]}

--- a/aggregation_mode/src/backend/mod.rs
+++ b/aggregation_mode/src/backend/mod.rs
@@ -8,12 +8,12 @@ mod types;
 use crate::aggregators::{AlignedProof, ProofAggregationError, ZKVMEngine};
 
 use alloy::{
-    consensus::BlobTransactionSidecar,
-    eips::eip4844::BYTES_PER_BLOB,
+    consensus::{BlobTransactionSidecar, EnvKzgSettings, EthereumTxEnvelope, TxEip4844WithSidecar},
+    eips::{eip4844::BYTES_PER_BLOB, eip7594::BlobTransactionSidecarEip7594, Encodable2718},
     hex,
     network::EthereumWallet,
     primitives::Address,
-    providers::{PendingTransactionError, ProviderBuilder},
+    providers::{PendingTransactionError, Provider, ProviderBuilder},
     rpc::types::TransactionReceipt,
     signers::local::LocalSigner,
 };
@@ -31,7 +31,7 @@ pub enum AggregatedProofSubmissionError {
     BuildingBlobProof,
     BuildingBlobVersionedHash,
     Risc0EncodingSeal(String),
-    SendVerifyAggregatedProofTransaction(alloy::contract::Error),
+    SendVerifyAggregatedProofTransaction(String),
     ReceiptError(PendingTransactionError),
     FetchingProofs(ProofsFetcherError),
     ZKVMAggregation(ProofAggregationError),
@@ -154,18 +154,16 @@ impl ProofAggregator {
         blob_versioned_hash: [u8; 32],
         aggregated_proof: AlignedProof,
     ) -> Result<TransactionReceipt, AggregatedProofSubmissionError> {
-        let res = match aggregated_proof {
-            AlignedProof::SP1(proof) => {
-                self.proof_aggregation_service
-                    .verifySP1(
-                        blob_versioned_hash.into(),
-                        proof.proof_with_pub_values.public_values.to_vec().into(),
-                        proof.proof_with_pub_values.bytes().into(),
-                    )
-                    .sidecar(blob)
-                    .send()
-                    .await
-            }
+        let tx_req = match aggregated_proof {
+            AlignedProof::SP1(proof) => self
+                .proof_aggregation_service
+                .verifySP1(
+                    blob_versioned_hash.into(),
+                    proof.proof_with_pub_values.public_values.to_vec().into(),
+                    proof.proof_with_pub_values.bytes().into(),
+                )
+                .sidecar(blob)
+                .into_transaction_request(),
             AlignedProof::Risc0(proof) => {
                 let encoded_seal = encode_seal(&proof.receipt).map_err(|e| {
                     AggregatedProofSubmissionError::Risc0EncodingSeal(e.to_string())
@@ -177,15 +175,41 @@ impl ProofAggregator {
                         proof.receipt.journal.bytes.into(),
                     )
                     .sidecar(blob)
-                    .send()
-                    .await
+                    .into_transaction_request()
             }
-        }
-        .map_err(AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction)?;
+        };
 
-        res.get_receipt()
+        let provider = self.proof_aggregation_service.provider();
+        let envelope = provider
+            .fill(tx_req)
             .await
-            .map_err(AggregatedProofSubmissionError::ReceiptError)
+            .map_err(Self::send_verify_aggregated_proof_err)?
+            .try_into_envelope()
+            .map_err(Self::send_verify_aggregated_proof_err)?;
+        let tx: EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> = envelope
+            .try_into_pooled()
+            .map_err(Self::send_verify_aggregated_proof_err)?
+            .try_map_eip4844(|tx| {
+                tx.try_map_sidecar(|sidecar| sidecar.try_into_7594(EnvKzgSettings::Default.get()))
+            })
+            .map_err(Self::send_verify_aggregated_proof_err)?;
+
+        let encoded_tx = tx.encoded_2718();
+        let pending_tx = provider
+            .send_raw_transaction(&encoded_tx)
+            .await
+            .map_err(Self::send_verify_aggregated_proof_err)?;
+
+        let receipt = pending_tx
+            .get_receipt()
+            .await
+            .map_err(Self::send_verify_aggregated_proof_err)?;
+
+        Ok(receipt)
+    }
+
+    fn send_verify_aggregated_proof_err<E: ToString>(err: E) -> AggregatedProofSubmissionError {
+        AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(err.to_string())
     }
 
     /// ### Blob capacity

--- a/aggregation_mode/src/backend/retry.rs
+++ b/aggregation_mode/src/backend/retry.rs
@@ -11,8 +11,8 @@ pub enum RetryError<E> {
 impl<E: std::fmt::Display> std::fmt::Display for RetryError<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            RetryError::Transient(e) => write!(f, "{}", e),
-            RetryError::Permanent(e) => write!(f, "{}", e),
+            RetryError::Transient(e) => write!(f, "{e}"),
+            RetryError::Permanent(e) => write!(f, "{e}"),
         }
     }
 }

--- a/aggregation_mode/src/backend/s3.rs
+++ b/aggregation_mode/src/backend/s3.rs
@@ -53,8 +53,8 @@ pub async fn get_aligned_batch_from_s3_with_multiple_urls(
                 return Ok(data);
             }
             Err(err) => {
-                warn!("Failed to fetch batch from URL {}: {:?}", url, err);
-                errors.push(format!("URL {}: {:?}", url, err));
+                warn!("Failed to fetch batch from URL {url}: {err:?}");
+                errors.push(format!("URL {url}: {err:?}"));
             }
         }
     }
@@ -84,7 +84,7 @@ fn parse_batch_urls(batch_urls: &str) -> Vec<String> {
 async fn get_aligned_batch_from_s3_retryable(
     url: String,
 ) -> Result<Vec<VerificationData>, RetryError<GetBatchProofsError>> {
-    info!("Fetching batch from S3 URL: {}", url);
+    info!("Fetching batch from S3 URL: {url}");
     let client = reqwest::Client::builder()
         .user_agent(DEFAULT_USER_AGENT)
         .connect_timeout(CONNECT_TIMEOUT_SECONDS)
@@ -95,7 +95,7 @@ async fn get_aligned_batch_from_s3_retryable(
         })?;
 
     let response = client.get(&url).send().await.map_err(|e| {
-        warn!("Failed to send request to {}: {}", url, e);
+        warn!("Failed to send request to {url}: {e}");
         RetryError::Transient(GetBatchProofsError::FetchingS3Batch(e.to_string()))
     })?;
 
@@ -122,13 +122,13 @@ async fn get_aligned_batch_from_s3_retryable(
     }
 
     let bytes = response.bytes().await.map_err(|e| {
-        warn!("Failed to read response body from {}: {}", url, e);
+        warn!("Failed to read response body from {url}: {e}");
         RetryError::Transient(GetBatchProofsError::EmptyBody(e.to_string()))
     })?;
     let bytes: &[u8] = bytes.iter().as_slice();
 
     let data: Vec<VerificationData> = ciborium::from_reader(bytes).map_err(|e| {
-        warn!("Failed to deserialize batch data from {}: {}", url, e);
+        warn!("Failed to deserialize batch data from {url}: {e}");
         RetryError::Permanent(GetBatchProofsError::Deserialization(e.to_string()))
     })?;
 

--- a/config-files/config-aggregator-ethereum-package.yaml
+++ b/config-files/config-aggregator-ethereum-package.yaml
@@ -4,9 +4,9 @@ environment: "production"
 aligned_layer_deployment_config_file_path: "./contracts/script/output/devnet/alignedlayer_deployment_output.json"
 eigen_layer_deployment_config_file_path: "./contracts/script/output/devnet/eigenlayer_deployment_output.json"
 eth_rpc_url: "http://localhost:8545"
-eth_rpc_url_fallback: "http://localhost:8551"
+eth_rpc_url_fallback: "http://localhost:8552"
 eth_ws_url: "ws://localhost:8546"
-eth_ws_url_fallback: "ws://localhost:8552"
+eth_ws_url_fallback: "ws://localhost:8553"
 eigen_metrics_ip_port_address: "localhost:9090"
 
 ## ECDSA Configurations

--- a/config-files/config-batcher-ethereum-package.yaml
+++ b/config-files/config-batcher-ethereum-package.yaml
@@ -4,9 +4,9 @@ environment: "production"
 aligned_layer_deployment_config_file_path: "./contracts/script/output/devnet/alignedlayer_deployment_output.json"
 eigen_layer_deployment_config_file_path: "./contracts/script/output/devnet/eigenlayer_deployment_output.json"
 eth_rpc_url: "http://localhost:8545"
-eth_rpc_url_fallback: "http://localhost:8551"
+eth_rpc_url_fallback: "http://localhost:8552"
 eth_ws_url: "ws://localhost:8546"
-eth_ws_url_fallback: "ws://localhost:8552"
+eth_ws_url_fallback: "ws://localhost:8553"
 eigen_metrics_ip_port_address: "localhost:9090"
 
 ## ECDSA Configurations

--- a/config-files/config-operator-1-ethereum-package.yaml
+++ b/config-files/config-operator-1-ethereum-package.yaml
@@ -4,9 +4,9 @@ environment: 'development'
 aligned_layer_deployment_config_file_path: './contracts/script/output/devnet/alignedlayer_deployment_output.json'
 eigen_layer_deployment_config_file_path: './contracts/script/output/devnet/eigenlayer_deployment_output.json'
 eth_rpc_url: "http://localhost:8545"
-eth_rpc_url_fallback: "http://localhost:8551"
+eth_rpc_url_fallback: "http://localhost:8552"
 eth_ws_url: "ws://localhost:8546"
-eth_ws_url_fallback: "ws://localhost:8552"
+eth_ws_url_fallback: "ws://localhost:8553"
 eigen_metrics_ip_port_address: 'localhost:9090'
 
 ## ECDSA Configurations

--- a/crates/batcher/build.rs
+++ b/crates/batcher/build.rs
@@ -26,7 +26,7 @@ fn main() {
 
     go_build.status().expect("Go build failed");
 
-    println!("cargo:rerun-if-changed={}", GO_SRC);
+    println!("cargo:rerun-if-changed={GO_SRC}");
     println!(
         "cargo:rustc-link-search=native={}",
         out_dir.to_str().unwrap()
@@ -36,5 +36,5 @@ fn main() {
         println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
     }
 
-    println!("cargo:rustc-link-lib=static={}", GO_LIB);
+    println!("cargo:rustc-link-lib=static={GO_LIB}");
 }

--- a/crates/batcher/src/types/errors.rs
+++ b/crates/batcher/src/types/errors.rs
@@ -50,7 +50,7 @@ impl From<Bytes> for TransactionSendError {
 
 pub enum BatcherError {
     TcpListenerError(String),
-    ConnectionError(tungstenite::Error),
+    ConnectionError(String),
     BatchVerifiedEventStreamError(String),
     EthereumSubscriptionError(String),
     SignatureError(SignatureError),
@@ -72,7 +72,7 @@ pub enum BatcherError {
 
 impl From<tungstenite::Error> for BatcherError {
     fn from(e: tungstenite::Error) -> Self {
-        BatcherError::ConnectionError(e)
+        BatcherError::ConnectionError(e.to_string())
     }
 }
 

--- a/crates/sdk/src/common/errors.rs
+++ b/crates/sdk/src/common/errors.rs
@@ -65,7 +65,7 @@ impl fmt::Display for AlignedError {
 
 #[derive(Debug)]
 pub enum SubmitError {
-    WebSocketConnectionError(tokio_tungstenite::tungstenite::Error),
+    WebSocketConnectionError(String),
     WebSocketClosedUnexpectedlyError(CloseFrame<'static>),
     IoError(PathBuf, io::Error),
     SerializationError(SerializationError),
@@ -104,7 +104,7 @@ pub enum SubmitError {
 
 impl From<tokio_tungstenite::tungstenite::Error> for SubmitError {
     fn from(e: tokio_tungstenite::tungstenite::Error) -> Self {
-        SubmitError::WebSocketConnectionError(e)
+        SubmitError::WebSocketConnectionError(e.to_string())
     }
 }
 

--- a/crates/sdk/src/communication/messaging.rs
+++ b/crates/sdk/src/communication/messaging.rs
@@ -70,7 +70,7 @@ pub async fn send_messages(
         // Send the message
         if let Err(e) = ws_write.send(Message::Binary(msg_bin.clone())).await {
             error!("Error while sending message: {:?}", e);
-            sent_verification_data.push(Err(SubmitError::WebSocketConnectionError(e)));
+            sent_verification_data.push(Err(SubmitError::WebSocketConnectionError(e.to_string())));
             return sent_verification_data;
         }
 

--- a/crates/sdk/src/verification_layer/mod.rs
+++ b/crates/sdk/src/verification_layer/mod.rs
@@ -258,7 +258,11 @@ pub async fn submit_multiple(
 ) -> Vec<Result<AlignedVerificationData, errors::SubmitError>> {
     let (ws_stream, _) = match connect_async(network.get_batcher_url()).await {
         Ok((ws_stream, response)) => (ws_stream, response),
-        Err(e) => return vec![Err(errors::SubmitError::WebSocketConnectionError(e))],
+        Err(e) => {
+            return vec![Err(errors::SubmitError::WebSocketConnectionError(
+                e.to_string(),
+            ))]
+        }
     };
 
     debug!("WebSocket handshake has been successfully completed");

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -1,8 +1,12 @@
 participants:
-  - el_type: reth
+  - el_type: geth
+    el_image: ethereum/client-go:v1.16.4
+    el_extra_params: ["--miner.extradata=lighthouseFromLocal"]
     cl_type: lighthouse
-    count: 3
-    validator_count: 32
+    cl_image: sigp/lighthouse:v8.0.0
+    count: 3 
+    supernode: true
+
 
 ethereum_metrics_exporter_enabled: true
 
@@ -22,6 +26,7 @@ port_publisher:
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
   image: ethpandaops/ethereum-genesis-generator:4.1.19
+  extra_env: {}
 
 # Default configuration parameters for the network
 network_params:
@@ -34,7 +39,7 @@ network_params:
   seconds_per_slot: 12
 
   # How long you want the network to wait before starting up
-  genesis_delay: 20
+  genesis_delay: 120
 
   # The gas limit of the network set at genesis
   genesis_gaslimit: 36000000
@@ -47,8 +52,17 @@ network_params:
   custody_requirement: 4
   # Maximum number of blobs per block
   #  max_blobs_per_block: 6
+  min_validator_withdrawability_delay: 1
+  shard_committee_period: 1
+  churn_limit_quotient: 16
+  fulu_fork_epoch: 1
+  bpo_1_epoch: 2
+  bpo_1_max_blobs: 15
+  bpo_1_target_blobs: 10
+  bpo_2_epoch: 3
+  bpo_2_max_blobs: 21
+  bpo_2_target_blobs: 14
 
-  preset: "minimal"
   devnet_repo: ethpandaops
 
   # Prefunded Accounts


### PR DESCRIPTION
## Description

This is the same fix of #2151 only that is keeps the alloy crate instead of migrating to ethrex.

Note: newer versions of alloy requires rust `+1.88.0`, which is why rust is bumped to `1.88.0` in the workflow. This update needed some changes in the codebase to make clippy happy but since they require a change in many files and across the whole codebase, they have been ignored ignored for now.


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
