### PR TITLE
feat(aggregation mode): bind gateway server to Non-TLS port when using TLS

### DIFF
--- a/aggregation_mode/gateway/src/config.rs
+++ b/aggregation_mode/gateway/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub tls_cert_path: String,
     #[cfg(feature = "tls")]
     pub tls_key_path: String,
+    #[cfg(feature = "tls")]
+    pub tls_port: u16,
 }
 
 impl Config {

--- a/aggregation_mode/gateway/src/http.rs
+++ b/aggregation_mode/gateway/src/http.rs
@@ -86,7 +86,7 @@ impl GatewayServer {
 
     pub async fn start(&self) {
         // Note: GatewayServer is thread safe so we can just clone it (no need to add mutexes)
-        let port = self.config.port;
+        let http_port = self.config.port;
         let state = self.clone();
 
         // Note: This creates a new Prometheus server different from the one created in GatewayServer::new. The created
@@ -95,18 +95,6 @@ impl GatewayServer {
             .endpoint("/metrics")
             .build()
             .unwrap();
-
-        #[cfg(feature = "tls")]
-        let protocol = "https";
-        #[cfg(not(feature = "tls"))]
-        let protocol = "http";
-
-        tracing::info!(
-            "Starting server at {}://{}:{}",
-            protocol,
-            self.config.ip,
-            self.config.port
-        );
 
         let server = HttpServer::new(move || {
             App::new()
@@ -121,21 +109,36 @@ impl GatewayServer {
         });
 
         #[cfg(feature = "tls")]
-        let server = {
+        {
+            let tls_port = self.config.tls_port;
+            tracing::info!("Starting HTTP server at http://{}:{}", self.config.ip, http_port);
+            tracing::info!("Starting HTTPS server at https://{}:{}", self.config.ip, tls_port);
+
             let tls_config =
                 Self::load_tls_config(&self.config.tls_cert_path, &self.config.tls_key_path)
                     .expect("Failed to load TLS configuration");
+
             server
-                .bind_rustls_0_23((self.config.ip.as_str(), port), tls_config)
-                .expect("To bind socket correctly with TLS")
-        };
+                .bind((self.config.ip.as_str(), http_port))
+                .expect("To bind HTTP socket correctly")
+                .bind_rustls_0_23((self.config.ip.as_str(), tls_port), tls_config)
+                .expect("To bind HTTPS socket correctly with TLS")
+                .run()
+                .await
+                .expect("Server to never end");
+        }
 
         #[cfg(not(feature = "tls"))]
-        let server = server
-            .bind((self.config.ip.as_str(), port))
-            .expect("To bind socket correctly");
+        {
+            tracing::info!("Starting HTTP server at http://{}:{}", self.config.ip, http_port);
 
-        server.run().await.expect("Server to never end");
+            server
+                .bind((self.config.ip.as_str(), http_port))
+                .expect("To bind HTTP socket correctly")
+                .run()
+                .await
+                .expect("Server to never end");
+        }
     }
 
     // Returns an OK response (code 200), no matters what receives in the request

--- a/aggregation_mode/gateway/src/http.rs
+++ b/aggregation_mode/gateway/src/http.rs
@@ -111,8 +111,16 @@ impl GatewayServer {
         #[cfg(feature = "tls")]
         {
             let tls_port = self.config.tls_port;
-            tracing::info!("Starting HTTP server at http://{}:{}", self.config.ip, http_port);
-            tracing::info!("Starting HTTPS server at https://{}:{}", self.config.ip, tls_port);
+            tracing::info!(
+                "Starting HTTP server at http://{}:{}",
+                self.config.ip,
+                http_port
+            );
+            tracing::info!(
+                "Starting HTTPS server at https://{}:{}",
+                self.config.ip,
+                tls_port
+            );
 
             let tls_config =
                 Self::load_tls_config(&self.config.tls_cert_path, &self.config.tls_key_path)
@@ -130,7 +138,11 @@ impl GatewayServer {
 
         #[cfg(not(feature = "tls"))]
         {
-            tracing::info!("Starting HTTP server at http://{}:{}", self.config.ip, http_port);
+            tracing::info!(
+                "Starting HTTP server at http://{}:{}",
+                self.config.ip,
+                http_port
+            );
 
             server
                 .bind((self.config.ip.as_str(), http_port))

--- a/aggregation_mode/gateway/src/http.rs
+++ b/aggregation_mode/gateway/src/http.rs
@@ -108,14 +108,19 @@ impl GatewayServer {
                 .route("/quotas/{address}", web::get().to(Self::get_quotas))
         });
 
+        tracing::info!(
+            "Starting HTTP server at http://{}:{}",
+            self.config.ip,
+            http_port
+        );
+
+        let server = server
+            .bind((self.config.ip.as_str(), http_port))
+            .expect("To bind HTTP socket correctly");
+
         #[cfg(feature = "tls")]
-        {
+        let server = {
             let tls_port = self.config.tls_port;
-            tracing::info!(
-                "Starting HTTP server at http://{}:{}",
-                self.config.ip,
-                http_port
-            );
             tracing::info!(
                 "Starting HTTPS server at https://{}:{}",
                 self.config.ip,
@@ -127,30 +132,11 @@ impl GatewayServer {
                     .expect("Failed to load TLS configuration");
 
             server
-                .bind((self.config.ip.as_str(), http_port))
-                .expect("To bind HTTP socket correctly")
                 .bind_rustls_0_23((self.config.ip.as_str(), tls_port), tls_config)
                 .expect("To bind HTTPS socket correctly with TLS")
-                .run()
-                .await
-                .expect("Server to never end");
-        }
+        };
 
-        #[cfg(not(feature = "tls"))]
-        {
-            tracing::info!(
-                "Starting HTTP server at http://{}:{}",
-                self.config.ip,
-                http_port
-            );
-
-            server
-                .bind((self.config.ip.as_str(), http_port))
-                .expect("To bind HTTP socket correctly")
-                .run()
-                .await
-                .expect("Server to never end");
-        }
+        server.run().await.expect("Server to never end");
     }
 
     // Returns an OK response (code 200), no matters what receives in the request


### PR DESCRIPTION
# feat(aggregation mode): bind gateway server to non tls port when using tls

## Description

This PR just binds the server not only to 443 port for TLS but also to port 8080 to connect through VPN without using the public domain

## Type of change

- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
