### PR TITLE
infra: start gpu server every 24hs

### DIFF
--- a/.github/workflows/aggregation_mode.yml
+++ b/.github/workflows/aggregation_mode.yml
@@ -1,0 +1,47 @@
+name: "Start Aggregation Mode Server"
+
+# Starts the Paperspace GPU server that runs the aggregation mode.
+#
+# The server is kept powered off to avoid 24/7 billing. This workflow boots it
+# once a day; on boot the machine runs `aggregation_mode.service`, which executes
+# the SP1 aggregations and then powers the machine off again
+# (see infra/aggregation_mode/run.sh).
+on:
+  schedule:
+    # 15:00 UTC == 12:00 GMT-3, every day. GitHub Actions cron is always in UTC.
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+
+jobs:
+  start-server:
+    name: Start Paperspace aggregation server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start Paperspace machine
+        env:
+          PAPERSPACE_API_KEY: ${{ secrets.PAPERSPACE_API_KEY }}
+          MACHINE_ID: ${{ secrets.PAPERSPACE_MACHINE_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PAPERSPACE_API_KEY}" ] || [ -z "${MACHINE_ID}" ]; then
+            echo "::error::PAPERSPACE_API_KEY and PAPERSPACE_MACHINE_ID secrets must be set."
+            exit 1
+          fi
+
+          echo "Starting Paperspace machine ${MACHINE_ID}..."
+          http_code=$(curl -sS -o response.json -w "%{http_code}" \
+            -X PATCH "https://api.paperspace.com/v1/machines/${MACHINE_ID}/start" \
+            -H "Authorization: Bearer ${PAPERSPACE_API_KEY}")
+
+          echo "Paperspace API responded with HTTP ${http_code}"
+          cat response.json || true
+
+          # 2xx means the start request was accepted.
+          if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+            echo "::error::Failed to start Paperspace machine (HTTP ${http_code})."
+            exit 1
+          fi
+
+          echo "Start request accepted. The machine will run the aggregation on boot and shut itself down afterwards."
+          

--- a/.github/workflows/aggregation_mode.yml
+++ b/.github/workflows/aggregation_mode.yml
@@ -44,4 +44,3 @@ jobs:
           fi
 
           echo "Start request accepted. The machine will run the aggregation on boot and shut itself down afterwards."
-          

--- a/.github/workflows/aggregation_mode.yml
+++ b/.github/workflows/aggregation_mode.yml
@@ -16,6 +16,8 @@ jobs:
   start-server:
     name: Start Paperspace aggregation server
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Start Paperspace machine
         env:
@@ -30,16 +32,19 @@ jobs:
           fi
 
           echo "Starting Paperspace machine ${MACHINE_ID}..."
-          http_code=$(curl -sS -o response.json -w "%{http_code}" \
+          http_code=$(curl -sS --max-time 30 -o response.json -w "%{http_code}" \
             -X PATCH "https://api.paperspace.com/v1/machines/${MACHINE_ID}/start" \
             -H "Authorization: Bearer ${PAPERSPACE_API_KEY}")
 
           echo "Paperspace API responded with HTTP ${http_code}"
-          cat response.json || true
 
           # 2xx means the start request was accepted.
           if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+            # Only dump the response body on failure: a successful start response
+            # contains the full machine object (public IP, network details, etc.),
+            # which GitHub Actions would not mask in the log.
             echo "::error::Failed to start Paperspace machine (HTTP ${http_code})."
+            cat response.json || true
             exit 1
           fi
 


### PR DESCRIPTION
# infra: run aggregation mode on a daily-scheduled GPU server

## Description

Run the aggregation mode on a Paperspace GPU server that is only powered on once a day, instead of keeping it running 24/7.

## Type of change

- [x] Infra

## Checklist

- [ ] “Hotfix” to `testnet`, everything else to `staging`
- [ ] Linked to Github Issue
- [ ] This change depends on code or research by an external entity
  - [ ] Acknowledgements were updated to give credit
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
- [ ] Has a known issue
  - [Link to the open issue addressing it]() 
- [ ] If your PR changes the Operator compatibility (Ex: Upgrade prover versions)
  - [ ] This PR adds compatibility for operator for both versions and do not change crates/docs/examples
  - [ ] This PR updates batcher and docs/examples to the newer version. This requires the operator are already updated to be compatible
