### PR TITLE
Fix long-range fork density comparison in select_secure_chain

### DIFF
--- a/operator/mina/lib/src/consensus_state.rs
+++ b/operator/mina/lib/src/consensus_state.rs
@@ -32,7 +32,7 @@ pub fn select_secure_chain(
     if is_short_range(candidate, tip)? {
         Ok(select_longer_chain(candidate, tip))
     } else {
-        let tip_density = relative_min_window_density(candidate, tip);
+        let tip_density = relative_min_window_density(tip, candidate);
         let candidate_density = relative_min_window_density(candidate, tip);
         Ok(match candidate_density.cmp(&tip_density) {
             Ordering::Less => ChainResult::Bridge,


### PR DESCRIPTION
# TITLE
Fix long-range fork density comparison in `select_secure_chain`

## Description

Fixes a bug where both tip_density and candidate_density were computed with identical inputs.
Ensures long-range fork decisions compare the candidate chain density against the tip chain density correctly.

**Details**
The current implementation computes:
```
tip_density = relative_min_window_density(candidate, tip)
candidate_density = relative_min_window_density(candidate, tip)
```

This makes both densities identical, causing long‑range fork resolution to always fall back to the tie path and use `select_longer_chain`, effectively disabling density-based selection.

The fix swaps the arguments for tip_density:
```
let tip_density = relative_min_window_density(tip, candidate);
let candidate_density = relative_min_window_density(candidate, tip);
```

This aligns with the intended semantics: compute each chain’s relative density against the other’s slot horizon.

## Type of change

- [x] Bug fix

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
