### PR TITLE
infra: add ai code reviews

### DIFF
--- a/.github/workflows/pr_review_claude.yml
+++ b/.github/workflows/pr_review_claude.yml
@@ -1,0 +1,39 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/claude') &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    uses: yetanotherco/actions/.github/workflows/pr_review_claude.yml@v1.0.1
+    with:
+      custom_prompt: |
+        1. **Security vulnerabilities** - Label by criticality (Critical/High/Medium/Low)
+           - Solidity: e.g. reentrancy, access control, integer issues, etc.
+           - Rust: e.g. unsafe blocks, error handling, panics, etc.
+           - Web/API: e.g. SQL injection, auth bypass, input validation, sensitive data exposure, CORS/CSRF, etc.
+
+        2. **Potential bugs** - Logic errors, edge cases, incorrect behavior, race conditions
+
+        3. **Performance issues** - Only significant: e.g. O(n²) on unbounded input, N+1 queries, unbounded memory growth
+
+        4. **Simplicity** - Prefer simple, readable code over clever abstractions
+
+        Guidelines:
+        - Be concise and to the point
+        - Do NOT suggest micro-optimizations or premature abstractions
+        - Always prefer simplicity over complexity when performance gains are marginal
+        - Focus on real issues, not hypothetical improvements
+        - Be concise and actionable
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr_review_codex.yml
+++ b/.github/workflows/pr_review_codex.yml
@@ -1,0 +1,39 @@
+name: Codex Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  codex-review:
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/codex') &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    uses: yetanotherco/actions/.github/workflows/pr_review_codex.yml@v1.0.1
+    with:
+      custom_prompt: |
+        1. **Security vulnerabilities** - Label by criticality (Critical/High/Medium/Low)
+           - Solidity: e.g. reentrancy, access control, integer issues, etc.
+           - Rust: e.g. unsafe blocks, error handling, panics, etc.
+           - Web/API: e.g. SQL injection, auth bypass, input validation, sensitive data exposure, CORS/CSRF, etc.
+
+        2. **Potential bugs** - Logic errors, edge cases, incorrect behavior, race conditions
+
+        3. **Performance issues** - Only significant: e.g. O(n²) on unbounded input, N+1 queries, unbounded memory growth
+
+        4. **Simplicity** - Prefer simple, readable code over clever abstractions
+
+        Guidelines:
+        - Be concise and to the point
+        - Do NOT suggest micro-optimizations or premature abstractions
+        - Always prefer simplicity over complexity when performance gains are marginal
+        - Focus on real issues, not hypothetical improvements
+        - Be concise and actionable
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
# Add Claude and Codex for code reviews

##  Description

Allow Claude and Codex to perform code reviews.



## Type of change


- [x] New feature

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
