### PR TITLE
fix(aggregation-mode): restore the send sp1 proof Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,11 @@ agg_mode_gateway_send_payment:
 		0x922D6956C99E12DFeB3224DEA977D0939758A1Fe \
 		--private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 
+agg_mode_gateway_send_sp1_proof:
+	@cargo run --manifest-path aggregation_mode/cli/Cargo.toml -- submit sp1 \
+		--proof scripts/test_files/sp1/sp1_fibonacci_5_0_0.proof \
+		--vk scripts/test_files/sp1/sp1_fibonacci_5_0_0_vk.bin \
+		--private-key "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 
 agg_mode_install_cli: ## Install the aggregation mode CLI
 	@cargo install --path aggregation_mode/cli


### PR DESCRIPTION
## Description

This PR restores the send sp1 proof Makefile target, which was removed on a previous PR.

## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
