### PR TITLE
feat(aggregation-mode): task sender + hoodi support in sdk/cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,11 +335,12 @@ agg_mode_gateway_send_payment:
 		0x922D6956C99E12DFeB3224DEA977D0939758A1Fe \
 		--private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 
-agg_mode_gateway_send_sp1_proof:
-	@cargo run --manifest-path aggregation_mode/cli/Cargo.toml -- submit sp1 \
-		--proof scripts/test_files/sp1/sp1_fibonacci_5_0_0.proof \
-		--vk scripts/test_files/sp1/sp1_fibonacci_5_0_0_vk.bin \
-		--private-key "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+agg_mode_install_cli: ## Install the aggregation mode CLI
+	@cargo install --path aggregation_mode/cli
+
+agg_mode_task_sender_start: agg_mode_install_cli ## Send proofs to agg mode gateway
+	@. scripts/.agg_mode.task_sender.env && . ./scripts/agg_mode_send_sp1_proof_interval.sh
 
 agg_mode_get_quotas:
 	curl -X GET http://127.0.0.1:8089/quotas/0x70997970C51812dc3A010C7d01b50e0d17dc79C8

--- a/aggregation_mode/gateway/src/config.rs
+++ b/aggregation_mode/gateway/src/config.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
+    pub ip: String,
     pub port: u16,
     pub db_connection_url: String,
     pub network: String,

--- a/aggregation_mode/gateway/src/http.rs
+++ b/aggregation_mode/gateway/src/http.rs
@@ -59,7 +59,7 @@ impl GatewayServer {
                 .route("/proof/risc0", web::post().to(Self::post_proof_risc0))
                 .route("/quotas/{address}", web::get().to(Self::get_quotas))
         })
-        .bind(("127.0.0.1", port))
+        .bind((self.config.ip.as_str(), port))
         .expect("To bind socket correctly")
         .run()
         .await

--- a/aggregation_mode/sdk/src/types.rs
+++ b/aggregation_mode/sdk/src/types.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 #[derive(Debug, Clone)]
 pub enum Network {
     Devnet,
+    Hoodi,
 }
 
 #[derive(Debug, Clone)]
@@ -24,12 +25,14 @@ impl Network {
     pub fn chain_id(&self) -> u64 {
         match self {
             Self::Devnet => 31_337,
+            Self::Hoodi => 56_0048,
         }
     }
 
     pub fn gateway_url(&self) -> String {
         match self {
             Self::Devnet => "http://127.0.0.1:8089".to_string(),
+            Self::Hoodi => "http://hoodi.gateway.alignedlayer.com:8080".to_string(),
         }
     }
 }

--- a/aggregation_mode/sdk/src/types.rs
+++ b/aggregation_mode/sdk/src/types.rs
@@ -16,6 +16,7 @@ impl FromStr for Network {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "devnet" => Ok(Self::Devnet),
+            "hoodi" => Ok(Self::Hoodi),
             _ => Err(NetworkError::InvalidNetwork),
         }
     }

--- a/config-files/config-agg-mode-gateway-ethereum-package.yaml
+++ b/config-files/config-agg-mode-gateway-ethereum-package.yaml
@@ -1,3 +1,4 @@
+ip: "127.0.0.1"
 port: 8089
 db_connection_url: "postgres://postgres:postgres@localhost:5435/"
 eth_rpc_url: "http://localhost:8545"

--- a/config-files/config-agg-mode-gateway-ethereum-package.yaml
+++ b/config-files/config-agg-mode-gateway-ethereum-package.yaml
@@ -4,3 +4,4 @@ eth_rpc_url: "http://localhost:8545"
 payment_service_address: "0x922D6956C99E12DFeB3224DEA977D0939758A1Fe"
 network: "devnet"
 max_daily_proofs_per_user: 32
+last_block_fetched_filepath: "config-files/proof-aggregator.last_block_fetched.json"

--- a/config-files/config-agg-mode-gateway.yaml
+++ b/config-files/config-agg-mode-gateway.yaml
@@ -1,3 +1,4 @@
+ip: "127.0.0.1"
 port: 8089
 db_connection_url: "postgres://postgres:postgres@localhost:5435/"
 eth_rpc_url: "http://localhost:8545"

--- a/scripts/.agg_mode.task_sender.env
+++ b/scripts/.agg_mode.task_sender.env
@@ -1,0 +1,5 @@
+INTERVAL_HOURS=1
+PROOF_PATH=scripts/test_files/sp1/sp1_fibonacci_5_0_0.proof
+VK_PATH=scripts/test_files/sp1/sp1_fibonacci_5_0_0_vk.bin
+PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+NETWORK=devnet

--- a/scripts/agg_mode_send_sp1_proof_interval.sh
+++ b/scripts/agg_mode_send_sp1_proof_interval.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+cli_bin="${AGG_MODE_CLI_BIN:-agg_mode_cli}"
+if ! command -v "$cli_bin" >/dev/null 2>&1; then
+  echo "agg_mode CLI not found in PATH. Run: make agg_mode_install_cli"
+  exit 1
+fi
+
+interval_hours=$INTERVAL_HOURS
+network=$NETWORK
+private_key=$PRIVATE_KEY
+proof_path=$PROOF_PATH
+vk_path=$VK_PATH
+
+if [[ -z "$interval_hours" ]]; then
+  echo "INTERVAL_HOURS not found"
+  exit 1
+fi
+
+if [[ -z "$network" ]]; then
+  echo "NETWORK not found"
+  exit 1
+fi
+
+if [[ -z "$private_key" ]]; then
+  echo "PRIVATE_KEY not found"
+  exit 1
+fi
+
+if [[ ! -f "$proof_path" ]]; then
+  echo "PROOF_PATH not found: $proof_path"
+  exit 1
+fi
+
+if [[ ! -f "$vk_path" ]]; then
+  echo "VK_PATH key not found: $vk_path"
+  exit 1
+fi
+
+
+sleep_seconds=$((interval_hours * 3600))
+echo "Sending SP1 proof every ${interval_hours} hour(s) using ${cli_bin}..."
+
+while true; do
+  "$cli_bin" submit sp1 \
+    --proof "$proof_path" \
+    --vk "$vk_path" \
+    --private-key "$private_key" \
+    --network "$network"
+  echo "sleeping for ${sleep_seconds} seconds"
+  sleep "$sleep_seconds"
+done


### PR DESCRIPTION
## Description

Adds a script to periodically send proofs to the agg mode gateway.

How to run it: 
1. Install cli:
```shell
make agg_mode_install_cli
```
2. Complete `.env` file at (by default the variables are set for devnet):
```shell
scripts/.agg_mode.task_sender.env
```
3. Start it:
```shell
make agg_mode_task_sender_start
```

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
