### PR TITLE
feat(aggregation-mode): daily proofs limit

### DIFF
--- a/aggregation_mode/batcher/src/config.rs
+++ b/aggregation_mode/batcher/src/config.rs
@@ -8,7 +8,7 @@ pub struct Config {
     pub db_connection_url: String,
     pub eth_rpc_url: String,
     pub payment_service_address: String,
-    pub max_proofs_per_day: usize,
+    pub max_proofs_per_day: i64,
 }
 
 impl Config {

--- a/aggregation_mode/batcher/src/config.rs
+++ b/aggregation_mode/batcher/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub db_connection_url: String,
     pub eth_rpc_url: String,
     pub payment_service_address: String,
+    pub max_proofs_per_day: usize,
 }
 
 impl Config {

--- a/aggregation_mode/batcher/src/config.rs
+++ b/aggregation_mode/batcher/src/config.rs
@@ -8,7 +8,7 @@ pub struct Config {
     pub db_connection_url: String,
     pub eth_rpc_url: String,
     pub payment_service_address: String,
-    pub max_proofs_per_day: i64,
+    pub max_daily_proofs_per_user: i64,
 }
 
 impl Config {

--- a/aggregation_mode/batcher/src/db.rs
+++ b/aggregation_mode/batcher/src/db.rs
@@ -96,18 +96,15 @@ impl Db {
         .await
     }
 
-    pub async fn get_daily_tasks_by_address(
-        &self,
-        address: &str,
-    ) -> Result<Vec<Receipt>, sqlx::Error> {
-        sqlx::query_as::<_, Receipt>(
-            "SELECT status,merkle_path,nonce,address
+    pub async fn get_daily_tasks_by_address(&self, address: &str) -> Result<i64, sqlx::Error> {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*)
             FROM tasks
             WHERE address = $1
             AND inserted_at::date = CURRENT_DATE",
         )
         .bind(address.to_lowercase())
-        .fetch_all(&self.pool)
+        .fetch_one(&self.pool)
         .await
     }
 

--- a/aggregation_mode/batcher/src/db.rs
+++ b/aggregation_mode/batcher/src/db.rs
@@ -96,6 +96,21 @@ impl Db {
         .await
     }
 
+    pub async fn get_daily_tasks_by_address(
+        &self,
+        address: &str,
+    ) -> Result<Vec<Receipt>, sqlx::Error> {
+        sqlx::query_as::<_, Receipt>(
+            "SELECT status,merkle_path,nonce,address
+            FROM tasks
+            WHERE address = $1
+            AND inserted_at::date = CURRENT_DATE",
+        )
+        .bind(address.to_lowercase())
+        .fetch_all(&self.pool)
+        .await
+    }
+
     pub async fn insert_task(
         &self,
         address: &str,

--- a/aggregation_mode/batcher/src/server/http.rs
+++ b/aggregation_mode/batcher/src/server/http.rs
@@ -111,7 +111,7 @@ impl BatcherServer {
                 .json(AppResponse::new_unsucessfull("Internal server error", 500));
         };
 
-        if daily_tasks_by_address >= state.config.max_proofs_per_day {
+        if daily_tasks_by_address >= state.config.max_daily_proofs_per_user {
             return HttpResponse::InternalServerError().json(AppResponse::new_unsucessfull(
                 "Request denied: Query limit exceeded.",
                 400,

--- a/aggregation_mode/batcher/src/server/http.rs
+++ b/aggregation_mode/batcher/src/server/http.rs
@@ -102,16 +102,13 @@ impl BatcherServer {
         let state = state.get_ref();
 
         // Checking if this address has submited more proofs than the ones allowed per day
-        let daily_tasks_by_address = match state
+        let Ok(daily_tasks_by_address) = state
             .db
             .get_daily_tasks_by_address(&recovered_address)
             .await
-        {
-            Ok(receipts) => receipts.len(),
-            Err(_) => {
-                return HttpResponse::InternalServerError()
-                    .json(AppResponse::new_unsucessfull("Internal server error", 500))
-            }
+        else {
+            return HttpResponse::InternalServerError()
+                .json(AppResponse::new_unsucessfull("Internal server error", 500));
         };
 
         if daily_tasks_by_address >= state.config.max_proofs_per_day {

--- a/aggregation_mode/batcher/src/server/http.rs
+++ b/aggregation_mode/batcher/src/server/http.rs
@@ -102,8 +102,6 @@ impl BatcherServer {
         let state = state.get_ref();
 
         // Checking if this address has submited more proofs than the ones allowed per day
-        const MAX_PROOFS_PER_DAY: usize = 4;
-
         let daily_tasks_by_address = match state
             .db
             .get_daily_tasks_by_address(&recovered_address)
@@ -116,7 +114,7 @@ impl BatcherServer {
             }
         };
 
-        if daily_tasks_by_address >= MAX_PROOFS_PER_DAY {
+        if daily_tasks_by_address >= state.config.max_proofs_per_day {
             return HttpResponse::InternalServerError().json(AppResponse::new_unsucessfull(
                 "Request denied: Query limit exceeded.",
                 400,

--- a/aggregation_mode/batcher/src/server/http.rs
+++ b/aggregation_mode/batcher/src/server/http.rs
@@ -101,6 +101,30 @@ impl BatcherServer {
         };
         let state = state.get_ref();
 
+        // Checking if this address has submited more proofs than the ones allowed per day
+        const MAX_PROOFS_PER_DAY: usize = 4;
+
+        let daily_tasks_by_address = match state
+            .db
+            .get_daily_tasks_by_address(&recovered_address)
+            .await
+        {
+            Ok(receipts) => receipts.len(),
+            Err(_) => {
+                return HttpResponse::InternalServerError().json(AppResponse::new_unsucessfull(
+                    format!("Internal server error").as_str(),
+                    500,
+                ))
+            }
+        };
+
+        if daily_tasks_by_address >= MAX_PROOFS_PER_DAY {
+            return HttpResponse::InternalServerError().json(AppResponse::new_unsucessfull(
+                format!("Request denied: Query limit exceeded.").as_str(),
+                400,
+            ));
+        }
+
         let Ok(count) = state.db.count_tasks_by_address(&recovered_address).await else {
             return HttpResponse::InternalServerError()
                 .json(AppResponse::new_unsucessfull("Internal server error", 500));

--- a/aggregation_mode/batcher/src/server/http.rs
+++ b/aggregation_mode/batcher/src/server/http.rs
@@ -111,16 +111,14 @@ impl BatcherServer {
         {
             Ok(receipts) => receipts.len(),
             Err(_) => {
-                return HttpResponse::InternalServerError().json(AppResponse::new_unsucessfull(
-                    format!("Internal server error").as_str(),
-                    500,
-                ))
+                return HttpResponse::InternalServerError()
+                    .json(AppResponse::new_unsucessfull("Internal server error", 500))
             }
         };
 
         if daily_tasks_by_address >= MAX_PROOFS_PER_DAY {
             return HttpResponse::InternalServerError().json(AppResponse::new_unsucessfull(
-                format!("Request denied: Query limit exceeded.").as_str(),
+                "Request denied: Query limit exceeded.",
                 400,
             ));
         }

--- a/aggregation_mode/db/migrations/001_init.sql
+++ b/aggregation_mode/db/migrations/001_init.sql
@@ -8,7 +8,8 @@ CREATE TABLE tasks (
     program_commitment BYTEA,
     merkle_path BYTEA,
     status task_status DEFAULT 'pending',
-    nonce BIGINT NOT NULL
+    nonce BIGINT NOT NULL,
+    inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE TABLE payment_events (
@@ -17,5 +18,6 @@ CREATE TABLE payment_events (
     amount BIGINT,
     started_at BIGINT,
     valid_until BIGINT,
-    tx_hash CHAR(66) UNIQUE
+    tx_hash CHAR(66) UNIQUE,
+    inserted_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/config-files/config-agg-mode-batcher-ethereum-package.yaml
+++ b/config-files/config-agg-mode-batcher-ethereum-package.yaml
@@ -2,3 +2,4 @@ port: 8089
 db_connection_url: "postgres://postgres:postgres@localhost:5435/"
 eth_rpc_url: "http://localhost:8545"
 payment_service_address: "0x922D6956C99E12DFeB3224DEA977D0939758A1Fe"
+max_proofs_per_day: 32

--- a/config-files/config-agg-mode-batcher-ethereum-package.yaml
+++ b/config-files/config-agg-mode-batcher-ethereum-package.yaml
@@ -2,4 +2,4 @@ port: 8089
 db_connection_url: "postgres://postgres:postgres@localhost:5435/"
 eth_rpc_url: "http://localhost:8545"
 payment_service_address: "0x922D6956C99E12DFeB3224DEA977D0939758A1Fe"
-max_proofs_per_day: 32
+max_daily_proofs_per_user: 32

--- a/config-files/config-agg-mode-batcher.yaml
+++ b/config-files/config-agg-mode-batcher.yaml
@@ -2,3 +2,4 @@ port: 8089
 db_connection_url: "postgres://postgres:postgres@localhost:5435/"
 eth_rpc_url: "http://localhost:8545"
 payment_service_address: "0x922D6956C99E12DFeB3224DEA977D0939758A1Fe"
+max_proofs_per_day: 4

--- a/config-files/config-agg-mode-batcher.yaml
+++ b/config-files/config-agg-mode-batcher.yaml
@@ -2,4 +2,4 @@ port: 8089
 db_connection_url: "postgres://postgres:postgres@localhost:5435/"
 eth_rpc_url: "http://localhost:8545"
 payment_service_address: "0x922D6956C99E12DFeB3224DEA977D0939758A1Fe"
-max_proofs_per_day: 4
+max_daily_proofs_per_user: 4


### PR DESCRIPTION
## Description

This PR adds a limit on the number of proofs that can be sent every day.

## How to test


1. Start anvil:
```
make anvil_start
```

2. Start agg mode batcher:
```
make agg_mode_batcher_start_local
```

Note: If you see a `Migrations to run correctly: VersionMismatch(1)` error, you have to clean the DB by running `make agg_mode_docker_clean`.

3. Send funds to the payment service:
```
make agg_mode_batcher_send_payment
```

4. Send proofs to the batcher to reach the limit established in the MAX_PROOFS_PER_DAY constant (currently set to 4 for testing purposes):
```
make agg_mode_batcher_send_sp1_proof
make agg_mode_batcher_send_sp1_proof
make agg_mode_batcher_send_sp1_proof
make agg_mode_batcher_send_sp1_proof
```

5. Now, try to send another proof (this would be the fifth on our example):
```
make agg_mode_batcher_send_sp1_proof
```


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
