### PR TITLE
infra(prometheus): update rules to support multiple batchers and aggregators

### DIFF
--- a/infra/ansible/playbooks/files/prometheus/rules.yml
+++ b/infra/ansible/playbooks/files/prometheus/rules.yml
@@ -17,7 +17,7 @@ groups:
 
   - alert: TaskDifferenceAggregatorBatcher
     # Condition for alerting
-    expr: floor(max(increase(aligned_aggregator_received_tasks{job="aligned-aggregator"}[15m]))) - on() floor(max(increase(sent_batches{job="aligned-batcher"}[15m]))) > 1
+    expr: floor(max(increase(aligned_aggregator_received_tasks{job="aligned-aggregator"}[15m]))) - on() floor(sum(increase(sent_batches{job="aligned-batcher"}[15m]))) > 1
     for: 30s
     # Annotation - additional informational labels to store more information
     annotations:
@@ -30,7 +30,7 @@ groups:
 
   - alert: TaskDifferenceAggregator
     # Condition for alerting
-    expr: floor(max(increase(aligned_aggregator_received_tasks{job="aligned-aggregator"}[15m]))) - floor(max(increase(aligned_aggregated_responses{job="aligned-aggregator"}[15m]))) > 1
+    expr: floor(max(increase(aligned_aggregator_received_tasks{job="aligned-aggregator"}[15m]))) - floor(sum(increase(aligned_aggregated_responses{job="aligned-aggregator"}[15m]))) > 1
     for: 30s
     # Annotation - additional informational labels to store more information
     annotations:

--- a/infra/ansible/playbooks/files/prometheus/rules.yml
+++ b/infra/ansible/playbooks/files/prometheus/rules.yml
@@ -17,7 +17,7 @@ groups:
 
   - alert: TaskDifferenceAggregatorBatcher
     # Condition for alerting
-    expr: floor(increase(aligned_aggregator_received_tasks{job="aligned-aggregator"}[15m])) - on() floor(increase(sent_batches{job="aligned-batcher"}[15m])) > 1
+    expr: floor(max(increase(aligned_aggregator_received_tasks{job="aligned-aggregator"}[15m]))) - on() floor(max(increase(sent_batches{job="aligned-batcher"}[15m]))) > 1
     for: 30s
     # Annotation - additional informational labels to store more information
     annotations:
@@ -30,7 +30,7 @@ groups:
 
   - alert: TaskDifferenceAggregator
     # Condition for alerting
-    expr: floor(increase(aligned_aggregator_received_tasks{job="aligned-aggregator"}[15m])) - floor(increase(aligned_aggregated_responses{job="aligned-aggregator"}[15m])) > 1
+    expr: floor(max(increase(aligned_aggregator_received_tasks{job="aligned-aggregator"}[15m]))) - floor(max(increase(aligned_aggregated_responses{job="aligned-aggregator"}[15m]))) > 1
     for: 30s
     # Annotation - additional informational labels to store more information
     annotations:


### PR DESCRIPTION
# infra(prometheus): update rules to support multiple batchers and aggregators

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
