### PR TITLE
chore: migrate ethereum package to fulu fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1568,7 +1568,7 @@ ansible_telemetry_deploy: ## Deploy the Telemetry. Parameters: INVENTORY
 __ETHEREUM_PACKAGE__:  ## ____
 
 ethereum_package_start: ## Starts the ethereum_package environment
-	kurtosis run --enclave aligned github.com/ethpandaops/ethereum-package --args-file network_params.yaml
+	kurtosis run --enclave aligned github.com/ethpandaops/ethereum-package@905bf4fe7e558ce4fa3dd843fb6dbe711fdc3049 --args-file network_params.yaml
 
 ethereum_package_inspect: ## Prints detailed information about the net
 	kurtosis enclave inspect aligned

--- a/Makefile
+++ b/Makefile
@@ -1568,7 +1568,7 @@ ansible_telemetry_deploy: ## Deploy the Telemetry. Parameters: INVENTORY
 __ETHEREUM_PACKAGE__:  ## ____
 
 ethereum_package_start: ## Starts the ethereum_package environment
-	kurtosis run --enclave aligned github.com/ethpandaops/ethereum-package@5.0.1 --args-file network_params.yaml
+	kurtosis run --enclave aligned github.com/ethpandaops/ethereum-package --args-file network_params.yaml
 
 ethereum_package_inspect: ## Prints detailed information about the net
 	kurtosis enclave inspect aligned

--- a/config-files/config-aggregator-ethereum-package.yaml
+++ b/config-files/config-aggregator-ethereum-package.yaml
@@ -4,9 +4,9 @@ environment: "production"
 aligned_layer_deployment_config_file_path: "./contracts/script/output/devnet/alignedlayer_deployment_output.json"
 eigen_layer_deployment_config_file_path: "./contracts/script/output/devnet/eigenlayer_deployment_output.json"
 eth_rpc_url: "http://localhost:8545"
-eth_rpc_url_fallback: "http://localhost:8551"
+eth_rpc_url_fallback: "http://localhost:8552"
 eth_ws_url: "ws://localhost:8546"
-eth_ws_url_fallback: "ws://localhost:8552"
+eth_ws_url_fallback: "ws://localhost:8553"
 eigen_metrics_ip_port_address: "localhost:9090"
 
 ## ECDSA Configurations

--- a/config-files/config-batcher-ethereum-package.yaml
+++ b/config-files/config-batcher-ethereum-package.yaml
@@ -4,9 +4,9 @@ environment: "production"
 aligned_layer_deployment_config_file_path: "./contracts/script/output/devnet/alignedlayer_deployment_output.json"
 eigen_layer_deployment_config_file_path: "./contracts/script/output/devnet/eigenlayer_deployment_output.json"
 eth_rpc_url: "http://localhost:8545"
-eth_rpc_url_fallback: "http://localhost:8551"
+eth_rpc_url_fallback: "http://localhost:8552"
 eth_ws_url: "ws://localhost:8546"
-eth_ws_url_fallback: "ws://localhost:8552"
+eth_ws_url_fallback: "ws://localhost:8553"
 eigen_metrics_ip_port_address: "localhost:9090"
 
 ## ECDSA Configurations

--- a/config-files/config-operator-1-ethereum-package.yaml
+++ b/config-files/config-operator-1-ethereum-package.yaml
@@ -4,9 +4,9 @@ environment: 'development'
 aligned_layer_deployment_config_file_path: './contracts/script/output/devnet/alignedlayer_deployment_output.json'
 eigen_layer_deployment_config_file_path: './contracts/script/output/devnet/eigenlayer_deployment_output.json'
 eth_rpc_url: "http://localhost:8545"
-eth_rpc_url_fallback: "http://localhost:8551"
+eth_rpc_url_fallback: "http://localhost:8552"
 eth_ws_url: "ws://localhost:8546"
-eth_ws_url_fallback: "ws://localhost:8552"
+eth_ws_url_fallback: "ws://localhost:8553"
 eigen_metrics_ip_port_address: 'localhost:9090'
 
 ## ECDSA Configurations

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -1,8 +1,12 @@
 participants:
-  - el_type: reth
+  - el_type: geth
+    el_image: ethereum/client-go:v1.16.4
+    el_extra_params: ["--miner.extradata=lighthouseFromLocal"]
     cl_type: lighthouse
-    count: 3
-    validator_count: 32
+    cl_image: sigp/lighthouse:v8.0.0
+    count: 3 
+    supernode: true
+
 
 ethereum_metrics_exporter_enabled: true
 
@@ -22,6 +26,7 @@ port_publisher:
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
   image: ethpandaops/ethereum-genesis-generator:4.1.19
+  extra_env: {}
 
 # Default configuration parameters for the network
 network_params:
@@ -34,7 +39,7 @@ network_params:
   seconds_per_slot: 12
 
   # How long you want the network to wait before starting up
-  genesis_delay: 20
+  genesis_delay: 120
 
   # The gas limit of the network set at genesis
   genesis_gaslimit: 36000000
@@ -47,8 +52,17 @@ network_params:
   custody_requirement: 4
   # Maximum number of blobs per block
   #  max_blobs_per_block: 6
+  min_validator_withdrawability_delay: 1
+  shard_committee_period: 1
+  churn_limit_quotient: 16
+  fulu_fork_epoch: 1
+  bpo_1_epoch: 2
+  bpo_1_max_blobs: 15
+  bpo_1_target_blobs: 10
+  bpo_2_epoch: 3
+  bpo_2_max_blobs: 21
+  bpo_2_target_blobs: 14
 
-  preset: "minimal"
   devnet_repo: ethpandaops
 
   # Prefunded Accounts


### PR DESCRIPTION
## Description

Updates `network_params.yaml` and ethereum package targets to support fulu fork.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
