### PR TITLE
feat(gateway): add / endpoint

### DIFF
--- a/aggregation_mode/gateway/src/http.rs
+++ b/aggregation_mode/gateway/src/http.rs
@@ -53,6 +53,7 @@ impl GatewayServer {
         HttpServer::new(move || {
             App::new()
                 .app_data(Data::new(state.clone()))
+                .route("/", web::get().to(Self::get_root))
                 .route("/nonce/{address}", web::get().to(Self::get_nonce))
                 .route("/receipts", web::get().to(Self::get_receipts))
                 .route("/proof/sp1", web::post().to(Self::post_proof_sp1))
@@ -64,6 +65,11 @@ impl GatewayServer {
         .run()
         .await
         .expect("Server to never end");
+    }
+
+    // Returns an OK response (code 200), no matters what receives in the request
+    async fn get_root(_req: HttpRequest) -> impl Responder {
+        HttpResponse::Ok().json(AppResponse::new_sucessfull(serde_json::json!({})))
     }
 
     // Returns the nonce (number of submitted tasks) for a given address


### PR DESCRIPTION
## Description

This PR adds a "/" endpoint for use in health checks. It returns OK 200 to all requests.

## How to test

To test this, you can call the endpoint via a simple curl:
```bash
curl 127.0.0.1:8089
```

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
