### PR TITLE
ci: replace archived actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build-and-test-rust.yml
+++ b/.github/workflows/build-and-test-rust.yml
@@ -20,11 +20,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.88.0
         with:
-          toolchain: 1.88.0
           components: rustfmt, clippy
-          override: true
 
       # Reference: https://github.com/succinctlabs/sp1/actions/runs/8886659400/workflow#L61-L65
       - name: Install sp1 toolchain
@@ -40,7 +38,7 @@ jobs:
           ~/.risc0/bin/rzup install
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -106,7 +104,7 @@ jobs:
           ~/.risc0/bin/rzup install
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/lint-contracts.yml
+++ b/.github/workflows/lint-contracts.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-merkle-tree.yml
+++ b/.github/workflows/test-merkle-tree.yml
@@ -29,9 +29,7 @@ jobs:
           with:
             go-version: '1.22'
             cache: false
-        - uses: actions-rs/toolchain@v1
-          with:
-            toolchain: stable
+        - uses: dtolnay/rust-toolchain@stable
         - name: Test Merkle Tree Rust
           run: make test_merkle_tree_rust_ffi
         - name: Test Merkle Tree go bindings

--- a/.github/workflows/test-risc-zero.yml
+++ b/.github/workflows/test-risc-zero.yml
@@ -29,9 +29,7 @@ jobs:
         with:
           go-version: "1.23"
           cache: false
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Test Risc Zero Rust
         run: make test_risc_zero_rust_ffi
       - name: Test Risc Zero go bindings

--- a/.github/workflows/test-sp1.yml
+++ b/.github/workflows/test-sp1.yml
@@ -20,9 +20,7 @@ jobs:
           with:
             go-version: '1.22'
             cache: false
-        - uses: actions-rs/toolchain@v1
-          with:
-            toolchain: stable
+        - uses: dtolnay/rust-toolchain@stable
         - name: Test SP1 Rust
           run: make test_sp1_rust_ffi
         - name: Test SP1 go bindings


### PR DESCRIPTION
## Problem

Four Rust workflows install their toolchain with `actions-rs/toolchain@v1`:

| File | Line |
|---|---|
| `.github/workflows/build-and-test-rust.yml` | 23 |
| `.github/workflows/test-merkle-tree.yml` | 32 |
| `.github/workflows/test-risc-zero.yml` | 32 |
| `.github/workflows/test-sp1.yml` | 23 |

The `actions-rs` organisation has been **archived since 2022** and its actions are pinned to the Node 12 runtime, which GitHub has removed. These steps emit deprecation annotations on every run today and are a standing breakage risk rather than a cosmetic issue.

Two more stragglers are inconsistent with the rest of the repo, which already standardises on v4:

- `lint-contracts.yml:18` — `actions/checkout@v2` (every other workflow here uses `@v4`)
- `build-and-test-rust.yml:43,109` — `actions/cache@v3`

## Fix

- `actions-rs/toolchain@v1` → `dtolnay/rust-toolchain`, the de-facto successor
  - `build-and-test-rust.yml`: `@1.88.0` (the ref *is* the toolchain), keeping `components: rustfmt, clippy`
  - the three `toolchain: stable` jobs: `@stable`
  - `override: true` is dropped because `dtolnay/rust-toolchain` always makes the installed toolchain the default — the previous behaviour is preserved
- `actions/checkout@v2` → `@v4` and `actions/cache@v3` → `@v4`, matching what the other 10 workflows in this repo already use

Net effect is 11 lines across 5 files; no job names, triggers, or build commands change.

## Verification

- `dtolnay/rust-toolchain@1.88.0` confirmed to exist as a ref (`GET /git/ref/heads/1.88.0` → 200), so the pinned Rust version is unchanged
- all 15 workflow files re-parsed as YAML after the edit, and each edited step was re-read back through the parser to confirm `uses`/`with` came out as intended
- `grep` confirms no `actions-rs`, `checkout@v1..v3` or `cache@v1..v3` references remain

CI-only change: no application code is touched.