### PR TITLE
fix(aggregation-mode): send sp1 proofs to the aggregation batcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ agg_mode_batcher_send_sp1_proof:
 		-F "nonce=$${NONCE}" \
 		-F "proof=@scripts/test_files/sp1/sp1_fibonacci_5_0_0.proof" \
 		-F "program_vk=@scripts/test_files/sp1/sp1_fibonacci_5_0_0_vk.bin" \
-		-F "signature_hex=0x0" \
+		-F "_signature_hex=0x0" \
 		http://127.0.0.1:8089/proof/sp1
 
 __AGGREGATOR__: ## ____


### PR DESCRIPTION
## Description

The `agg_mode_batcher_send_sp1_proof` Makefile target was broken because the `_signature_hex` field of the curl request content was missing the first `_`. This PR fixes that.

## How to test

1. Start anvil:
```
make anvil_start
```

2. Start agg mode batcher:
```
make agg_mode_batcher_start_local
```

Note: If you see a `Migrations to run correctly: VersionMismatch(1)` error, you have to clean the DB by running `make agg_mode_docker_clean`.

3. Send funds to the payment service:
```
cast send --value 1ether 0x922D6956C99E12DFeB3224DEA977D0939758A1Fe  --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
```

4. Send proofs to the batcher:
```
make agg_mode_batcher_send_sp1_proof
```

You can check that the proof was submitted in Adminer at http://localhost:8090/

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
