### PR TITLE
infra(aggregator): update ansible deployment script

### DIFF
--- a/infra/ansible/playbooks/aggregator.yaml
+++ b/infra/ansible/playbooks/aggregator.yaml
@@ -38,7 +38,7 @@
       git:
         repo: https://github.com/yetanotherco/aligned_layer.git
         dest: /home/{{ ansible_user }}/repos/{{ service }}/aligned_layer
-        version: 2075-feat-hoodi-deployment
+        version: v0.20.0
       loop:
         - aggregator
 

--- a/infra/ansible/playbooks/templates/config-files/config-aggregator.yaml.j2
+++ b/infra/ansible/playbooks/templates/config-files/config-aggregator.yaml.j2
@@ -38,3 +38,4 @@ aggregator:
   # The Gas formula is percentage (gas_base_bump_percentage + gas_bump_incremental_percentage * i) / 100) is checked against this value
   # If it is higher, it will default to `gas_bump_percentage_limit`
   time_to_wait_before_bump: 72s # The time to wait for the receipt when responding to task. Suggested value 72 seconds (6 blocks)
+  poll_latest_batch_interval: 20s # The interval to poll for latest batches. Default: 20s


### PR DESCRIPTION
# infra(aggregator): update ansible deployment script

## Description

This PR updates the ansible config template for aggregator deployment and set the version to v0.20.0


## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
