### PR TITLE
feat(aggregation-mode): Bump fee when proof verification times out

### DIFF
--- a/aggregation_mode/proof_aggregator/src/backend/config.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/config.rs
@@ -21,6 +21,9 @@ pub struct Config {
     pub sp1_chunk_aggregator_vk_hash: String,
     pub monthly_budget_eth: f64,
     pub db_connection_urls: Vec<String>,
+    pub max_bump_retries: u16,
+    pub bump_retry_interval_seconds: u64,
+    pub bump_increase_fee_multiplier: f64,
 }
 
 impl Config {

--- a/aggregation_mode/proof_aggregator/src/backend/config.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/config.rs
@@ -26,7 +26,6 @@ pub struct Config {
     pub base_bump_percentage: u64,
     pub max_fee_bump_percentage: u64,
     pub priority_fee_wei: u128,
-    pub final_receipt_check_timeout_seconds: u64,
 }
 
 impl Config {

--- a/aggregation_mode/proof_aggregator/src/backend/config.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/config.rs
@@ -23,7 +23,8 @@ pub struct Config {
     pub db_connection_urls: Vec<String>,
     pub max_bump_retries: u16,
     pub bump_retry_interval_seconds: u64,
-    pub bump_increase_fee_multiplier: f64,
+    pub base_bump_percentage: u64,
+    pub retry_attempt_percentage: u64,
 }
 
 impl Config {

--- a/aggregation_mode/proof_aggregator/src/backend/config.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/config.rs
@@ -25,7 +25,7 @@ pub struct Config {
     pub bump_retry_interval_seconds: u64,
     pub base_bump_percentage: u64,
     pub max_fee_bump_percentage: u64,
-    pub priority_fee_gwei: u128,
+    pub priority_fee_wei: u128,
 }
 
 impl Config {

--- a/aggregation_mode/proof_aggregator/src/backend/config.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/config.rs
@@ -24,7 +24,8 @@ pub struct Config {
     pub max_bump_retries: u16,
     pub bump_retry_interval_seconds: u64,
     pub base_bump_percentage: u64,
-    pub retry_attempt_percentage: u64,
+    pub max_fee_bump_percentage: u64,
+    pub priority_fee_gwei: u128,
 }
 
 impl Config {

--- a/aggregation_mode/proof_aggregator/src/backend/config.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
     pub max_bump_retries: u16,
     pub bump_retry_interval_seconds: u64,
     pub max_fee_bump_percentage: u64,
-    pub priority_fee_wei: u128,
+    pub max_priority_fee_upper_limit: u128,
 }
 
 impl Config {

--- a/aggregation_mode/proof_aggregator/src/backend/config.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub base_bump_percentage: u64,
     pub max_fee_bump_percentage: u64,
     pub priority_fee_wei: u128,
+    pub final_receipt_check_timeout_seconds: u64,
 }
 
 impl Config {

--- a/aggregation_mode/proof_aggregator/src/backend/config.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/config.rs
@@ -23,7 +23,6 @@ pub struct Config {
     pub db_connection_urls: Vec<String>,
     pub max_bump_retries: u16,
     pub bump_retry_interval_seconds: u64,
-    pub base_bump_percentage: u64,
     pub max_fee_bump_percentage: u64,
     pub priority_fee_wei: u128,
 }

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -20,7 +20,10 @@ use crate::{
 
 use alloy::{
     consensus::{BlobTransactionSidecar, EnvKzgSettings, EthereumTxEnvelope, TxEip4844WithSidecar},
-    eips::{eip4844::BYTES_PER_BLOB, eip7594::BlobTransactionSidecarEip7594, Encodable2718},
+    eips::{
+        eip4844::BYTES_PER_BLOB, eip7594::BlobTransactionSidecarEip7594, BlockNumberOrTag,
+        Encodable2718,
+    },
     hex,
     network::{EthereumWallet, TransactionBuilder},
     primitives::{utils::parse_ether, Address, TxHash, U256},
@@ -52,6 +55,8 @@ pub enum AggregatedProofSubmissionError {
     MerkleRootMisMatch,
     StoringMerklePaths(DbError),
     GasPriceError(String),
+    LatestBlockNotFound,
+    BaseFeePerGasMissing,
 }
 
 enum SubmitOutcome {
@@ -589,18 +594,23 @@ impl ProofAggregator {
     ) -> Result<TransactionRequest, AggregatedProofSubmissionError> {
         let provider = self.proof_aggregation_service.provider();
 
-        let current_gas_price = provider
-            .get_gas_price()
+        let latest_block = provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
             .await
-            .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?;
+            .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?
+            .ok_or(AggregatedProofSubmissionError::LatestBlockNotFound)?;
 
-        let new_base_fee = current_gas_price as f64 * (1.0 + base_bump_percentage as f64 / 100.0);
+        let current_base_fee = latest_block
+            .header
+            .base_fee_per_gas
+            .ok_or(AggregatedProofSubmissionError::BaseFeePerGasMissing)?;
+
+        let new_base_fee = current_base_fee as f64 * (1.0 + base_bump_percentage as f64 / 100.0);
         let new_max_fee = new_base_fee * (1.0 + max_fee_bump_percentage as f64 / 100.0);
-        let new_priority_fee = priority_fee_wei;
 
         Ok(tx_req
             .with_max_fee_per_gas(new_max_fee as u128)
-            .with_max_priority_fee_per_gas(new_priority_fee))
+            .with_max_priority_fee_per_gas(priority_fee_wei))
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -468,9 +468,6 @@ impl ProofAggregator {
         nonce: u64,
     ) -> Result<SubmitOutcome, AggregatedProofSubmissionError> {
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
-        let base_bump_percentage = self.config.base_bump_percentage;
-        let max_fee_bump_percentage = self.config.max_fee_bump_percentage;
-        let priority_fee_wei = self.config.priority_fee_wei;
 
         // Build the transaction request
         let mut tx_req = match aggregated_proof {
@@ -504,14 +501,7 @@ impl ProofAggregator {
         tx_req = tx_req.with_nonce(nonce);
 
         // Apply gas fee bump for retries
-        tx_req = self
-            .apply_gas_fee_bump(
-                base_bump_percentage,
-                max_fee_bump_percentage,
-                priority_fee_wei,
-                tx_req,
-            )
-            .await?;
+        tx_req = self.apply_gas_fee_bump(tx_req).await?;
 
         let provider = self.proof_aggregation_service.provider();
 
@@ -587,12 +577,13 @@ impl ProofAggregator {
 
     async fn apply_gas_fee_bump(
         &self,
-        base_bump_percentage: u64,
-        max_fee_bump_percentage: u64,
-        priority_fee_wei: u128,
         tx_req: TransactionRequest,
     ) -> Result<TransactionRequest, AggregatedProofSubmissionError> {
         let provider = self.proof_aggregation_service.provider();
+
+        let base_bump_percentage = self.config.base_bump_percentage;
+        let max_fee_bump_percentage = self.config.max_fee_bump_percentage;
+        let priority_fee_wei = self.config.priority_fee_wei;
 
         let latest_block = provider
             .get_block_by_number(BlockNumberOrTag::Latest)

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -335,9 +335,6 @@ impl ProofAggregator {
         info!("Sending proof to ProofAggregationService contract...");
 
         let max_retries = self.config.max_bump_retries;
-        let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
-        let base_bump_percentage = self.config.base_bump_percentage;
-        let retry_attempt_percentage = self.config.retry_attempt_percentage;
 
         let mut last_error: Option<AggregatedProofSubmissionError> = None;
 
@@ -350,10 +347,7 @@ impl ProofAggregator {
                     &blob,
                     blob_versioned_hash,
                     aggregated_proof,
-                    base_bump_percentage,
-                    retry_attempt_percentage,
                     attempt as u64,
-                    retry_interval,
                 )
                 .await;
 
@@ -393,11 +387,12 @@ impl ProofAggregator {
         blob: &BlobTransactionSidecar,
         blob_versioned_hash: [u8; 32],
         aggregated_proof: &AlignedProof,
-        base_bump_percentage: u64,
-        retry_attempt_percentage: u64,
         attempt: u64,
-        retry_interval: Duration,
     ) -> Result<TransactionReceipt, AggregatedProofSubmissionError> {
+        let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
+        let base_bump_percentage = self.config.base_bump_percentage;
+        let retry_attempt_percentage = self.config.retry_attempt_percentage;
+
         // Build the transaction request
         let mut tx_req = match aggregated_proof {
             AlignedProof::SP1(proof) => self
@@ -446,15 +441,13 @@ impl ProofAggregator {
             .await
             .map_err(|err| {
                 AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
-                    "Failed to fill transaction: {}",
-                    err
+                    "Failed to fill transaction: {err}"
                 ))
             })?
             .try_into_envelope()
             .map_err(|err| {
                 AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
-                    "Failed to convert to envelope: {}",
-                    err
+                    "Failed to convert to envelope: {err}"
                 ))
             })?;
 
@@ -463,8 +456,7 @@ impl ProofAggregator {
             .try_into_pooled()
             .map_err(|err| {
                 AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
-                    "Failed to pool transaction: {}",
-                    err
+                    "Failed to pool transaction: {err}"
                 ))
             })?
             .try_map_eip4844(|tx| {
@@ -472,8 +464,7 @@ impl ProofAggregator {
             })
             .map_err(|err| {
                 AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
-                    "Failed to convert to EIP-7594: {}",
-                    err
+                    "Failed to convert to EIP-7594: {err}"
                 ))
             })?;
 
@@ -484,8 +475,7 @@ impl ProofAggregator {
             .await
             .map_err(|err| {
                 AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
-                    "Failed to send raw transaction: {}",
-                    err
+                    "Failed to send raw transaction: {err}"
                 ))
             })?;
 
@@ -498,8 +488,7 @@ impl ProofAggregator {
             Ok(Ok(receipt)) => Ok(receipt),
             Ok(Err(err)) => Err(
                 AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
-                    "Error getting receipt: {}",
-                    err
+                    "Error getting receipt: {err}"
                 )),
             ),
             Err(_) => Err(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -23,7 +23,7 @@ use alloy::{
     eips::{eip4844::BYTES_PER_BLOB, eip7594::BlobTransactionSidecarEip7594, Encodable2718},
     hex,
     network::{EthereumWallet, TransactionBuilder},
-    primitives::{utils::parse_ether, Address, U256},
+    primitives::{utils::parse_ether, Address, TxHash, U256},
     providers::{PendingTransactionError, Provider, ProviderBuilder},
     rpc::types::{TransactionReceipt, TransactionRequest},
     signers::local::LocalSigner,
@@ -52,6 +52,11 @@ pub enum AggregatedProofSubmissionError {
     MerkleRootMisMatch,
     StoringMerklePaths(DbError),
     GasPriceError(String),
+}
+
+enum SubmitOutcome {
+    Confirmed(TransactionReceipt),
+    Pending(TxHash),
 }
 
 pub struct ProofAggregator {
@@ -342,6 +347,8 @@ impl ProofAggregator {
 
         let mut last_error: Option<AggregatedProofSubmissionError> = None;
 
+        let mut pending_hashes: Vec<TxHash> = Vec::with_capacity(max_retries as usize);
+
         // Get the nonce once at the beginning and reuse it for all retries
         let nonce = self
             .proof_aggregation_service
@@ -364,22 +371,34 @@ impl ProofAggregator {
             // Wrap the entire transaction submission in a result to catch all errors, passing
             // the same nonce to all attempts
             let attempt_result = self
-                .try_submit_transaction(
-                    &blob,
-                    blob_versioned_hash,
-                    aggregated_proof,
-                    attempt as u64,
-                    nonce,
-                )
+                .try_submit_transaction(&blob, blob_versioned_hash, aggregated_proof, nonce)
                 .await;
 
             match attempt_result {
-                Ok(receipt) => {
+                Ok(SubmitOutcome::Confirmed(receipt)) => {
                     info!(
                         "Transaction confirmed successfully on attempt {}",
                         attempt + 1
                     );
                     return Ok(receipt);
+                }
+                Ok(SubmitOutcome::Pending(tx_hash)) => {
+                    warn!(
+                    "Attempt {} timed out waiting for receipt; storing pending tx and continuing",
+                    attempt + 1
+                );
+                    pending_hashes.push(tx_hash);
+
+                    last_error = Some(
+                        AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                            "Timed out waiting for receipt".to_string(),
+                        ),
+                    );
+
+                    if attempt < max_retries - 1 {
+                        info!("Retrying with bumped gas fees and same nonce {}...", nonce);
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                    }
                 }
                 Err(err) => {
                     warn!("Attempt {} failed: {:?}", attempt + 1, err);
@@ -396,7 +415,36 @@ impl ProofAggregator {
             }
         }
 
-        // If we exhausted all retries, return the last error
+        // After exhausting all retry attempts, we iterate over every pending transaction hash
+        // that was previously submitted with the same nonce but different gas parameters.
+        // One of these transactions may have been included in a block while we were still
+        // retrying and waiting on others. By explicitly checking the receipt for each hash,
+        // we ensure we don't "lose" a transaction that was actually mined but whose receipt
+        // we never observed due to timeouts during earlier attempts.
+        for (i, tx_hash) in pending_hashes.into_iter().enumerate() {
+            match self
+                .proof_aggregation_service
+                .provider()
+                .get_transaction_receipt(tx_hash)
+                .await
+            {
+                Ok(Some(receipt)) => {
+                    info!("Pending tx #{} confirmed; returning receipt", i + 1);
+                    return Ok(receipt);
+                }
+                Ok(None) => {
+                    warn!(
+                        "Pending tx #{} still no receipt yet (hash {})",
+                        i + 1,
+                        tx_hash
+                    );
+                }
+                Err(err) => {
+                    warn!("Pending tx #{} receipt query failed: {:?}", i + 1, err);
+                }
+            }
+        }
+
         Err(RetryError::Transient(last_error.unwrap_or_else(|| {
             AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
                 "Max retries exceeded with no error details".to_string(),
@@ -409,9 +457,8 @@ impl ProofAggregator {
         blob: &BlobTransactionSidecar,
         blob_versioned_hash: [u8; 32],
         aggregated_proof: &AlignedProof,
-        _attempt: u64, // Check if this param is useful
         nonce: u64,
-    ) -> Result<TransactionReceipt, AggregatedProofSubmissionError> {
+    ) -> Result<SubmitOutcome, AggregatedProofSubmissionError> {
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
         let base_bump_percentage = self.config.base_bump_percentage;
         let max_fee_bump_percentage = self.config.max_fee_bump_percentage;
@@ -504,27 +551,18 @@ impl ProofAggregator {
                 ))
             })?;
 
-        info!(
-            "Transaction sent with nonce {}, waiting for confirmation...",
-            nonce
-        );
+        let tx_hash = *pending_tx.tx_hash();
 
-        // Wait for the receipt with timeout
         let receipt_result = tokio::time::timeout(retry_interval, pending_tx.get_receipt()).await;
 
         match receipt_result {
-            Ok(Ok(receipt)) => Ok(receipt),
+            Ok(Ok(receipt)) => Ok(SubmitOutcome::Confirmed(receipt)),
             Ok(Err(err)) => Err(
                 AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
                     "Error getting receipt: {err}"
                 )),
             ),
-            Err(_) => Err(
-                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
-                    "Transaction timeout after {} seconds",
-                    retry_interval.as_secs()
-                )),
-            ),
+            Err(_) => Ok(SubmitOutcome::Pending(tx_hash)),
         }
     }
 

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -558,9 +558,6 @@ impl ProofAggregator {
         let new_priority_fee = priority_fee_wei;
 
         Ok(tx_req
-            // In TransactionRequest docs the gas_price field is defined as
-            // "The max base fee per gas the sender is willing to pay."
-            .with_gas_price(new_base_fee as u128)
             .with_max_fee_per_gas(new_max_fee as u128)
             .with_max_priority_fee_per_gas(new_priority_fee))
     }

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -611,24 +611,25 @@ impl ProofAggregator {
             .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?
             as u128;
 
-        // Calculate priority fee: suggested * (1 + (attempt + 1), capped at max
-        let priority_fee_multiplier = attempt + 1;
+        // Calculate priority fee: suggested * (attempt + 1), capped at max
+        let priority_fee_multiplier = (attempt + 1) as u128;
         let max_priority_fee_per_gas = (suggested_priority_fee * priority_fee_multiplier)
             .min(max_priority_fee_upper_limit);
 
         // Calculate max fee with cumulative bump per attempt to ensure replacement tx is accepted
         let max_fee_multiplier = 1.0 + max_fee_bump_percentage as f64 / 100.0;
-        let max_fee_per_gas = max_fee_multiplier * current_base_fee + max_priority_fee_per_gas;
+        let max_fee_per_gas =
+            (max_fee_multiplier * current_base_fee) as u128 + max_priority_fee_per_gas;
 
         info!(
             "Base fee: {:.4} Gwei. Applying max_fee_per_gas: {:.4} Gwei and max_priority_fee_per_gas: {:.4} Gwei to tx",
             current_base_fee / 1e9,
-            max_fee_per_gas / 1e9,
-            max_priority_fee_per_gas / 1e9
+            max_fee_per_gas as f64 / 1e9,
+            max_priority_fee_per_gas as f64 / 1e9
         );
 
         Ok(tx_req
-            .with_max_fee_per_gas(max_fee_per_gas as u128)
+            .with_max_fee_per_gas(max_fee_per_gas)
             .with_max_priority_fee_per_gas(max_priority_fee_per_gas))
     }
 

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -24,7 +24,7 @@ use alloy::{
     hex,
     network::{EthereumWallet, TransactionBuilder},
     primitives::{utils::parse_ether, Address, U256},
-    providers::{PendingTransactionError, Provider, ProviderBuilder, WalletProvider},
+    providers::{PendingTransactionError, Provider, ProviderBuilder},
     rpc::types::{TransactionReceipt, TransactionRequest},
     signers::local::LocalSigner,
 };
@@ -73,7 +73,7 @@ impl ProofAggregator {
             config.ecdsa.private_key_store_password.clone(),
         )
         .expect("Keystore signer should be `cast wallet` compliant");
-        let wallet = EthereumWallet::from(signer);
+        let wallet = EthereumWallet::from(signer.clone());
 
         let signer_address = signer.address();
 
@@ -409,7 +409,7 @@ impl ProofAggregator {
         blob: &BlobTransactionSidecar,
         blob_versioned_hash: [u8; 32],
         aggregated_proof: &AlignedProof,
-        attempt: u64,
+        _attempt: u64, // Check if this param is useful
         nonce: u64,
     ) -> Result<TransactionReceipt, AggregatedProofSubmissionError> {
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -398,67 +398,32 @@ impl ProofAggregator {
                 }
                 Ok(SubmitOutcome::Pending(tx_hash)) => {
                     warn!(
-                    "Attempt {} timed out waiting for receipt; storing pending tx and continuing",
-                    attempt + 1
-                );
+                        "Attempt {} timed out waiting for receipt; storing pending tx",
+                        attempt + 1
+                    );
                     pending_hashes.push(tx_hash);
-
                     last_error = Some(
                         AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
                             "Timed out waiting for receipt".to_string(),
                         ),
                     );
-
-                    if attempt < max_retries - 1 {
-                        info!("Retrying with bumped gas fees and same nonce {}...", nonce);
-                        tokio::time::sleep(Duration::from_millis(500)).await;
-                    }
                 }
                 Err(err) => {
                     warn!("Attempt {} failed: {:?}", attempt + 1, err);
                     last_error = Some(err);
-
-                    if attempt < max_retries - 1 {
-                        info!("Retrying with bumped gas fees and same nonce {}...", nonce);
-
-                        tokio::time::sleep(Duration::from_millis(500)).await;
-                    } else {
-                        warn!("Max retries ({}) exceeded", max_retries);
-                    }
                 }
             }
-        }
 
-        // After exhausting all retry attempts, we iterate over every pending transaction hash
-        // that was previously submitted with the same nonce but different gas parameters.
-        // One of these transactions may have been included in a block while we were still
-        // retrying and waiting on others. By explicitly checking the receipt for each hash,
-        // we ensure we don't "lose" a transaction that was actually mined but whose receipt
-        // we never observed due to timeouts during earlier attempts.
-        for (i, tx_hash) in pending_hashes.into_iter().enumerate() {
-            match self
-                .proof_aggregation_service
-                .provider()
-                .get_transaction_receipt(tx_hash)
-                .await
-            {
-                Ok(Some(receipt)) => {
-                    info!("Pending tx #{} confirmed; returning receipt", i + 1);
-                    return Ok(receipt);
-                }
-                Ok(None) => {
-                    warn!(
-                        "Pending tx #{} still no receipt yet (hash {})",
-                        i + 1,
-                        tx_hash
-                    );
-                }
-                Err(err) => {
-                    warn!("Pending tx #{} receipt query failed: {:?}", i + 1, err);
-                }
+            // Check if any pending tx was confirmed before retrying
+            if let Some(receipt) = self.check_pending_txs_confirmed(&pending_hashes).await {
+                return Ok(receipt);
             }
+
+            info!("Retrying with bumped gas fees and same nonce {}...", nonce);
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
 
+        warn!("Max retries ({}) exceeded", max_retries);
         Err(RetryError::Transient(last_error.unwrap_or_else(|| {
             AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
                 "Max retries exceeded with no error details".to_string(),
@@ -571,6 +536,26 @@ impl ProofAggregator {
         }
     }
 
+    // Checks if any of the pending transactions have been confirmed.
+    // Returns the receipt if one is found, otherwise None.
+    async fn check_pending_txs_confirmed(
+        &self,
+        pending_hashes: &[TxHash],
+    ) -> Option<TransactionReceipt> {
+        for tx_hash in pending_hashes {
+            if let Ok(Some(receipt)) = self
+                .proof_aggregation_service
+                .provider()
+                .get_transaction_receipt(*tx_hash)
+                .await
+            {
+                info!("Pending tx {} confirmed before retry", tx_hash);
+                return Some(receipt);
+            }
+        }
+        None
+    }
+
     // Updates the gas fees of a `TransactionRequest` using EIP-1559 fee parameters.
     // Intended for retrying an on-chain submission after a timeout.
     //
@@ -613,8 +598,8 @@ impl ProofAggregator {
 
         // Calculate priority fee: suggested * (attempt + 1), capped at max
         let priority_fee_multiplier = (attempt + 1) as u128;
-        let max_priority_fee_per_gas = (suggested_priority_fee * priority_fee_multiplier)
-            .min(max_priority_fee_upper_limit);
+        let max_priority_fee_per_gas =
+            (suggested_priority_fee * priority_fee_multiplier).min(max_priority_fee_upper_limit);
 
         // Calculate max fee with cumulative bump per attempt to ensure replacement tx is accepted
         let max_fee_multiplier = 1.0 + max_fee_bump_percentage as f64 / 100.0;

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -374,7 +374,7 @@ impl ProofAggregator {
             // TODO: Move this to a separate method reset_gas_fees()
             // Increase gas price/fees for retries before filling
             if attempt > 0 {
-                let multiplier = fee_multiplier.powi(attempt as i32);
+                let multiplier = fee_multiplier.powi(attempt);
 
                 info!(
                     "Retry attempt {} with increased fee ({}x)",

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -379,7 +379,13 @@ impl ProofAggregator {
             // Wrap the entire transaction submission in a result to catch all errors, passing
             // the same nonce to all attempts
             let attempt_result = self
-                .try_submit_transaction(&blob, blob_versioned_hash, aggregated_proof, nonce)
+                .try_submit_transaction(
+                    &blob,
+                    blob_versioned_hash,
+                    aggregated_proof,
+                    nonce,
+                    attempt,
+                )
                 .await;
 
             match attempt_result {
@@ -466,6 +472,7 @@ impl ProofAggregator {
         blob_versioned_hash: [u8; 32],
         aggregated_proof: &AlignedProof,
         nonce: u64,
+        attempt: u16,
     ) -> Result<SubmitOutcome, AggregatedProofSubmissionError> {
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
 
@@ -501,7 +508,7 @@ impl ProofAggregator {
         tx_req = tx_req.with_nonce(nonce);
 
         // Apply gas fee bump for retries
-        tx_req = self.apply_gas_fee_bump(tx_req).await?;
+        tx_req = self.apply_gas_fee_bump(tx_req, attempt).await?;
 
         let provider = self.proof_aggregation_service.provider();
 
@@ -569,19 +576,21 @@ impl ProofAggregator {
     //
     // Strategy:
     // - Fetch the current base fee from the latest block.
-    // - Set `max_priority_fee_per_gas` to a fixed value from `priority_fee_wei`.
+    // - Fetch the suggested priority fee from the network (eth_maxPriorityFeePerGas).
+    // - Compute priority fee as: suggested * (1 + (attempt + 1) * 0.1), capped at `max_priority_fee_upper_limit`.
     // - Compute `max_fee_per_gas` as: (1 + max_fee_bump_percentage/100) * base_fee + priority_fee.
     //
-    // Fees are recomputed on each retry using the latest base fee (no incremental per-attempt bump).
+    // Fees are recomputed on each retry using the latest base fee.
 
     async fn apply_gas_fee_bump(
         &self,
         tx_req: TransactionRequest,
+        attempt: u16,
     ) -> Result<TransactionRequest, AggregatedProofSubmissionError> {
         let provider = self.proof_aggregation_service.provider();
 
         let max_fee_bump_percentage = self.config.max_fee_bump_percentage;
-        let priority_fee_wei = self.config.priority_fee_wei;
+        let max_priority_fee_upper_limit = self.config.max_priority_fee_upper_limit;
 
         let latest_block = provider
             .get_block_by_number(BlockNumberOrTag::Latest)
@@ -592,14 +601,34 @@ impl ProofAggregator {
         let current_base_fee = latest_block
             .header
             .base_fee_per_gas
-            .ok_or(AggregatedProofSubmissionError::BaseFeePerGasMissing)?;
+            .ok_or(AggregatedProofSubmissionError::BaseFeePerGasMissing)?
+            as f64;
+
+        // Fetch suggested priority fee from the network
+        let suggested_priority_fee = provider
+            .get_max_priority_fee_per_gas()
+            .await
+            .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?
+            as f64;
+
+        // Calculate priority fee: suggested * (1 + (attempt + 1) * 0.1), capped at max
+        let priority_fee_multiplier = 1.0 + (attempt + 1) as f64 * 0.1;
+        let max_priority_fee_per_gas = (suggested_priority_fee * priority_fee_multiplier)
+            .min(max_priority_fee_upper_limit as f64);
 
         let max_fee_multiplier = 1.0 + max_fee_bump_percentage as f64 / 100.0;
-        let new_max_fee = max_fee_multiplier * current_base_fee as f64 + priority_fee_wei as f64;
+        let max_fee_per_gas = max_fee_multiplier * current_base_fee + max_priority_fee_per_gas;
+
+        info!(
+            "Base fee: {:.4} Gwei. Applying max_fee_per_gas: {:.4} Gwei and max_priority_fee_per_gas: {:.4} Gwei to tx",
+            current_base_fee / 1e9,
+            max_fee_per_gas / 1e9,
+            max_priority_fee_per_gas / 1e9
+        );
 
         Ok(tx_req
-            .with_max_fee_per_gas(new_max_fee as u128)
-            .with_max_priority_fee_per_gas(priority_fee_wei))
+            .with_max_fee_per_gas(max_fee_per_gas as u128)
+            .with_max_priority_fee_per_gas(max_priority_fee_per_gas as u128))
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -423,6 +423,8 @@ impl ProofAggregator {
             }
         }
 
+        let receipt_timeout = Duration::from_secs(self.config.final_receipt_check_timeout_seconds);
+
         // After exhausting all retry attempts, we iterate over every pending transaction hash
         // that was previously submitted with the same nonce but different gas parameters.
         // One of these transactions may have been included in a block while we were still
@@ -430,25 +432,36 @@ impl ProofAggregator {
         // we ensure we don't "lose" a transaction that was actually mined but whose receipt
         // we never observed due to timeouts during earlier attempts.
         for (i, tx_hash) in pending_hashes.into_iter().enumerate() {
-            match self
-                .proof_aggregation_service
-                .provider()
-                .get_transaction_receipt(tx_hash)
-                .await
+            // NOTE: `get_transaction_receipt` has no built-in timeout, so we guard it to
+            // avoid hanging the aggregator on a stuck RPC call.
+            match tokio::time::timeout(
+                receipt_timeout,
+                self.proof_aggregation_service
+                    .provider()
+                    .get_transaction_receipt(tx_hash),
+            )
+            .await
             {
-                Ok(Some(receipt)) => {
+                Ok(Ok(Some(receipt))) => {
                     info!("Pending tx #{} confirmed; returning receipt", i + 1);
                     return Ok(receipt);
                 }
-                Ok(None) => {
+                Ok(Ok(None)) => {
                     warn!(
                         "Pending tx #{} still no receipt yet (hash {})",
                         i + 1,
                         tx_hash
                     );
                 }
-                Err(err) => {
+                Ok(Err(err)) => {
                     warn!("Pending tx #{} receipt query failed: {:?}", i + 1, err);
+                }
+                Err(_) => {
+                    warn!(
+                        "Pending tx #{} receipt query timed out after {:?}",
+                        i + 1,
+                        receipt_timeout
+                    );
                 }
             }
         }

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -593,8 +593,7 @@ impl ProofAggregator {
         let suggested_priority_fee = provider
             .get_max_priority_fee_per_gas()
             .await
-            .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?
-            as u128;
+            .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?;
 
         // Calculate priority fee: suggested * (attempt + 1), capped at max
         let priority_fee_multiplier = (attempt + 1) as u128;

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -609,13 +609,14 @@ impl ProofAggregator {
             .get_max_priority_fee_per_gas()
             .await
             .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?
-            as f64;
+            as u128;
 
-        // Calculate priority fee: suggested * (1 + (attempt + 1) * 0.1), capped at max
-        let priority_fee_multiplier = 1.0 + (attempt + 1) as f64 * 0.1;
+        // Calculate priority fee: suggested * (1 + (attempt + 1), capped at max
+        let priority_fee_multiplier = attempt + 1;
         let max_priority_fee_per_gas = (suggested_priority_fee * priority_fee_multiplier)
-            .min(max_priority_fee_upper_limit as f64);
+            .min(max_priority_fee_upper_limit);
 
+        // Calculate max fee with cumulative bump per attempt to ensure replacement tx is accepted
         let max_fee_multiplier = 1.0 + max_fee_bump_percentage as f64 / 100.0;
         let max_fee_per_gas = max_fee_multiplier * current_base_fee + max_priority_fee_per_gas;
 
@@ -628,7 +629,7 @@ impl ProofAggregator {
 
         Ok(tx_req
             .with_max_fee_per_gas(max_fee_per_gas as u128)
-            .with_max_priority_fee_per_gas(max_priority_fee_per_gas as u128))
+            .with_max_priority_fee_per_gas(max_priority_fee_per_gas))
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -62,6 +62,7 @@ pub struct ProofAggregator {
     sp1_chunk_aggregator_vk_hash_bytes: [u8; 32],
     risc0_chunk_aggregator_image_id_bytes: [u8; 32],
     db: Db,
+    signer_address: Address,
 }
 
 impl ProofAggregator {
@@ -73,6 +74,8 @@ impl ProofAggregator {
         )
         .expect("Keystore signer should be `cast wallet` compliant");
         let wallet = EthereumWallet::from(signer);
+
+        let signer_address = signer.address();
 
         // Check if the monthly budget is non-negative to avoid runtime errors later
         let _monthly_budget_in_wei = parse_ether(&config.monthly_budget_eth.to_string())
@@ -117,6 +120,7 @@ impl ProofAggregator {
             sp1_chunk_aggregator_vk_hash_bytes,
             risc0_chunk_aggregator_image_id_bytes,
             db,
+            signer_address,
         }
     }
 
@@ -342,11 +346,7 @@ impl ProofAggregator {
         let nonce = self
             .proof_aggregation_service
             .provider()
-            .get_transaction_count(
-                self.proof_aggregation_service
-                    .provider()
-                    .default_signer_address(),
-            )
+            .get_transaction_count(self.signer_address)
             .await
             .map_err(|e| {
                 RetryError::Transient(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -369,44 +369,14 @@ impl ProofAggregator {
                 }
             };
 
-            let provider = self.proof_aggregation_service.provider();
-
-            // TODO: Move this to a separate method reset_gas_fees()
             // Increase gas price/fees for retries before filling
             if attempt > 0 {
-                let multiplier = fee_multiplier.powi(attempt);
-
-                info!(
-                    "Retry attempt {} with increased fee ({}x)",
-                    attempt, multiplier
-                );
-
-                // Obtain the current gas price if not set
-                if tx_req.max_fee_per_gas.is_none() {
-                    let current_gas_price = provider.get_gas_price().await.map_err(|e| {
-                        RetryError::Transient(AggregatedProofSubmissionError::GasPriceError(
-                            e.to_string(),
-                        ))
-                    })?;
-
-                    let new_max_fee = (current_gas_price as f64 * multiplier) as u128;
-                    let new_priority_fee = (current_gas_price as f64 * multiplier * 0.1) as u128;
-
-                    tx_req = tx_req
-                        .with_max_fee_per_gas(new_max_fee)
-                        .with_max_priority_fee_per_gas(new_priority_fee);
-                } else {
-                    // If set, multiplicate the current ones
-                    if let Some(max_fee) = tx_req.max_fee_per_gas {
-                        let new_max_fee = (max_fee as f64 * multiplier) as u128;
-                        tx_req = tx_req.with_max_fee_per_gas(new_max_fee);
-                    }
-                    if let Some(priority_fee) = tx_req.max_priority_fee_per_gas {
-                        let new_priority_fee = (priority_fee as f64 * multiplier * 0.1) as u128;
-                        tx_req = tx_req.with_max_priority_fee_per_gas(new_priority_fee);
-                    }
-                }
+                tx_req = self
+                    .update_gas_fees(fee_multiplier, attempt, tx_req)
+                    .await?;
             }
+
+            let provider = self.proof_aggregation_service.provider();
 
             let envelope = provider
                 .fill(tx_req)
@@ -498,6 +468,69 @@ impl ProofAggregator {
                 "Max retries exceeded".to_string(),
             ),
         ))
+    }
+
+    // Updates the gas fees of a `TransactionRequest` for retry attempts by applying an exponential fee
+    // multiplier based on the retry number. This method is intended to be used when a previous transaction
+    // attempt was not confirmed (e.g. receipt timeout or transient failure). By increasing the gas fees
+    // on each retry, it improves the likelihood that the transaction will be included
+    // on the next block.
+    //
+    // Fee strategy:
+    // An exponential multiplier is computed on each iteration. For example, with `fee_multiplier = 1.2`:
+    //   - `attempt = 1` → `1.2x`
+    //   - `attempt = 2` → `1.44x`
+    //   - `attempt = 3` → `1.728x`
+    //
+    // If the transaction request doesn't have `max_fee_per_gas` set, the current network gas price is fetched
+    // from the provider, the max fee per gas is set to `current_gas_price * multiplier` and the max priority
+    // fee per gas is set to `current_gas_price * multiplier * 0.1`.
+    //
+    // If the transaction request already contains the fee fields, the existing max fee per gas is multiplied
+    // by `multiplier`, and the existing max priority fee per gas is multiplied by multiplier * 0.1`.
+    async fn update_gas_fees(
+        &self,
+        fee_multiplier: f64,
+        attempt: i32,
+        tx_req: alloy::rpc::types::TransactionRequest,
+    ) -> Result<alloy::rpc::types::TransactionRequest, RetryError<AggregatedProofSubmissionError>>
+    {
+        let provider = self.proof_aggregation_service.provider();
+
+        let multiplier = fee_multiplier.powi(attempt);
+
+        info!(
+            "Retry attempt {} with increased fee ({}x)",
+            attempt, multiplier
+        );
+
+        let mut current_tx_req = tx_req.clone();
+
+        // Obtain the current gas price if not set
+        if tx_req.max_fee_per_gas.is_none() {
+            let current_gas_price = provider.get_gas_price().await.map_err(|e| {
+                RetryError::Transient(AggregatedProofSubmissionError::GasPriceError(e.to_string()))
+            })?;
+
+            let new_max_fee = (current_gas_price as f64 * multiplier) as u128;
+            let new_priority_fee = (current_gas_price as f64 * multiplier * 0.1) as u128;
+
+            current_tx_req = current_tx_req
+                .with_max_fee_per_gas(new_max_fee)
+                .with_max_priority_fee_per_gas(new_priority_fee);
+        } else {
+            // If set, multiplicate the current ones
+            if let Some(max_fee) = tx_req.max_fee_per_gas {
+                let new_max_fee = (max_fee as f64 * multiplier) as u128;
+                current_tx_req = tx_req.clone().with_max_fee_per_gas(new_max_fee);
+            }
+            if let Some(priority_fee) = tx_req.max_priority_fee_per_gas {
+                let new_priority_fee = (priority_fee as f64 * multiplier * 0.1) as u128;
+                current_tx_req = tx_req.with_max_priority_fee_per_gas(new_priority_fee);
+            }
+        }
+
+        Ok(current_tx_req)
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -411,7 +411,7 @@ impl ProofAggregator {
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
         let base_bump_percentage = self.config.base_bump_percentage;
         let max_fee_bump_percentage = self.config.max_fee_bump_percentage;
-        let priority_fee_gwei = self.config.priority_fee_gwei;
+        let priority_fee_wei = self.config.priority_fee_wei;
 
         // Build the transaction request
         let mut tx_req = match aggregated_proof {
@@ -450,7 +450,7 @@ impl ProofAggregator {
                 .apply_gas_fee_bump(
                     base_bump_percentage,
                     max_fee_bump_percentage,
-                    priority_fee_gwei,
+                    priority_fee_wei,
                     tx_req,
                 )
                 .await?;
@@ -533,7 +533,7 @@ impl ProofAggregator {
     // - Fetch the current network gas price.
     // - Apply `base_bump_percentage` to compute a bumped base fee.
     // - Apply `max_fee_bump_percentage` on top of the bumped base fee to set `max_fee_per_gas`.
-    // - Set `max_priority_fee_per_gas` to a fixed value derived from `priority_fee_gwei`.
+    // - Set `max_priority_fee_per_gas` to a fixed value derived from `priority_fee_wei`.
     //
     // Fees are recomputed on each retry using the latest gas price (no incremental per-attempt bump).
 
@@ -541,7 +541,7 @@ impl ProofAggregator {
         &self,
         base_bump_percentage: u64,
         max_fee_bump_percentage: u64,
-        priority_fee_gwei: u128,
+        priority_fee_wei: u128,
         tx_req: TransactionRequest,
     ) -> Result<TransactionRequest, AggregatedProofSubmissionError> {
         let provider = self.proof_aggregation_service.provider();
@@ -553,7 +553,7 @@ impl ProofAggregator {
 
         let new_base_fee = current_gas_price * (1 + base_bump_percentage as u128 / 100);
         let new_max_fee = new_base_fee * (1 + max_fee_bump_percentage as u128 / 100);
-        let new_priority_fee = priority_fee_gwei * 1000000000; // Convert to wei
+        let new_priority_fee = priority_fee_wei;
 
         Ok(tx_req
             .with_max_fee_per_gas(new_max_fee)

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -564,16 +564,15 @@ impl ProofAggregator {
         }
     }
 
-    // Updates the gas fees of a `TransactionRequest` using a fixed bump strategy.
+    // Updates the gas fees of a `TransactionRequest` using EIP-1559 fee parameters.
     // Intended for retrying an on-chain submission after a timeout.
     //
     // Strategy:
-    // - Fetch the current network gas price.
-    // - Apply `base_bump_percentage` to compute a bumped base fee.
-    // - Apply `max_fee_bump_percentage` on top of the bumped base fee to set `max_fee_per_gas`.
-    // - Set `max_priority_fee_per_gas` to a fixed value derived from `priority_fee_wei`.
+    // - Fetch the current base fee from the latest block.
+    // - Set `max_priority_fee_per_gas` to a fixed value from `priority_fee_wei`.
+    // - Compute `max_fee_per_gas` as: (1 + max_fee_bump_percentage/100) * base_fee + priority_fee.
     //
-    // Fees are recomputed on each retry using the latest gas price (no incremental per-attempt bump).
+    // Fees are recomputed on each retry using the latest base fee (no incremental per-attempt bump).
 
     async fn apply_gas_fee_bump(
         &self,
@@ -581,7 +580,6 @@ impl ProofAggregator {
     ) -> Result<TransactionRequest, AggregatedProofSubmissionError> {
         let provider = self.proof_aggregation_service.provider();
 
-        let base_bump_percentage = self.config.base_bump_percentage;
         let max_fee_bump_percentage = self.config.max_fee_bump_percentage;
         let priority_fee_wei = self.config.priority_fee_wei;
 
@@ -596,8 +594,8 @@ impl ProofAggregator {
             .base_fee_per_gas
             .ok_or(AggregatedProofSubmissionError::BaseFeePerGasMissing)?;
 
-        let new_base_fee = current_base_fee as f64 * (1.0 + base_bump_percentage as f64 / 100.0);
-        let new_max_fee = new_base_fee * (1.0 + max_fee_bump_percentage as f64 / 100.0);
+        let max_fee_multiplier = 1.0 + max_fee_bump_percentage as f64 / 100.0;
+        let new_max_fee = max_fee_multiplier * current_base_fee as f64 + priority_fee_wei as f64;
 
         Ok(tx_req
             .with_max_fee_per_gas(new_max_fee as u128)

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -22,7 +22,7 @@ use alloy::{
     consensus::{BlobTransactionSidecar, EnvKzgSettings, EthereumTxEnvelope, TxEip4844WithSidecar},
     eips::{eip4844::BYTES_PER_BLOB, eip7594::BlobTransactionSidecarEip7594, Encodable2718},
     hex,
-    network::EthereumWallet,
+    network::{EthereumWallet, TransactionBuilder},
     primitives::{utils::parse_ether, Address, U256},
     providers::{PendingTransactionError, Provider, ProviderBuilder},
     rpc::types::TransactionReceipt,
@@ -334,90 +334,170 @@ impl ProofAggregator {
 
         info!("Sending proof to ProofAggregationService contract...");
 
-        let tx_req = match aggregated_proof {
-            AlignedProof::SP1(proof) => self
-                .proof_aggregation_service
-                .verifyAggregationSP1(
-                    blob_versioned_hash.into(),
-                    proof.proof_with_pub_values.public_values.to_vec().into(),
-                    proof.proof_with_pub_values.bytes().into(),
-                    self.sp1_chunk_aggregator_vk_hash_bytes.into(),
-                )
-                .sidecar(blob)
-                .into_transaction_request(),
-            AlignedProof::Risc0(proof) => {
-                let encoded_seal = encode_seal(&proof.receipt)
-                    .map_err(|e| AggregatedProofSubmissionError::Risc0EncodingSeal(e.to_string()))
-                    .map_err(RetryError::Permanent)?;
-                self.proof_aggregation_service
-                    .verifyAggregationRisc0(
+        // TODO: Read from config
+        let max_retries = 5;
+        let retry_interval = Duration::from_secs(120);
+        let fee_multiplier: f64 = 1.2;
+
+        for attempt in 0..max_retries {
+            let mut tx_req = match aggregated_proof {
+                AlignedProof::SP1(proof) => self
+                    .proof_aggregation_service
+                    .verifyAggregationSP1(
                         blob_versioned_hash.into(),
-                        encoded_seal.into(),
-                        proof.receipt.journal.bytes.clone().into(),
-                        self.risc0_chunk_aggregator_image_id_bytes.into(),
+                        proof.proof_with_pub_values.public_values.to_vec().into(),
+                        proof.proof_with_pub_values.bytes().into(),
+                        self.sp1_chunk_aggregator_vk_hash_bytes.into(),
                     )
-                    .sidecar(blob)
-                    .into_transaction_request()
+                    .sidecar(blob.clone())
+                    .into_transaction_request(),
+                AlignedProof::Risc0(proof) => {
+                    let encoded_seal = encode_seal(&proof.receipt)
+                        .map_err(|e| {
+                            AggregatedProofSubmissionError::Risc0EncodingSeal(e.to_string())
+                        })
+                        .map_err(RetryError::Permanent)?;
+                    self.proof_aggregation_service
+                        .verifyAggregationRisc0(
+                            blob_versioned_hash.into(),
+                            encoded_seal.into(),
+                            proof.receipt.journal.bytes.clone().into(),
+                            self.risc0_chunk_aggregator_image_id_bytes.into(),
+                        )
+                        .sidecar(blob.clone())
+                        .into_transaction_request()
+                }
+            };
+
+            let provider = self.proof_aggregation_service.provider();
+
+            // TODO: Move this to a separate method reset_gas_fees()
+            // Increase gas price/fees for retries before filling
+            if attempt > 0 {
+                let multiplier = fee_multiplier.powi(attempt as i32);
+
+                info!(
+                    "Retry attempt {} with increased fee ({}x)",
+                    attempt, multiplier
+                );
+
+                // Obtain the current gas price if not set
+                if tx_req.max_fee_per_gas.is_none() {
+                    let current_gas_price = provider.get_gas_price().await.map_err(|e| {
+                        RetryError::Transient(AggregatedProofSubmissionError::GasPriceError(
+                            e.to_string(),
+                        ))
+                    })?;
+
+                    let new_max_fee = (current_gas_price as f64 * multiplier) as u128;
+                    let new_priority_fee = (current_gas_price as f64 * multiplier * 0.1) as u128;
+
+                    tx_req = tx_req
+                        .with_max_fee_per_gas(new_max_fee)
+                        .with_max_priority_fee_per_gas(new_priority_fee);
+                } else {
+                    // If set, multiplicate the current ones
+                    if let Some(max_fee) = tx_req.max_fee_per_gas {
+                        let new_max_fee = (max_fee as f64 * multiplier) as u128;
+                        tx_req = tx_req.with_max_fee_per_gas(new_max_fee);
+                    }
+                    if let Some(priority_fee) = tx_req.max_priority_fee_per_gas {
+                        let new_priority_fee = (priority_fee as f64 * multiplier * 0.1) as u128;
+                        tx_req = tx_req.with_max_priority_fee_per_gas(new_priority_fee);
+                    }
+                }
             }
-        };
 
-        let provider = self.proof_aggregation_service.provider();
-        let envelope = provider
-            .fill(tx_req)
-            .await
-            .map_err(|err| {
-                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                    err.to_string(),
-                )
-            })
-            .map_err(RetryError::Transient)?
-            .try_into_envelope()
-            .map_err(|err| {
-                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                    err.to_string(),
-                )
-            })
-            .map_err(RetryError::Transient)?;
-        let tx: EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> = envelope
-            .try_into_pooled()
-            .map_err(|err| {
-                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                    err.to_string(),
-                )
-            })
-            .map_err(RetryError::Transient)?
-            .try_map_eip4844(|tx| {
-                tx.try_map_sidecar(|sidecar| sidecar.try_into_7594(EnvKzgSettings::Default.get()))
-            })
-            .map_err(|err| {
-                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                    err.to_string(),
-                )
-            })
-            .map_err(RetryError::Transient)?;
+            let envelope = provider
+                .fill(tx_req)
+                .await
+                .map_err(|err| {
+                    AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                        err.to_string(),
+                    )
+                })
+                .map_err(RetryError::Transient)?
+                .try_into_envelope()
+                .map_err(|err| {
+                    AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                        err.to_string(),
+                    )
+                })
+                .map_err(RetryError::Transient)?;
 
-        let encoded_tx = tx.encoded_2718();
-        let pending_tx = provider
-            .send_raw_transaction(&encoded_tx)
-            .await
-            .map_err(|err| {
-                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                    err.to_string(),
-                )
-            })
-            .map_err(RetryError::Transient)?;
+            let tx: EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> =
+                envelope
+                    .try_into_pooled()
+                    .map_err(|err| {
+                        AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                            err.to_string(),
+                        )
+                    })
+                    .map_err(RetryError::Transient)?
+                    .try_map_eip4844(|tx| {
+                        tx.try_map_sidecar(|sidecar| {
+                            sidecar.try_into_7594(EnvKzgSettings::Default.get())
+                        })
+                    })
+                    .map_err(|err| {
+                        AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                            err.to_string(),
+                        )
+                    })
+                    .map_err(RetryError::Transient)?;
 
-        let receipt = pending_tx
-            .get_receipt()
-            .await
-            .map_err(|err| {
-                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                    err.to_string(),
-                )
-            })
-            .map_err(RetryError::Transient)?;
+            let encoded_tx = tx.encoded_2718();
+            let pending_tx = provider
+                .send_raw_transaction(&encoded_tx)
+                .await
+                .map_err(|err| {
+                    AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                        err.to_string(),
+                    )
+                })
+                .map_err(RetryError::Transient)?;
 
-        Ok(receipt)
+            // Wait for the receipt with timeout
+            let receipt_result =
+                tokio::time::timeout(retry_interval, pending_tx.get_receipt()).await;
+
+            match receipt_result {
+                Ok(Ok(receipt)) => {
+                    info!(
+                        "Transaction confirmed successfully on attempt {}",
+                        attempt + 1
+                    );
+                    return Ok(receipt);
+                }
+                Ok(Err(err)) => {
+                    warn!("Error getting receipt on attempt {}: {}", attempt + 1, err);
+                    if attempt == max_retries - 1 {
+                        return Err(RetryError::Transient(
+                            AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                                err.to_string(),
+                            ),
+                        ));
+                    }
+                }
+                Err(_) => {
+                    warn!("Transaction not confirmed after {} seconds on attempt {}, retrying with higher fee...", 
+                    retry_interval.as_secs(), attempt + 1);
+                    if attempt == max_retries - 1 {
+                        return Err(RetryError::Transient(
+                            AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                                "Transaction timeout after all retries".to_string(),
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        Err(RetryError::Transient(
+            AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
+                "Max retries exceeded".to_string(),
+            ),
+        ))
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -334,10 +334,9 @@ impl ProofAggregator {
 
         info!("Sending proof to ProofAggregationService contract...");
 
-        // TODO: Read from config
-        let max_retries = 5;
-        let retry_interval = Duration::from_secs(120);
-        let fee_multiplier: f64 = 1.2;
+        let max_retries = self.config.max_bump_retries;
+        let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
+        let fee_multiplier: f64 = self.config.bump_increase_fee_multiplier;
 
         for attempt in 0..max_retries {
             let mut tx_req = match aggregated_proof {
@@ -372,7 +371,7 @@ impl ProofAggregator {
             // Increase gas price/fees for retries before filling
             if attempt > 0 {
                 tx_req = self
-                    .update_gas_fees(fee_multiplier, attempt, tx_req)
+                    .update_gas_fees(fee_multiplier, attempt as i32, tx_req)
                     .await?;
             }
 

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -423,8 +423,6 @@ impl ProofAggregator {
             }
         }
 
-        let receipt_timeout = Duration::from_secs(self.config.final_receipt_check_timeout_seconds);
-
         // After exhausting all retry attempts, we iterate over every pending transaction hash
         // that was previously submitted with the same nonce but different gas parameters.
         // One of these transactions may have been included in a block while we were still
@@ -432,36 +430,25 @@ impl ProofAggregator {
         // we ensure we don't "lose" a transaction that was actually mined but whose receipt
         // we never observed due to timeouts during earlier attempts.
         for (i, tx_hash) in pending_hashes.into_iter().enumerate() {
-            // NOTE: `get_transaction_receipt` has no built-in timeout, so we guard it to
-            // avoid hanging the aggregator on a stuck RPC call.
-            match tokio::time::timeout(
-                receipt_timeout,
-                self.proof_aggregation_service
-                    .provider()
-                    .get_transaction_receipt(tx_hash),
-            )
-            .await
+            match self
+                .proof_aggregation_service
+                .provider()
+                .get_transaction_receipt(tx_hash)
+                .await
             {
-                Ok(Ok(Some(receipt))) => {
+                Ok(Some(receipt)) => {
                     info!("Pending tx #{} confirmed; returning receipt", i + 1);
                     return Ok(receipt);
                 }
-                Ok(Ok(None)) => {
+                Ok(None) => {
                     warn!(
                         "Pending tx #{} still no receipt yet (hash {})",
                         i + 1,
                         tx_hash
                     );
                 }
-                Ok(Err(err)) => {
+                Err(err) => {
                     warn!("Pending tx #{} receipt query failed: {:?}", i + 1, err);
-                }
-                Err(_) => {
-                    warn!(
-                        "Pending tx #{} receipt query timed out after {:?}",
-                        i + 1,
-                        receipt_timeout
-                    );
                 }
             }
         }

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -25,7 +25,7 @@ use alloy::{
     network::{EthereumWallet, TransactionBuilder},
     primitives::{utils::parse_ether, Address, U256},
     providers::{PendingTransactionError, Provider, ProviderBuilder},
-    rpc::types::TransactionReceipt,
+    rpc::types::{TransactionReceipt, TransactionRequest},
     signers::local::LocalSigner,
 };
 use config::Config;
@@ -391,7 +391,8 @@ impl ProofAggregator {
     ) -> Result<TransactionReceipt, AggregatedProofSubmissionError> {
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
         let base_bump_percentage = self.config.base_bump_percentage;
-        let retry_attempt_percentage = self.config.retry_attempt_percentage;
+        let max_fee_bump_percentage = self.config.max_fee_bump_percentage;
+        let priority_fee_gwei = self.config.priority_fee_gwei;
 
         // Build the transaction request
         let mut tx_req = match aggregated_proof {
@@ -426,8 +427,8 @@ impl ProofAggregator {
             tx_req = self
                 .apply_gas_fee_bump(
                     base_bump_percentage,
-                    retry_attempt_percentage,
-                    attempt,
+                    max_fee_bump_percentage,
+                    priority_fee_gwei,
                     tx_req,
                 )
                 .await?;
@@ -500,70 +501,38 @@ impl ProofAggregator {
         }
     }
 
-    // Updates the gas fees of a `TransactionRequest` for retry attempts by applying a linear fee
-    // bump based on the retry number. This method is intended to be used when a previous transaction
-    // attempt was not confirmed (e.g. receipt timeout or transient failure).
+    // Updates the gas fees of a `TransactionRequest` using a fixed bump strategy.
+    // Intended for retrying an on-chain submission after a timeout.
     //
-    // Fee strategy (similar to Go implementation):
-    // The bump is calculated as: base_bump_percentage + (retry_count * retry_attempt_percentage)
-    // For example, with `base_bump_percentage = 10` and `retry_attempt_percentage = 5`:
-    //   - `attempt = 1` → 10% + (1 * 5%) = 15% bump
-    //   - `attempt = 2` → 10% + (2 * 5%) = 20% bump
-    //   - `attempt = 3` → 10% + (3 * 5%) = 25% bump
+    // Strategy:
+    // - Fetch the current network gas price.
+    // - Apply `base_bump_percentage` to compute a bumped base fee.
+    // - Apply `max_fee_bump_percentage` on top of the bumped base fee to set `max_fee_per_gas`.
+    // - Set `max_priority_fee_per_gas` to a fixed value derived from `priority_fee_gwei`.
     //
-    // The bumped price is: current_gas_price * (1 + total_bump_percentage / 100)
+    // Fees are recomputed on each retry using the latest gas price (no incremental per-attempt bump).
+
     async fn apply_gas_fee_bump(
         &self,
         base_bump_percentage: u64,
-        retry_attempt_percentage: u64,
-        attempt: u64,
-        tx_req: alloy::rpc::types::TransactionRequest,
-    ) -> Result<alloy::rpc::types::TransactionRequest, AggregatedProofSubmissionError> {
+        max_fee_bump_percentage: u64,
+        priority_fee_gwei: u128,
+        tx_req: TransactionRequest,
+    ) -> Result<TransactionRequest, AggregatedProofSubmissionError> {
         let provider = self.proof_aggregation_service.provider();
 
-        // Calculate total bump percentage: base + (retry_count * retry_attempt)
-        let incremental_retry_percentage = retry_attempt_percentage * attempt;
-        let total_bump_percentage = base_bump_percentage + incremental_retry_percentage;
+        let current_gas_price = provider
+            .get_gas_price()
+            .await
+            .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?;
 
-        info!(
-            "Applying {}% gas fee bump for attempt {}",
-            total_bump_percentage,
-            attempt + 1
-        );
+        let new_base_fee = current_gas_price * (1 + base_bump_percentage as u128 / 100);
+        let new_max_fee = new_base_fee * (1 + max_fee_bump_percentage as u128 / 100);
+        let new_priority_fee = priority_fee_gwei * 1000000000; // Convert to wei
 
-        let mut current_tx_req = tx_req.clone();
-
-        if current_tx_req.max_fee_per_gas.is_none() {
-            let current_gas_price = provider
-                .get_gas_price()
-                .await
-                .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?;
-
-            let new_max_fee =
-                Self::calculate_bumped_price(current_gas_price, total_bump_percentage);
-            let new_priority_fee = new_max_fee / 10;
-
-            current_tx_req = current_tx_req
-                .with_max_fee_per_gas(new_max_fee)
-                .with_max_priority_fee_per_gas(new_priority_fee);
-        } else {
-            if let Some(max_fee) = current_tx_req.max_fee_per_gas {
-                let new_max_fee = Self::calculate_bumped_price(max_fee, total_bump_percentage);
-                current_tx_req = current_tx_req.with_max_fee_per_gas(new_max_fee);
-            }
-            if let Some(priority_fee) = current_tx_req.max_priority_fee_per_gas {
-                let new_priority_fee =
-                    Self::calculate_bumped_price(priority_fee, total_bump_percentage);
-                current_tx_req = current_tx_req.with_max_priority_fee_per_gas(new_priority_fee);
-            }
-        }
-
-        Ok(current_tx_req)
-    }
-
-    fn calculate_bumped_price(current_price: u128, total_bump_percentage: u64) -> u128 {
-        let bump_amount = (current_price * total_bump_percentage as u128) / 100;
-        current_price + bump_amount
+        Ok(tx_req
+            .with_max_fee_per_gas(new_max_fee)
+            .with_max_priority_fee_per_gas(new_priority_fee))
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -556,7 +556,7 @@ impl ProofAggregator {
             .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?;
 
         let new_base_fee = current_gas_price as f64 * (1.0 + base_bump_percentage as f64 / 100.0);
-        let new_max_fee = new_base_fee as f64 * (1.0 + max_fee_bump_percentage as f64 / 100.0);
+        let new_max_fee = new_base_fee * (1.0 + max_fee_bump_percentage as f64 / 100.0);
         let new_priority_fee = priority_fee_wei;
 
         Ok(tx_req
@@ -564,7 +564,7 @@ impl ProofAggregator {
             // "The max base fee per gas the sender is willing to pay."
             .with_gas_price(new_base_fee as u128)
             .with_max_fee_per_gas(new_max_fee as u128)
-            .with_max_priority_fee_per_gas(new_priority_fee as u128))
+            .with_max_priority_fee_per_gas(new_priority_fee))
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -505,8 +505,7 @@ impl ProofAggregator {
 
         let mut current_tx_req = tx_req.clone();
 
-        // Obtain the current gas price if not set
-        if tx_req.max_fee_per_gas.is_none() {
+        if current_tx_req.max_fee_per_gas.is_none() {
             let current_gas_price = provider.get_gas_price().await.map_err(|e| {
                 RetryError::Transient(AggregatedProofSubmissionError::GasPriceError(e.to_string()))
             })?;
@@ -518,14 +517,13 @@ impl ProofAggregator {
                 .with_max_fee_per_gas(new_max_fee)
                 .with_max_priority_fee_per_gas(new_priority_fee);
         } else {
-            // If set, multiplicate the current ones
-            if let Some(max_fee) = tx_req.max_fee_per_gas {
+            if let Some(max_fee) = current_tx_req.max_fee_per_gas {
                 let new_max_fee = (max_fee as f64 * multiplier) as u128;
-                current_tx_req = tx_req.clone().with_max_fee_per_gas(new_max_fee);
+                current_tx_req = current_tx_req.with_max_fee_per_gas(new_max_fee);
             }
-            if let Some(priority_fee) = tx_req.max_priority_fee_per_gas {
-                let new_priority_fee = (priority_fee as f64 * multiplier * 0.1) as u128;
-                current_tx_req = tx_req.with_max_priority_fee_per_gas(new_priority_fee);
+            if let Some(priority_fee) = current_tx_req.max_priority_fee_per_gas {
+                let new_priority_fee = (priority_fee as f64 * multiplier) as u128;
+                current_tx_req = current_tx_req.with_max_priority_fee_per_gas(new_priority_fee);
             }
         }
 

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -560,6 +560,9 @@ impl ProofAggregator {
         let new_priority_fee = priority_fee_wei;
 
         Ok(tx_req
+            // In TransactionRequest docs the gas_price field is defined as
+            // "The max base fee per gas the sender is willing to pay."
+            .with_gas_price(new_base_fee as u128)
             .with_max_fee_per_gas(new_max_fee as u128)
             .with_max_priority_fee_per_gas(new_priority_fee as u128))
     }

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -449,16 +449,14 @@ impl ProofAggregator {
         tx_req = tx_req.with_nonce(nonce);
 
         // Apply gas fee bump for retries
-        if attempt > 0 {
-            tx_req = self
-                .apply_gas_fee_bump(
-                    base_bump_percentage,
-                    max_fee_bump_percentage,
-                    priority_fee_wei,
-                    tx_req,
-                )
-                .await?;
-        }
+        tx_req = self
+            .apply_gas_fee_bump(
+                base_bump_percentage,
+                max_fee_bump_percentage,
+                priority_fee_wei,
+                tx_req,
+            )
+            .await?;
 
         let provider = self.proof_aggregation_service.provider();
 

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -24,7 +24,7 @@ use alloy::{
     hex,
     network::{EthereumWallet, TransactionBuilder},
     primitives::{utils::parse_ether, Address, U256},
-    providers::{PendingTransactionError, Provider, ProviderBuilder},
+    providers::{PendingTransactionError, Provider, ProviderBuilder, WalletProvider},
     rpc::types::{TransactionReceipt, TransactionRequest},
     signers::local::LocalSigner,
 };
@@ -342,7 +342,11 @@ impl ProofAggregator {
         let nonce = self
             .proof_aggregation_service
             .provider()
-            .get_transaction_count(*self.proof_aggregation_service.address())
+            .get_transaction_count(
+                self.proof_aggregation_service
+                    .provider()
+                    .default_signer_address(),
+            )
             .await
             .map_err(|e| {
                 RetryError::Transient(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -336,143 +336,179 @@ impl ProofAggregator {
 
         let max_retries = self.config.max_bump_retries;
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
-        let base_bump_percentage = self.config.base_bump_percentage; // e.g., 10
-        let retry_attempt_percentage = self.config.retry_attempt_percentage; // e.g., 5
+        let base_bump_percentage = self.config.base_bump_percentage;
+        let retry_attempt_percentage = self.config.retry_attempt_percentage;
+
+        let mut last_error: Option<AggregatedProofSubmissionError> = None;
 
         for attempt in 0..max_retries {
-            let mut tx_req = match aggregated_proof {
-                AlignedProof::SP1(proof) => self
-                    .proof_aggregation_service
-                    .verifyAggregationSP1(
-                        blob_versioned_hash.into(),
-                        proof.proof_with_pub_values.public_values.to_vec().into(),
-                        proof.proof_with_pub_values.bytes().into(),
-                        self.sp1_chunk_aggregator_vk_hash_bytes.into(),
-                    )
-                    .sidecar(blob.clone())
-                    .into_transaction_request(),
-                AlignedProof::Risc0(proof) => {
-                    let encoded_seal = encode_seal(&proof.receipt)
-                        .map_err(|e| {
-                            AggregatedProofSubmissionError::Risc0EncodingSeal(e.to_string())
-                        })
-                        .map_err(RetryError::Permanent)?;
-                    self.proof_aggregation_service
-                        .verifyAggregationRisc0(
-                            blob_versioned_hash.into(),
-                            encoded_seal.into(),
-                            proof.receipt.journal.bytes.clone().into(),
-                            self.risc0_chunk_aggregator_image_id_bytes.into(),
-                        )
-                        .sidecar(blob.clone())
-                        .into_transaction_request()
-                }
-            };
+            info!("Transaction attempt {} of {}", attempt + 1, max_retries);
 
-            // Increase gas price/fees for retries before filling
-            if attempt > 0 {
-                tx_req = self
-                    .update_gas_fees(
-                        base_bump_percentage,
-                        retry_attempt_percentage,
-                        attempt as u64,
-                        tx_req,
-                    )
-                    .await?;
-            }
+            // Wrap the entire transaction submission in a result to catch all errors
+            let attempt_result = self
+                .try_submit_transaction(
+                    &blob,
+                    blob_versioned_hash,
+                    aggregated_proof,
+                    base_bump_percentage,
+                    retry_attempt_percentage,
+                    attempt as u64,
+                    retry_interval,
+                )
+                .await;
 
-            let provider = self.proof_aggregation_service.provider();
-
-            let envelope = provider
-                .fill(tx_req)
-                .await
-                .map_err(|err| {
-                    AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                        err.to_string(),
-                    )
-                })
-                .map_err(RetryError::Transient)?
-                .try_into_envelope()
-                .map_err(|err| {
-                    AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                        err.to_string(),
-                    )
-                })
-                .map_err(RetryError::Transient)?;
-
-            let tx: EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> =
-                envelope
-                    .try_into_pooled()
-                    .map_err(|err| {
-                        AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                            err.to_string(),
-                        )
-                    })
-                    .map_err(RetryError::Transient)?
-                    .try_map_eip4844(|tx| {
-                        tx.try_map_sidecar(|sidecar| {
-                            sidecar.try_into_7594(EnvKzgSettings::Default.get())
-                        })
-                    })
-                    .map_err(|err| {
-                        AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                            err.to_string(),
-                        )
-                    })
-                    .map_err(RetryError::Transient)?;
-
-            let encoded_tx = tx.encoded_2718();
-            let pending_tx = provider
-                .send_raw_transaction(&encoded_tx)
-                .await
-                .map_err(|err| {
-                    AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                        err.to_string(),
-                    )
-                })
-                .map_err(RetryError::Transient)?;
-
-            // Wait for the receipt with timeout
-            let receipt_result =
-                tokio::time::timeout(retry_interval, pending_tx.get_receipt()).await;
-
-            match receipt_result {
-                Ok(Ok(receipt)) => {
+            match attempt_result {
+                Ok(receipt) => {
                     info!(
                         "Transaction confirmed successfully on attempt {}",
                         attempt + 1
                     );
                     return Ok(receipt);
                 }
-                Ok(Err(err)) => {
-                    warn!("Error getting receipt on attempt {}: {}", attempt + 1, err);
-                    if attempt == max_retries - 1 {
-                        return Err(RetryError::Transient(
-                            AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                                err.to_string(),
-                            ),
-                        ));
-                    }
-                }
-                Err(_) => {
-                    warn!("Transaction not confirmed after {} seconds on attempt {}, retrying with higher fee...", 
-                    retry_interval.as_secs(), attempt + 1);
-                    if attempt == max_retries - 1 {
-                        return Err(RetryError::Transient(
-                            AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                                "Transaction timeout after all retries".to_string(),
-                            ),
-                        ));
+                Err(err) => {
+                    warn!("Attempt {} failed: {:?}", attempt + 1, err);
+                    last_error = Some(err);
+
+                    if attempt < max_retries - 1 {
+                        info!("Retrying with bumped gas fees...");
+
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                    } else {
+                        warn!("Max retries ({}) exceeded", max_retries);
                     }
                 }
             }
         }
 
-        Err(RetryError::Transient(
+        // If we exhausted all retries, return the last error
+        Err(RetryError::Transient(last_error.unwrap_or_else(|| {
             AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(
-                "Max retries exceeded".to_string(),
+                "Max retries exceeded with no error details".to_string(),
+            )
+        })))
+    }
+
+    async fn try_submit_transaction(
+        &self,
+        blob: &BlobTransactionSidecar,
+        blob_versioned_hash: [u8; 32],
+        aggregated_proof: &AlignedProof,
+        base_bump_percentage: u64,
+        retry_attempt_percentage: u64,
+        attempt: u64,
+        retry_interval: Duration,
+    ) -> Result<TransactionReceipt, AggregatedProofSubmissionError> {
+        // Build the transaction request
+        let mut tx_req = match aggregated_proof {
+            AlignedProof::SP1(proof) => self
+                .proof_aggregation_service
+                .verifyAggregationSP1(
+                    blob_versioned_hash.into(),
+                    proof.proof_with_pub_values.public_values.to_vec().into(),
+                    proof.proof_with_pub_values.bytes().into(),
+                    self.sp1_chunk_aggregator_vk_hash_bytes.into(),
+                )
+                .sidecar(blob.clone())
+                .into_transaction_request(),
+            AlignedProof::Risc0(proof) => {
+                let encoded_seal = encode_seal(&proof.receipt).map_err(|e| {
+                    AggregatedProofSubmissionError::Risc0EncodingSeal(e.to_string())
+                })?;
+                self.proof_aggregation_service
+                    .verifyAggregationRisc0(
+                        blob_versioned_hash.into(),
+                        encoded_seal.into(),
+                        proof.receipt.journal.bytes.clone().into(),
+                        self.risc0_chunk_aggregator_image_id_bytes.into(),
+                    )
+                    .sidecar(blob.clone())
+                    .into_transaction_request()
+            }
+        };
+
+        // Apply gas fee bump for retries
+        if attempt > 0 {
+            tx_req = self
+                .apply_gas_fee_bump(
+                    base_bump_percentage,
+                    retry_attempt_percentage,
+                    attempt,
+                    tx_req,
+                )
+                .await?;
+        }
+
+        let provider = self.proof_aggregation_service.provider();
+
+        // Fill the transaction
+        let envelope = provider
+            .fill(tx_req)
+            .await
+            .map_err(|err| {
+                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
+                    "Failed to fill transaction: {}",
+                    err
+                ))
+            })?
+            .try_into_envelope()
+            .map_err(|err| {
+                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
+                    "Failed to convert to envelope: {}",
+                    err
+                ))
+            })?;
+
+        // Convert to EIP-4844 transaction
+        let tx: EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarEip7594>> = envelope
+            .try_into_pooled()
+            .map_err(|err| {
+                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
+                    "Failed to pool transaction: {}",
+                    err
+                ))
+            })?
+            .try_map_eip4844(|tx| {
+                tx.try_map_sidecar(|sidecar| sidecar.try_into_7594(EnvKzgSettings::Default.get()))
+            })
+            .map_err(|err| {
+                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
+                    "Failed to convert to EIP-7594: {}",
+                    err
+                ))
+            })?;
+
+        // Send the transaction
+        let encoded_tx = tx.encoded_2718();
+        let pending_tx = provider
+            .send_raw_transaction(&encoded_tx)
+            .await
+            .map_err(|err| {
+                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
+                    "Failed to send raw transaction: {}",
+                    err
+                ))
+            })?;
+
+        info!("Transaction sent, waiting for confirmation...");
+
+        // Wait for the receipt with timeout
+        let receipt_result = tokio::time::timeout(retry_interval, pending_tx.get_receipt()).await;
+
+        match receipt_result {
+            Ok(Ok(receipt)) => Ok(receipt),
+            Ok(Err(err)) => Err(
+                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
+                    "Error getting receipt: {}",
+                    err
+                )),
             ),
-        ))
+            Err(_) => Err(
+                AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
+                    "Transaction timeout after {} seconds",
+                    retry_interval.as_secs()
+                )),
+            ),
+        }
     }
 
     // Updates the gas fees of a `TransactionRequest` for retry attempts by applying a linear fee
@@ -487,30 +523,36 @@ impl ProofAggregator {
     //   - `attempt = 3` → 10% + (3 * 5%) = 25% bump
     //
     // The bumped price is: current_gas_price * (1 + total_bump_percentage / 100)
-    async fn update_gas_fees(
+    async fn apply_gas_fee_bump(
         &self,
         base_bump_percentage: u64,
         retry_attempt_percentage: u64,
         attempt: u64,
         tx_req: alloy::rpc::types::TransactionRequest,
-    ) -> Result<alloy::rpc::types::TransactionRequest, RetryError<AggregatedProofSubmissionError>>
-    {
+    ) -> Result<alloy::rpc::types::TransactionRequest, AggregatedProofSubmissionError> {
         let provider = self.proof_aggregation_service.provider();
 
         // Calculate total bump percentage: base + (retry_count * retry_attempt)
         let incremental_retry_percentage = retry_attempt_percentage * attempt;
         let total_bump_percentage = base_bump_percentage + incremental_retry_percentage;
 
+        info!(
+            "Applying {}% gas fee bump for attempt {}",
+            total_bump_percentage,
+            attempt + 1
+        );
+
         let mut current_tx_req = tx_req.clone();
 
         if current_tx_req.max_fee_per_gas.is_none() {
-            let current_gas_price = provider.get_gas_price().await.map_err(|e| {
-                RetryError::Transient(AggregatedProofSubmissionError::GasPriceError(e.to_string()))
-            })?;
+            let current_gas_price = provider
+                .get_gas_price()
+                .await
+                .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?;
 
             let new_max_fee =
                 Self::calculate_bumped_price(current_gas_price, total_bump_percentage);
-            let new_priority_fee = new_max_fee / 10; // 10% of max fee
+            let new_priority_fee = new_max_fee / 10;
 
             current_tx_req = current_tx_req
                 .with_max_fee_per_gas(new_max_fee)

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -356,7 +356,7 @@ impl ProofAggregator {
                 )
             })?;
 
-        info!("Using nonce {} for all retry attempts", nonce);
+        info!("Using nonce {}", nonce);
 
         for attempt in 0..max_retries {
             info!("Transaction attempt {} of {}", attempt + 1, max_retries);

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -551,13 +551,13 @@ impl ProofAggregator {
             .await
             .map_err(|e| AggregatedProofSubmissionError::GasPriceError(e.to_string()))?;
 
-        let new_base_fee = current_gas_price * (1 + base_bump_percentage as u128 / 100);
-        let new_max_fee = new_base_fee * (1 + max_fee_bump_percentage as u128 / 100);
+        let new_base_fee = current_gas_price as f64 * (1.0 + base_bump_percentage as f64 / 100.0);
+        let new_max_fee = new_base_fee as f64 * (1.0 + max_fee_bump_percentage as f64 / 100.0);
         let new_priority_fee = priority_fee_wei;
 
         Ok(tx_req
-            .with_max_fee_per_gas(new_max_fee)
-            .with_max_priority_fee_per_gas(new_priority_fee))
+            .with_max_fee_per_gas(new_max_fee as u128)
+            .with_max_priority_fee_per_gas(new_priority_fee as u128))
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -336,7 +336,8 @@ impl ProofAggregator {
 
         let max_retries = self.config.max_bump_retries;
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
-        let fee_multiplier: f64 = self.config.bump_increase_fee_multiplier;
+        let base_bump_percentage = self.config.base_bump_percentage; // e.g., 10
+        let retry_attempt_percentage = self.config.retry_attempt_percentage; // e.g., 5
 
         for attempt in 0..max_retries {
             let mut tx_req = match aggregated_proof {
@@ -371,7 +372,12 @@ impl ProofAggregator {
             // Increase gas price/fees for retries before filling
             if attempt > 0 {
                 tx_req = self
-                    .update_gas_fees(fee_multiplier, attempt as i32, tx_req)
+                    .update_gas_fees(
+                        base_bump_percentage,
+                        retry_attempt_percentage,
+                        attempt as u64,
+                        tx_req,
+                    )
                     .await?;
             }
 
@@ -469,39 +475,31 @@ impl ProofAggregator {
         ))
     }
 
-    // Updates the gas fees of a `TransactionRequest` for retry attempts by applying an exponential fee
-    // multiplier based on the retry number. This method is intended to be used when a previous transaction
-    // attempt was not confirmed (e.g. receipt timeout or transient failure). By increasing the gas fees
-    // on each retry, it improves the likelihood that the transaction will be included
-    // on the next block.
+    // Updates the gas fees of a `TransactionRequest` for retry attempts by applying a linear fee
+    // bump based on the retry number. This method is intended to be used when a previous transaction
+    // attempt was not confirmed (e.g. receipt timeout or transient failure).
     //
-    // Fee strategy:
-    // An exponential multiplier is computed on each iteration. For example, with `fee_multiplier = 1.2`:
-    //   - `attempt = 1` → `1.2x`
-    //   - `attempt = 2` → `1.44x`
-    //   - `attempt = 3` → `1.728x`
+    // Fee strategy (similar to Go implementation):
+    // The bump is calculated as: base_bump_percentage + (retry_count * retry_attempt_percentage)
+    // For example, with `base_bump_percentage = 10` and `retry_attempt_percentage = 5`:
+    //   - `attempt = 1` → 10% + (1 * 5%) = 15% bump
+    //   - `attempt = 2` → 10% + (2 * 5%) = 20% bump
+    //   - `attempt = 3` → 10% + (3 * 5%) = 25% bump
     //
-    // If the transaction request doesn't have `max_fee_per_gas` set, the current network gas price is fetched
-    // from the provider, the max fee per gas is set to `current_gas_price * multiplier` and the max priority
-    // fee per gas is set to `current_gas_price * multiplier * 0.1`.
-    //
-    // If the transaction request already contains the fee fields, the existing max fee per gas is multiplied
-    // by `multiplier`, and the existing max priority fee per gas is multiplied by multiplier * 0.1`.
+    // The bumped price is: current_gas_price * (1 + total_bump_percentage / 100)
     async fn update_gas_fees(
         &self,
-        fee_multiplier: f64,
-        attempt: i32,
+        base_bump_percentage: u64,
+        retry_attempt_percentage: u64,
+        attempt: u64,
         tx_req: alloy::rpc::types::TransactionRequest,
     ) -> Result<alloy::rpc::types::TransactionRequest, RetryError<AggregatedProofSubmissionError>>
     {
         let provider = self.proof_aggregation_service.provider();
 
-        let multiplier = fee_multiplier.powi(attempt);
-
-        info!(
-            "Retry attempt {} with increased fee ({}x)",
-            attempt, multiplier
-        );
+        // Calculate total bump percentage: base + (retry_count * retry_attempt)
+        let incremental_retry_percentage = retry_attempt_percentage * attempt;
+        let total_bump_percentage = base_bump_percentage + incremental_retry_percentage;
 
         let mut current_tx_req = tx_req.clone();
 
@@ -510,24 +508,31 @@ impl ProofAggregator {
                 RetryError::Transient(AggregatedProofSubmissionError::GasPriceError(e.to_string()))
             })?;
 
-            let new_max_fee = (current_gas_price as f64 * multiplier) as u128;
-            let new_priority_fee = (current_gas_price as f64 * multiplier * 0.1) as u128;
+            let new_max_fee =
+                Self::calculate_bumped_price(current_gas_price, total_bump_percentage);
+            let new_priority_fee = new_max_fee / 10; // 10% of max fee
 
             current_tx_req = current_tx_req
                 .with_max_fee_per_gas(new_max_fee)
                 .with_max_priority_fee_per_gas(new_priority_fee);
         } else {
             if let Some(max_fee) = current_tx_req.max_fee_per_gas {
-                let new_max_fee = (max_fee as f64 * multiplier) as u128;
+                let new_max_fee = Self::calculate_bumped_price(max_fee, total_bump_percentage);
                 current_tx_req = current_tx_req.with_max_fee_per_gas(new_max_fee);
             }
             if let Some(priority_fee) = current_tx_req.max_priority_fee_per_gas {
-                let new_priority_fee = (priority_fee as f64 * multiplier) as u128;
+                let new_priority_fee =
+                    Self::calculate_bumped_price(priority_fee, total_bump_percentage);
                 current_tx_req = current_tx_req.with_max_priority_fee_per_gas(new_priority_fee);
             }
         }
 
         Ok(current_tx_req)
+    }
+
+    fn calculate_bumped_price(current_price: u128, total_bump_percentage: u64) -> u128 {
+        let bump_amount = (current_price * total_bump_percentage as u128) / 100;
+        current_price + bump_amount
     }
 
     async fn wait_until_can_submit_aggregated_proof(

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -338,16 +338,34 @@ impl ProofAggregator {
 
         let mut last_error: Option<AggregatedProofSubmissionError> = None;
 
+        // Get the nonce once at the beginning and reuse it for all retries
+        let nonce = self
+            .proof_aggregation_service
+            .provider()
+            .get_transaction_count(*self.proof_aggregation_service.address())
+            .await
+            .map_err(|e| {
+                RetryError::Transient(
+                    AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
+                        "Failed to get nonce: {e}"
+                    )),
+                )
+            })?;
+
+        info!("Using nonce {} for all retry attempts", nonce);
+
         for attempt in 0..max_retries {
             info!("Transaction attempt {} of {}", attempt + 1, max_retries);
 
-            // Wrap the entire transaction submission in a result to catch all errors
+            // Wrap the entire transaction submission in a result to catch all errors, passing
+            // the same nonce to all attempts
             let attempt_result = self
                 .try_submit_transaction(
                     &blob,
                     blob_versioned_hash,
                     aggregated_proof,
                     attempt as u64,
+                    nonce,
                 )
                 .await;
 
@@ -364,7 +382,7 @@ impl ProofAggregator {
                     last_error = Some(err);
 
                     if attempt < max_retries - 1 {
-                        info!("Retrying with bumped gas fees...");
+                        info!("Retrying with bumped gas fees and same nonce {}...", nonce);
 
                         tokio::time::sleep(Duration::from_millis(500)).await;
                     } else {
@@ -388,6 +406,7 @@ impl ProofAggregator {
         blob_versioned_hash: [u8; 32],
         aggregated_proof: &AlignedProof,
         attempt: u64,
+        nonce: u64,
     ) -> Result<TransactionReceipt, AggregatedProofSubmissionError> {
         let retry_interval = Duration::from_secs(self.config.bump_retry_interval_seconds);
         let base_bump_percentage = self.config.base_bump_percentage;
@@ -421,6 +440,9 @@ impl ProofAggregator {
                     .into_transaction_request()
             }
         };
+
+        // Set the nonce explicitly
+        tx_req = tx_req.with_nonce(nonce);
 
         // Apply gas fee bump for retries
         if attempt > 0 {
@@ -480,7 +502,10 @@ impl ProofAggregator {
                 ))
             })?;
 
-        info!("Transaction sent, waiting for confirmation...");
+        info!(
+            "Transaction sent with nonce {}, waiting for confirmation...",
+            nonce
+        );
 
         // Wait for the receipt with timeout
         let receipt_result = tokio::time::timeout(retry_interval, pending_tx.get_receipt()).await;

--- a/aggregation_mode/proof_aggregator/src/backend/mod.rs
+++ b/aggregation_mode/proof_aggregator/src/backend/mod.rs
@@ -55,7 +55,10 @@ pub enum AggregatedProofSubmissionError {
 }
 
 enum SubmitOutcome {
-    Confirmed(TransactionReceipt),
+    // NOTE: Boxed because enums are sized to their largest variant; without boxing,
+    // every `SubmitOutcome` would reserve space for a full `TransactionReceipt`,
+    // even in the `Pending` case (see clippy::large_enum_variant).
+    Confirmed(Box<TransactionReceipt>),
     Pending(TxHash),
 }
 
@@ -380,7 +383,7 @@ impl ProofAggregator {
                         "Transaction confirmed successfully on attempt {}",
                         attempt + 1
                     );
-                    return Ok(receipt);
+                    return Ok(*receipt);
                 }
                 Ok(SubmitOutcome::Pending(tx_hash)) => {
                     warn!(
@@ -556,7 +559,7 @@ impl ProofAggregator {
         let receipt_result = tokio::time::timeout(retry_interval, pending_tx.get_receipt()).await;
 
         match receipt_result {
-            Ok(Ok(receipt)) => Ok(SubmitOutcome::Confirmed(receipt)),
+            Ok(Ok(receipt)) => Ok(SubmitOutcome::Confirmed(Box::new(receipt))),
             Ok(Err(err)) => Err(
                 AggregatedProofSubmissionError::SendVerifyAggregatedProofTransaction(format!(
                     "Error getting receipt: {err}"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -32,8 +32,7 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_wei: 3000000000 # 3 Gwei
-final_receipt_check_timeout_seconds: 5
+priority_fee_wei: 3000000000 // 3 Gwei
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -32,7 +32,7 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_wei: 2000000000
+priority_fee_wei: 3000000000 // 3 Gwei
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -32,7 +32,7 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_wei: 3000000000 // 3 Gwei
+priority_fee_wei: 3000000000 # 3 Gwei
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -27,6 +27,11 @@ monthly_budget_eth: 15.0
 sp1_chunk_aggregator_vk_hash: "00d6e32a34f68ea643362b96615591c94ee0bf99ee871740ab2337966a4f77af"
 risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f62e7c994491629d74c"
 
+# These values modify the bumping behavior after the aggregated proof on-chain submission times out.
+max_bump_retries: 5
+bump_retry_interval_seconds: 120
+bump_increase_fee_multiplier: 1.2
+
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"
   private_key_store_password: ""

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -30,7 +30,6 @@ risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f
 # These values modify the bumping behavior after the aggregated proof on-chain submission times out.
 max_bump_retries: 5
 bump_retry_interval_seconds: 120
-base_bump_percentage: 10
 max_fee_bump_percentage: 100
 priority_fee_wei: 3000000000 # 3 Gwei
 

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -31,7 +31,8 @@ risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f
 max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
-retry_attempt_percentage: 2
+max_fee_bump_percentage: 100
+priority_fee_gwei: 2
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -32,7 +32,7 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_gwei: 2
+priority_fee_wei: 2000000000
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -32,7 +32,8 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_wei: 3000000000 // 3 Gwei
+priority_fee_wei: 3000000000 # 3 Gwei
+final_receipt_check_timeout_seconds: 5
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -31,7 +31,7 @@ risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f
 max_bump_retries: 5
 bump_retry_interval_seconds: 120
 max_fee_bump_percentage: 100
-priority_fee_wei: 3000000000 # 3 Gwei
+max_priority_fee_upper_limit: 3000000000 # 3 Gwei
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator-ethereum-package.yaml
+++ b/config-files/config-proof-aggregator-ethereum-package.yaml
@@ -30,7 +30,8 @@ risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f
 # These values modify the bumping behavior after the aggregated proof on-chain submission times out.
 max_bump_retries: 5
 bump_retry_interval_seconds: 120
-bump_increase_fee_multiplier: 1.2
+base_bump_percentage: 10
+retry_attempt_percentage: 2
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -32,8 +32,7 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_wei: 3000000000 # 3 Gwei
-final_receipt_check_timeout_seconds: 5
+priority_fee_wei: 3000000000 // 3 Gwei
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -32,7 +32,7 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_wei: 2000000000
+priority_fee_wei: 3000000000 // 3 Gwei
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -24,8 +24,8 @@ monthly_budget_eth: 15.0
 # These program ids are the ones from the chunk aggregator programs
 # Can be found in the Proof Aggregation Service deployment config
 # (remember to trim the 0x prefix)
-sp1_chunk_aggregator_vk_hash: "00ba19eed0aaeb0151f07b8d3ee7c659bcd29f3021e48fb42766882f55b84509"
-risc0_chunk_aggregator_image_id: "d8cfdd5410c70395c0a1af1842a0148428cc46e353355faccfba694dd4862dbf"
+sp1_chunk_aggregator_vk_hash: "00d6e32a34f68ea643362b96615591c94ee0bf99ee871740ab2337966a4f77af"
+risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f62e7c994491629d74c"
 
 # These values modify the bumping behavior after the aggregated proof on-chain submission times out.
 max_bump_retries: 5

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -32,7 +32,7 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_wei: 3000000000 // 3 Gwei
+priority_fee_wei: 3000000000 # 3 Gwei
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -27,6 +27,11 @@ monthly_budget_eth: 15.0
 sp1_chunk_aggregator_vk_hash: "00ba19eed0aaeb0151f07b8d3ee7c659bcd29f3021e48fb42766882f55b84509"
 risc0_chunk_aggregator_image_id: "d8cfdd5410c70395c0a1af1842a0148428cc46e353355faccfba694dd4862dbf"
 
+# These values modify the bumping behavior after the aggregated proof on-chain submission times out.
+max_bump_retries: 5
+bump_retry_interval_seconds: 120
+bump_increase_fee_multiplier: 1.2
+
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"
   private_key_store_password: ""

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -30,7 +30,6 @@ risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f
 # These values modify the bumping behavior after the aggregated proof on-chain submission times out.
 max_bump_retries: 5
 bump_retry_interval_seconds: 120
-base_bump_percentage: 10
 max_fee_bump_percentage: 100
 priority_fee_wei: 3000000000 # 3 Gwei
 

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -31,7 +31,8 @@ risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f
 max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
-retry_attempt_percentage: 2
+max_fee_bump_percentage: 100
+priority_fee_gwei: 2
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -32,7 +32,7 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_gwei: 2
+priority_fee_wei: 2000000000
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -30,7 +30,8 @@ risc0_chunk_aggregator_image_id: "d8cfdd5410c70395c0a1af1842a0148428cc46e353355f
 # These values modify the bumping behavior after the aggregated proof on-chain submission times out.
 max_bump_retries: 5
 bump_retry_interval_seconds: 120
-bump_increase_fee_multiplier: 1.2
+base_bump_percentage: 10
+retry_attempt_percentage: 2
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -32,7 +32,8 @@ max_bump_retries: 5
 bump_retry_interval_seconds: 120
 base_bump_percentage: 10
 max_fee_bump_percentage: 100
-priority_fee_wei: 3000000000 // 3 Gwei
+priority_fee_wei: 3000000000 # 3 Gwei
+final_receipt_check_timeout_seconds: 5
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"

--- a/config-files/config-proof-aggregator.yaml
+++ b/config-files/config-proof-aggregator.yaml
@@ -31,7 +31,7 @@ risc0_chunk_aggregator_image_id: "8908f01022827e80a5de71908c16ee44f4a467236df20f
 max_bump_retries: 5
 bump_retry_interval_seconds: 120
 max_fee_bump_percentage: 100
-priority_fee_wei: 3000000000 # 3 Gwei
+max_priority_fee_upper_limit: 3000000000 # 3 Gwei
 
 ecdsa:
   private_key_store_path: "config-files/anvil.proof-aggregator.ecdsa.key.json"


### PR DESCRIPTION
## Description

This PR adds the bump fee option to the proof aggregator when the proof verification times out. This means that, in the event the proof aggregator attempts to submit the aggregated proof to the contract and the time elapsed is longer than a specified number of seconds, the proof aggregator will resubmit the proof by sending the same request with a higher fee to the network.

## How to test

1. Start ethereum package:
```shell
make ethereum_package_start
```
2. Start gateway:
```shell
make agg_mode_gateway_start_ethereum_package
```
3. Start payments poller:
```shell
make agg_mode_payments_poller_start_local
```
4. Send payment and sp1 proof:
```shell
make agg_mode_gateway_send_payment
make agg_mode_gateway_send_sp1_proof
```
5. Start proof aggregator with sp1:
```shell
make proof_aggregator_start AGGREGATOR=sp1
```

You can check that the normal flow works, or try to trigger some retries to check that the bump logic really works. I used this bump config at `config-files/config-proof-aggregator.yaml`:

```yaml
# These values modify the bumping behavior after the aggregated proof on-chain submission times out.
max_bump_retries: 15
bump_retry_interval_seconds: 10
base_bump_percentage: 30
max_fee_bump_percentage: 100
priority_fee_gwei: 2
```


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Refactor

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
