### PR TITLE
feat(aggregation mode): add TLS support to Gateway

### DIFF
--- a/aggregation_mode/Cargo.lock
+++ b/aggregation_mode/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "base64 0.22.1",
  "bitflags 2.10.0",
@@ -159,6 +160,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6176099de3f58fbddac916a7f8c6db297e021d706e7a6b99947785fee14abe9f"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "impl-more",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +201,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "bytes",

--- a/aggregation_mode/Cargo.lock
+++ b/aggregation_mode/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
  "db",
  "hex",
  "prometheus",
+ "rustls 0.23.35",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/aggregation_mode/gateway/Cargo.toml
+++ b/aggregation_mode/gateway/Cargo.toml
@@ -18,7 +18,7 @@ db = { workspace = true }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 bincode = "1.3.3"
-actix-web = "4"
+actix-web = { version = "4", features = ["rustls-0_23"] }
 actix-multipart = "0.7.2"
 actix-web-prometheus = "0.1.2"
 rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "aws-lc-rs"] }

--- a/aggregation_mode/gateway/Cargo.toml
+++ b/aggregation_mode/gateway/Cargo.toml
@@ -3,6 +3,10 @@ name = "gateway"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+tls = ["dep:rustls"]
+
 [dependencies]
 serde =  { workspace = true }
 serde_json = { workspace = true }
@@ -17,8 +21,8 @@ bincode = "1.3.3"
 actix-web = "4"
 actix-multipart = "0.7.2"
 actix-web-prometheus = "0.1.2"
+rustls = { version = "0.23", optional = true, default-features = false, features = ["std", "aws-lc-rs"] }
 alloy = { workspace = true }
 tokio = { version = "1", features = ["time", "macros", "rt-multi-thread"]}
-# TODO: enable tls
 sqlx = { version = "0.8", features = [ "runtime-tokio", "postgres", "uuid", "bigdecimal" ] }
 hex = "0.4"

--- a/aggregation_mode/gateway/src/config.rs
+++ b/aggregation_mode/gateway/src/config.rs
@@ -10,6 +10,10 @@ pub struct Config {
     pub network: String,
     pub max_daily_proofs_per_user: i64,
     pub gateway_metrics_port: u16,
+    #[cfg(feature = "tls")]
+    pub tls_cert_path: String,
+    #[cfg(feature = "tls")]
+    pub tls_key_path: String,
 }
 
 impl Config {

--- a/aggregation_mode/gateway/src/http.rs
+++ b/aggregation_mode/gateway/src/http.rs
@@ -63,13 +63,16 @@ impl GatewayServer {
     }
 
     #[cfg(feature = "tls")]
-    fn load_tls_config(cert_path: &str, key_path: &str) -> Result<ServerConfig, Box<dyn std::error::Error>> {
+    fn load_tls_config(
+        cert_path: &str,
+        key_path: &str,
+    ) -> Result<ServerConfig, Box<dyn std::error::Error>> {
         // Install the default crypto provider
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         // Load certificate chain
-        let certs: Vec<CertificateDer> = CertificateDer::pem_file_iter(cert_path)?
-            .collect::<Result<Vec<_>, _>>()?;
+        let certs: Vec<CertificateDer> =
+            CertificateDer::pem_file_iter(cert_path)?.collect::<Result<Vec<_>, _>>()?;
 
         // Load private key
         let private_key = PrivateKeyDer::from_pem_file(key_path)?;
@@ -98,7 +101,12 @@ impl GatewayServer {
         #[cfg(not(feature = "tls"))]
         let protocol = "http";
 
-        tracing::info!("Starting server at {}://{}:{}", protocol, self.config.ip, self.config.port);
+        tracing::info!(
+            "Starting server at {}://{}:{}",
+            protocol,
+            self.config.ip,
+            self.config.port
+        );
 
         let server = HttpServer::new(move || {
             App::new()
@@ -114,20 +122,20 @@ impl GatewayServer {
 
         #[cfg(feature = "tls")]
         let server = {
-            let tls_config = Self::load_tls_config(&self.config.tls_cert_path, &self.config.tls_key_path)
-                .expect("Failed to load TLS configuration");
-            server.bind_rustls_0_23((self.config.ip.as_str(), port), tls_config)
+            let tls_config =
+                Self::load_tls_config(&self.config.tls_cert_path, &self.config.tls_key_path)
+                    .expect("Failed to load TLS configuration");
+            server
+                .bind_rustls_0_23((self.config.ip.as_str(), port), tls_config)
                 .expect("To bind socket correctly with TLS")
         };
 
         #[cfg(not(feature = "tls"))]
-        let server = server.bind((self.config.ip.as_str(), port))
+        let server = server
+            .bind((self.config.ip.as_str(), port))
             .expect("To bind socket correctly");
 
-        server
-            .run()
-            .await
-            .expect("Server to never end");
+        server.run().await.expect("Server to never end");
     }
 
     // Returns an OK response (code 200), no matters what receives in the request

--- a/aggregation_mode/gateway/src/http.rs
+++ b/aggregation_mode/gateway/src/http.rs
@@ -4,6 +4,12 @@ use std::{
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(feature = "tls")]
+use rustls::{
+    pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer},
+    ServerConfig,
+};
+
 use actix_multipart::form::MultipartForm;
 use actix_web::{
     web::{self, Data},
@@ -56,6 +62,25 @@ impl GatewayServer {
         }
     }
 
+    #[cfg(feature = "tls")]
+    fn load_tls_config(cert_path: &str, key_path: &str) -> Result<ServerConfig, Box<dyn std::error::Error>> {
+        // Install the default crypto provider
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        // Load certificate chain
+        let certs: Vec<CertificateDer> = CertificateDer::pem_file_iter(cert_path)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Load private key
+        let private_key = PrivateKeyDer::from_pem_file(key_path)?;
+
+        let config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, private_key)?;
+
+        Ok(config)
+    }
+
     pub async fn start(&self) {
         // Note: GatewayServer is thread safe so we can just clone it (no need to add mutexes)
         let port = self.config.port;
@@ -68,8 +93,14 @@ impl GatewayServer {
             .build()
             .unwrap();
 
-        tracing::info!("Starting server at port {}", self.config.port);
-        HttpServer::new(move || {
+        #[cfg(feature = "tls")]
+        let protocol = "https";
+        #[cfg(not(feature = "tls"))]
+        let protocol = "http";
+
+        tracing::info!("Starting server at {}://{}:{}", protocol, self.config.ip, self.config.port);
+
+        let server = HttpServer::new(move || {
             App::new()
                 .app_data(Data::new(state.clone()))
                 .wrap(prometheus.clone())
@@ -79,12 +110,24 @@ impl GatewayServer {
                 .route("/proof/sp1", web::post().to(Self::post_proof_sp1))
                 .route("/proof/risc0", web::post().to(Self::post_proof_risc0))
                 .route("/quotas/{address}", web::get().to(Self::get_quotas))
-        })
-        .bind((self.config.ip.as_str(), port))
-        .expect("To bind socket correctly")
-        .run()
-        .await
-        .expect("Server to never end");
+        });
+
+        #[cfg(feature = "tls")]
+        let server = {
+            let tls_config = Self::load_tls_config(&self.config.tls_cert_path, &self.config.tls_key_path)
+                .expect("Failed to load TLS configuration");
+            server.bind_rustls_0_23((self.config.ip.as_str(), port), tls_config)
+                .expect("To bind socket correctly with TLS")
+        };
+
+        #[cfg(not(feature = "tls"))]
+        let server = server.bind((self.config.ip.as_str(), port))
+            .expect("To bind socket correctly");
+
+        server
+            .run()
+            .await
+            .expect("Server to never end");
     }
 
     // Returns an OK response (code 200), no matters what receives in the request


### PR DESCRIPTION
# feat(aggregation mode): add TLS support to Gateway

## Description

This PR adds compatibility run run the Gateway and expose it with TLS

It is already available in https://hoodi.gateway.alignedlayer.com

## Type of change

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
