### PR TITLE
fix(terraform): ignore ami changes in EC2 lifecycle

### DIFF
--- a/infra/aggregation_mode/terraform/modules/ec2/main.tf
+++ b/infra/aggregation_mode/terraform/modules/ec2/main.tf
@@ -95,6 +95,10 @@ resource "aws_instance" "this" {
     var.ec2_tags
   )
 
+  lifecycle {
+    ignore_changes = [ami]
+  }
+
   root_block_device {
     volume_size = var.ec2_root_volume_size
   }


### PR DESCRIPTION
# fix: ignore ami changes in EC2 lifecycle

## Description

Ignore AMI changes to avoid server destruction when it is not needed 

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
